### PR TITLE
⚡ Bolt: Add index on unidade_processo(unidade_codigo)

### DIFF
--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -372,3 +372,4 @@ create index if not exists idx_subprocesso_unidade on sgc.subprocesso (unidade_c
 create index if not exists idx_alerta_unidade_destino on sgc.alerta (unidade_destino_codigo);
 create index if not exists idx_alerta_processo on sgc.alerta (processo_codigo);
 create index if not exists idx_alerta_usuario_usuario on sgc.alerta_usuario (usuario_titulo);
+create index if not exists idx_unidade_processo_unidade on sgc.unidade_processo (unidade_codigo);

--- a/backend/src/test/resources/db/schema.sql
+++ b/backend/src/test/resources/db/schema.sql
@@ -358,3 +358,5 @@ alter table if exists sgc.ocupacao_critica
 
 alter table if exists sgc.ocupacao_critica
     add constraint fk_ocupacao_competencia foreign key (competencia_codigo) references sgc.competencia;
+
+create index if not exists idx_unidade_processo_unidade on sgc.unidade_processo (unidade_codigo);


### PR DESCRIPTION
Added database index on `unidade_processo(unidade_codigo)` to optimize queries filtering by unit. Synchronized changes to both main and test schema files.

---
*PR created automatically by Jules for task [17264257094132236154](https://jules.google.com/task/17264257094132236154) started by @lgalvao*