### PR TITLE
🛡️ Sentinel: Fix IDOR in obtaining subprocess registration & Secure Defaults

### DIFF
--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoFacade.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoFacade.java
@@ -552,6 +552,10 @@ public class SubprocessoFacade {
 
     private SubprocessoCadastroDto obterCadastroInterno(Long codSubprocesso) {
         Subprocesso sp = crudService.buscarSubprocesso(codSubprocesso);
+
+        Usuario usuario = usuarioService.obterUsuarioAutenticado();
+        accessControlService.verificarPermissao(usuario, Acao.VISUALIZAR_SUBPROCESSO, sp);
+
         List<SubprocessoCadastroDto.AtividadeCadastroDto> atividadesComConhecimentos = new ArrayList<>();
         List<Atividade> atividades = atividadeService.buscarPorMapaCodigoComConhecimentos(sp.getMapa().getCodigo());
         for (Atividade a : atividades) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -50,7 +50,7 @@ logging:
     org.hibernate.tool.schema.internal.SchemaDropperImpl: ERROR
     sgc: INFO
 aplicacao:
-  ambiente-testes: true
+  ambiente-testes: false
   acesso-ad:
     base-url: https://sedesenvdev01.tre-pe.gov.br/acessoAD
     codigo-sistema: SGC

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoFacadeTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoFacadeTest.java
@@ -118,4 +118,26 @@ class SubprocessoFacadeTest {
         facade.alterarDataLimite(1L, java.time.LocalDate.now());
         verify(workflowService).alterarDataLimite(1L, java.time.LocalDate.now());
     }
+
+    @Test
+    void deveVerificarPermissaoAoObterCadastro() {
+        Long codSubprocesso = 1L;
+        sgc.subprocesso.model.Subprocesso subprocesso = new sgc.subprocesso.model.Subprocesso();
+        sgc.mapa.model.Mapa mapa = new sgc.mapa.model.Mapa();
+        mapa.setCodigo(10L);
+        subprocesso.setMapa(mapa);
+        sgc.organizacao.model.Unidade unidade = new sgc.organizacao.model.Unidade();
+        unidade.setSigla("TEST");
+        subprocesso.setUnidade(unidade);
+
+        sgc.organizacao.model.Usuario usuario = new sgc.organizacao.model.Usuario();
+
+        org.mockito.Mockito.when(crudService.buscarSubprocesso(codSubprocesso)).thenReturn(subprocesso);
+        org.mockito.Mockito.when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
+        org.mockito.Mockito.when(atividadeService.buscarPorMapaCodigoComConhecimentos(10L)).thenReturn(Collections.emptyList());
+
+        facade.obterCadastro(codSubprocesso);
+
+        verify(accessControlService).verificarPermissao(usuario, sgc.seguranca.acesso.Acao.VISUALIZAR_SUBPROCESSO, subprocesso);
+    }
 }


### PR DESCRIPTION
This PR addresses two security issues:
1.  **IDOR Vulnerability:** `SubprocessoFacade.obterCadastro` (and by extension `SubprocessoCadastroController.obterCadastro`) did not check if the authenticated user had permission to view the specific subprocess's registration data. Users could potentially access draft data from other units. This has been fixed by adding `accessControlService.verificarPermissao(..., Acao.VISUALIZAR_SUBPROCESSO, ...)`.
2.  **Insecure Default Configuration:** `application.yml` had `aplicacao.ambiente-testes: true` by default, which disables rate limiting. This has been changed to `false`. Test environments continue to work correctly as they use `backend/src/test/resources/application.yml` which explicitly sets it to `true`.

Verified with unit tests.

---
*PR created automatically by Jules for task [3588720877547126295](https://jules.google.com/task/3588720877547126295) started by @lgalvao*