### PR TITLE
feat(ui): add EmptyState to TreeTableView

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-01-29 - [Modal Content Focus]
 **Learning:** Standard HTML `autofocus` attribute in modals is often unreliable due to the modal library's internal focus management (e.g., `bootstrap-vue-next` focuses the modal container or specific buttons).
 **Action:** To reliably focus an input field in a modal, expose the `shown` event from the modal component and use a `ref` to programmatically call `focus()` in the parent's event handler. Ensure the `shown` event is emitted *after* any internal focus logic of the modal component.
+
+## 2025-01-30 - [Empty States in Generic Components]
+**Learning:** Generic data components like `TreeTableView` often neglect empty states, forcing consumers to handle `v-if` logic repeatedly.
+**Action:** Bake `EmptyState` support directly into generic components (with customizable props) so that "no data" scenarios are handled gracefully and consistently by default without extra boilerplate in every view.

--- a/frontend/src/components/TreeTableView.vue
+++ b/frontend/src/components/TreeTableView.vue
@@ -48,15 +48,27 @@
           </tr>
         </thead>
         <tbody>
-          <TreeRowItem
-            v-for="item in flattenedData"
-            :key="item.codigo"
-            :columns="columns"
-            :item="item"
-            :level="item.level"
-            @toggle="toggleExpand"
-            @row-click="handleTreeRowClick"
-          />
+          <template v-if="flattenedData.length > 0">
+            <TreeRowItem
+              v-for="item in flattenedData"
+              :key="item.codigo"
+              :columns="columns"
+              :item="item"
+              :level="item.level"
+              @toggle="toggleExpand"
+              @row-click="handleTreeRowClick"
+            />
+          </template>
+          <tr v-else>
+            <td :colspan="columns.length" class="p-0 border-0">
+              <EmptyState
+                :title="emptyTitle"
+                :description="emptyDescription"
+                :icon="emptyIcon"
+                class="border-0 bg-transparent mb-0"
+              />
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -67,6 +79,7 @@
 import { BButton } from "bootstrap-vue-next";
 import { computed, nextTick, ref, watch } from "vue";
 import TreeRowItem from "./TreeRowItem.vue";
+import EmptyState from "@/components/EmptyState.vue";
 
 interface TreeItem {
   codigo: number | string;
@@ -92,9 +105,19 @@ interface TreeTableProps {
   columns: Column[];
   title?: string;
   hideHeaders?: boolean;
+  emptyTitle?: string;
+  emptyDescription?: string;
+  emptyIcon?: string;
 }
 
-const props = defineProps<TreeTableProps>();
+const props = withDefaults(defineProps<TreeTableProps>(), {
+  title: undefined,
+  hideHeaders: false,
+  emptyTitle: "Nenhum registro encontrado",
+  emptyDescription: "Não há dados para exibir.",
+  emptyIcon: "bi-folder2-open",
+});
+
 const emit = defineEmits<(e: "row-click", item: TreeItem) => void>();
 
 const internalData = ref<TreeItem[]>([]);

--- a/frontend/src/components/__tests__/TreeTableView.spec.ts
+++ b/frontend/src/components/__tests__/TreeTableView.spec.ts
@@ -2,6 +2,7 @@ import {mount} from "@vue/test-utils";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 import TreeRowItem from "../TreeRowItem.vue";
 import TreeTableView from "../TreeTableView.vue";
+import EmptyState from "@/components/EmptyState.vue";
 import {setupComponentTest} from "@/test-utils/componentTestHelpers";
 
 // Mock do componente TreeRow
@@ -253,5 +254,39 @@ describe("TreeTable.vue", () => {
 
         // Verificar que não quebrou e manteve estado
         expect(mockData[0].expanded).toBe(false);
+    });
+
+    it("deve renderizar o estado vazio quando não houver dados", () => {
+        const wrapper = mount(TreeTableView, {
+            props: {data: [], columns: mockColumns},
+            global: {stubs: {TreeRowItem: mockTreeRow}},
+        });
+
+        // Verifica se EmptyState está presente
+        const emptyState = wrapper.findComponent(EmptyState);
+        expect(emptyState.exists()).toBe(true);
+        expect(emptyState.props('title')).toBe("Nenhum registro encontrado");
+
+        // Verifica se TreeRowItem NÃO está presente
+        expect(wrapper.findComponent(TreeRowItem).exists()).toBe(false);
+    });
+
+    it("deve renderizar o estado vazio customizado", () => {
+        const wrapper = mount(TreeTableView, {
+            props: {
+                data: [],
+                columns: mockColumns,
+                emptyTitle: "Nada aqui",
+                emptyDescription: "Vazio mesmo",
+                emptyIcon: "bi-x-circle"
+            },
+            global: {stubs: {TreeRowItem: mockTreeRow}},
+        });
+
+        const emptyState = wrapper.findComponent(EmptyState);
+        expect(emptyState.exists()).toBe(true);
+        expect(emptyState.props('title')).toBe("Nada aqui");
+        expect(emptyState.props('description')).toBe("Vazio mesmo");
+        expect(emptyState.props('icon')).toBe("bi-x-circle");
     });
 });


### PR DESCRIPTION
This PR improves the UX of the `TreeTableView` component by displaying a standardized "Empty State" message when no data is available, instead of an empty table body. This aligns with other table components in the system and provides better feedback to the user.

- **Frontend:** Modified `TreeTableView.vue` to check for empty data and render `EmptyState`.
- **Tests:** Added unit tests for the new empty state logic.
- **Documentation:** Updated Palette's journal.

---
*PR created automatically by Jules for task [18314407899950749419](https://jules.google.com/task/18314407899950749419) started by @lgalvao*