### PR TITLE
Fix backend test failures and quality issues

### DIFF
--- a/backend/src/test/java/sgc/integracao/CDU11IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU11IntegrationTest.java
@@ -14,8 +14,7 @@ import sgc.integracao.mocks.WithMockAdmin;
 import sgc.integracao.mocks.WithMockChefe;
 import sgc.integracao.mocks.WithMockGestor;
 import sgc.mapa.model.*;
-import sgc.organizacao.model.Unidade;
-import sgc.organizacao.model.UnidadeRepo;
+import sgc.organizacao.model.*;
 import sgc.processo.model.Processo;
 import sgc.processo.model.ProcessoRepo;
 import sgc.processo.model.SituacaoProcesso;
@@ -53,6 +52,8 @@ class CDU11IntegrationTest extends BaseIntegrationTest {
     @Autowired private MapaRepo mapaRepo;
     @Autowired private AtividadeRepo atividadeRepo;
     @Autowired private ConhecimentoRepo conhecimentoRepo;
+    @Autowired private UsuarioRepo usuarioRepo;
+    @Autowired private UsuarioPerfilRepo usuarioPerfilRepo;
 
 
     // Test data
@@ -79,6 +80,11 @@ class CDU11IntegrationTest extends BaseIntegrationTest {
         unidade = UnidadeFixture.unidadeComSigla("SENIC");
         unidade.setCodigo(null);
         unidade = unidadeRepo.save(unidade);
+
+        // Setup users for mocks
+        criarUsuario("111122223333", Perfil.CHEFE, unidade); // For @WithMockChefe
+        criarUsuario("222222222222", Perfil.GESTOR, unidade); // For @WithMockGestor
+        criarUsuario("user", Perfil.SERVIDOR, unidade); // For @WithMockUser (default username)
 
         // Processo
         processo = ProcessoFixture.processoPadrao();
@@ -118,6 +124,20 @@ class CDU11IntegrationTest extends BaseIntegrationTest {
 
         Conhecimento conhecimento2b = Conhecimento.builder().atividade(atividade2).descricao("Uso de planilhas").build();
         conhecimentoRepo.save(conhecimento2b);
+    }
+
+    private void criarUsuario(String titulo, Perfil perfil, Unidade unidade) {
+        Usuario usuario = UsuarioFixture.usuarioComTitulo(titulo);
+        usuario.setUnidadeLotacao(unidade);
+        usuario = usuarioRepo.save(usuario);
+
+        UsuarioPerfil up = new UsuarioPerfil();
+        up.setUsuario(usuario);
+        up.setUsuarioTitulo(titulo);
+        up.setUnidade(unidade);
+        up.setUnidadeCodigo(unidade.getCodigo());
+        up.setPerfil(perfil);
+        usuarioPerfilRepo.save(up);
     }
 
     @Nested


### PR DESCRIPTION
This PR addresses quality issues identified in the backend test suite.

### Changes
1.  **`backend/src/test/java/sgc/e2e/E2eControllerTest.java`**:
    -   Modified `deveUsarSegundoCaminhoParaSeedSql` to mock an exception from `dataSource.getConnection()`. This prevents `ScriptUtils` from hanging on a mocked connection while still validating the fallback resource loading logic.
    -   Added `StandardCharsets.UTF_8` to `getBytes()` call to satisfy SpotBugs.

2.  **`backend/src/test/java/sgc/integracao/CDU11IntegrationTest.java`**:
    -   Updated `setUp` method to persist mock users (`111122223333`, `222222222222`, `user`) and their `UsuarioPerfil` associations with the test unit (`SENIC`). This resolves 403 Forbidden and 404 Not Found errors caused by the application logic failing to find the authenticated user in the database.

### Verification
-   Ran `./gradlew qualityCheck` successfully (1385 tests passed).
-   Ran specific failing tests to confirm fixes.

---
*PR created automatically by Jules for task [17247626730568206836](https://jules.google.com/task/17247626730568206836) started by @lgalvao*