### PR TITLE
⚡ Bolt: Optimize Movimentacao fetch with JOIN FETCH

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,8 @@ Competence-Activity associations because `Competencia.getAtividades()` was acces
 scans for common dashboard queries. `sgc.alerta_usuario` was missing an index on `usuario_titulo`.
 **Action:** Always verify `schema.sql` against `JpaRepository` queries (especially `findBy...`) to ensure foreign keys
 and filter columns are indexed.
+
+## 2025-02-18 - N+1 on Movimentacao
+
+**Learning:** `MovimentacaoRepo.findBySubprocessoCodigoOrderByDataHoraDesc` was a derived query causing N+1 selects for `Unidade` (origin and destination) because they are EAGER by default.
+**Action:** Replaced with `@Query` using `LEFT JOIN FETCH`. Always check derived queries involving entities with EAGER relationships.

--- a/backend/src/main/java/sgc/subprocesso/model/MovimentacaoRepo.java
+++ b/backend/src/main/java/sgc/subprocesso/model/MovimentacaoRepo.java
@@ -1,6 +1,8 @@
 package sgc.subprocesso.model;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,11 +17,21 @@ public interface MovimentacaoRepo extends JpaRepository<Movimentacao, Long> {
     /**
      * Recupera movimentações vinculadas a um subprocesso, ordenadas por dataHora desc (mais recente
      * primeiro).
+     * <p>
+     * Optimization: Uses JOIN FETCH for unidadeOrigem and unidadeDestino to prevent N+1 queries.
+     * </p>
      *
      * @param subprocessoCodigo codigo do subprocesso
      * @return lista de Movimentacao ordenada por dataHora desc
      */
-    List<Movimentacao> findBySubprocessoCodigoOrderByDataHoraDesc(Long subprocessoCodigo);
+    @Query("""
+            SELECT m FROM Movimentacao m
+            LEFT JOIN FETCH m.unidadeOrigem
+            LEFT JOIN FETCH m.unidadeDestino
+            WHERE m.subprocesso.codigo = :subprocessoCodigo
+            ORDER BY m.dataHora DESC
+            """)
+    List<Movimentacao> findBySubprocessoCodigoOrderByDataHoraDesc(@Param("subprocessoCodigo") Long subprocessoCodigo);
 
     List<Movimentacao> findBySubprocessoCodigo(Long subprocessoCodigo);
 }

--- a/backend/src/test/java/sgc/subprocesso/model/MovimentacaoRepoPerformanceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/MovimentacaoRepoPerformanceTest.java
@@ -1,0 +1,92 @@
+package sgc.subprocesso.model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import sgc.organizacao.model.TipoUnidade;
+import sgc.organizacao.model.Unidade;
+import sgc.processo.model.Processo;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@Tag("integration")
+@ActiveProfiles("test")
+class MovimentacaoRepoPerformanceTest {
+
+    @Autowired
+    private MovimentacaoRepo movimentacaoRepo;
+
+    @Autowired
+    private sgc.organizacao.model.UnidadeRepo unidadeRepo;
+
+    @Autowired
+    private sgc.processo.model.ProcessoRepo processoRepo;
+
+    @Autowired
+    private SubprocessoRepo subprocessoRepo;
+
+    @Test
+    @DisplayName("Deve buscar movimentações com join fetch")
+    void deveBuscarMovimentacoesComJoinFetch() {
+        // Given
+        Unidade uOrigem = new Unidade();
+        uOrigem.setSigla("UO");
+        uOrigem.setNome("Unidade Origem");
+        uOrigem.setTipo(TipoUnidade.OPERACIONAL);
+        uOrigem = unidadeRepo.save(uOrigem);
+
+        Unidade uDestino = new Unidade();
+        uDestino.setSigla("UD");
+        uDestino.setNome("Unidade Destino");
+        uDestino.setTipo(TipoUnidade.OPERACIONAL);
+        uDestino = unidadeRepo.save(uDestino);
+
+        Processo p = new Processo();
+        p = processoRepo.save(p);
+
+        Subprocesso sp = Subprocesso.builder()
+            .processo(p)
+            .unidade(uOrigem)
+            .situacao(SituacaoSubprocesso.NAO_INICIADO)
+            .build();
+        sp = subprocessoRepo.save(sp);
+
+        Movimentacao m1 = Movimentacao.builder()
+            .subprocesso(sp)
+            .unidadeOrigem(uOrigem)
+            .unidadeDestino(uDestino)
+            .descricao("Mov 1")
+            .dataHora(LocalDateTime.now().minusHours(1))
+            .build();
+        movimentacaoRepo.save(m1);
+
+        Movimentacao m2 = Movimentacao.builder()
+            .subprocesso(sp)
+            .unidadeOrigem(uOrigem)
+            .unidadeDestino(null)
+            .descricao("Mov 2")
+            .dataHora(LocalDateTime.now())
+            .build();
+        movimentacaoRepo.save(m2);
+
+        // When
+        List<Movimentacao> result = movimentacaoRepo.findBySubprocessoCodigoOrderByDataHoraDesc(sp.getCodigo());
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getDescricao()).isEqualTo("Mov 2");
+        assertThat(result.get(1).getDescricao()).isEqualTo("Mov 1");
+
+        assertThat(result.get(1).getUnidadeDestino().getSigla()).isEqualTo("UD");
+        assertThat(result.get(0).getUnidadeDestino()).isNull();
+    }
+}


### PR DESCRIPTION
💡 What: Optimized `MovimentacaoRepo.findBySubprocessoCodigoOrderByDataHoraDesc` to use `LEFT JOIN FETCH`.
🎯 Why: Accessing `unidadeOrigem` and `unidadeDestino` on `Movimentacao` entities was triggering N+1 select queries due to default EAGER fetching behavior on `@ManyToOne` relationships without explicit joins.
📊 Impact: Reduces database queries from 1 + 2N (or 1 + N) to 1 query for listing subprocess movements.
🔬 Measurement: Verified with `MovimentacaoRepoPerformanceTest` which confirms the query executes successfully and populates the relationships. Existing regression tests ensure no side effects.

---
*PR created automatically by Jules for task [9097476874115067569](https://jules.google.com/task/9097476874115067569) started by @lgalvao*