### PR TITLE
🎨 Palette: Enforce explicit selection for Process Type

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@ internal focus logic of the modal component.
 `v-if` logic repeatedly.
 **Action:** Bake `EmptyState` support directly into generic components (with customizable props) so that "no data"
 scenarios are handled gracefully and consistently by default without extra boilerplate in every view.
+
+## 2026-01-27 - [Explicit Choice vs Smart Default]
+**Learning:** For critical classifications like "Process Type", defaulting to the first option (e.g., "Mapeamento") prone to user error, as users often skip fields with pre-filled values.
+**Action:** Initialize such fields as null/empty and force an explicit user selection using a disabled placeholder option (e.g., "-- Selecione --"), ensuring the user makes a conscious decision.

--- a/frontend/src/composables/useProcessoForm.ts
+++ b/frontend/src/composables/useProcessoForm.ts
@@ -4,7 +4,7 @@ import {type AtualizarProcessoRequest, type CriarProcessoRequest, type Processo,
 
 export function useProcessoForm(initialData?: Processo) {
   const descricao = ref(initialData?.descricao ?? '');
-  const tipo = ref(initialData?.tipo ?? TipoProcesso.MAPEAMENTO);
+  const tipo = ref<TipoProcesso | null>(initialData?.tipo ?? null);
 
   // Handling date format for input type="date"
   const initialDate = initialData?.dataLimite ? initialData.dataLimite.split('T')[0] : '';
@@ -63,7 +63,7 @@ export function useProcessoForm(initialData?: Processo) {
 
   function limpar() {
     descricao.value = '';
-    tipo.value = TipoProcesso.MAPEAMENTO;
+    tipo.value = null;
     dataLimite.value = '';
     unidadesSelecionadas.value = [];
     clearErrors();

--- a/frontend/src/views/CadProcesso.vue
+++ b/frontend/src/views/CadProcesso.vue
@@ -47,7 +47,11 @@
             :options="tipoOptions"
             :state="fieldErrors.tipo ? false : null"
             data-testid="sel-processo-tipo"
-        />
+        >
+          <template #first>
+            <BFormSelectOption :value="null" disabled>-- Selecione o tipo --</BFormSelectOption>
+          </template>
+        </BFormSelect>
         <BFormInvalidFeedback :state="fieldErrors.tipo ? false : null">
           {{ fieldErrors.tipo }}
         </BFormInvalidFeedback>
@@ -185,6 +189,7 @@ import {
   BFormInput,
   BFormInvalidFeedback,
   BFormSelect,
+  BFormSelectOption,
 } from "bootstrap-vue-next";
 import {nextTick, onMounted, ref, watch} from "vue";
 import {useRoute, useRouter} from "vue-router";
@@ -292,7 +297,7 @@ onMounted(async () => {
       mostrarAlerta('danger', "Erro ao carregar processo", "Não foi possível carregar os detalhes do processo.");
       logger.error("Erro ao carregar processo:", error);
     }
-  } else {
+  } else if (tipo.value) {
     await unidadesStore.buscarUnidadesParaProcesso(tipo.value);
   }
 
@@ -308,7 +313,9 @@ watch(tipo, async (novoTipo) => {
   const codProcesso = processoEditando.value
       ? processoEditando.value.codigo
       : undefined;
-  await unidadesStore.buscarUnidadesParaProcesso(novoTipo, codProcesso);
+  if (novoTipo) {
+    await unidadesStore.buscarUnidadesParaProcesso(novoTipo, codProcesso);
+  }
 });
 
 function handleApiErrors(error: any, title: string, defaultMsg: string) {

--- a/frontend/src/views/__tests__/CadProcesso.spec.ts
+++ b/frontend/src/views/__tests__/CadProcesso.spec.ts
@@ -69,9 +69,13 @@ describe('CadProcesso.vue', () => {
                         props: ['modelValue']
                     },
                     BFormSelect: {
-                        template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option value="MAPEAMENTO">MAPEAMENTO</option></select>',
+                        template: '<select :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot name="first" /><option value="MAPEAMENTO">MAPEAMENTO</option></select>',
                         props: ['modelValue', 'options'],
                         inheritAttrs: false
+                    },
+                    BFormSelectOption: {
+                        template: '<option :value="value" :disabled="disabled"><slot /></option>',
+                        props: ['value', 'disabled']
                     },
                     BButton: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
                     BModal: {
@@ -105,7 +109,7 @@ describe('CadProcesso.vue', () => {
     it('renders correctly in creation mode', async () => {
         const { wrapper } = createWrapper();
         expect(wrapper.find('h2').text()).toBe('Cadastro de processo');
-        expect(unidadesStore.buscarUnidadesParaProcesso).toHaveBeenCalledWith('MAPEAMENTO');
+        expect(unidadesStore.buscarUnidadesParaProcesso).not.toHaveBeenCalled();
         expect(wrapper.find('[data-testid="btn-processo-salvar"]').exists()).toBe(true);
         expect(wrapper.find('[data-testid="btn-processo-remover"]').exists()).toBe(false);
     });
@@ -131,7 +135,14 @@ describe('CadProcesso.vue', () => {
         wrapper.vm.unidadesSelecionadas = [1];
         await nextTick();
 
-        // Now it should be enabled (tipo has default 'MAPEAMENTO')
+        // Still disabled because tipo is null
+        expect((salvarBtn.element as HTMLButtonElement).disabled).toBe(true);
+
+        // Select type
+        wrapper.vm.tipo = 'MAPEAMENTO';
+        await nextTick();
+
+        // Now it should be enabled
         expect((salvarBtn.element as HTMLButtonElement).disabled).toBe(false);
         expect((iniciarBtn.element as HTMLButtonElement).disabled).toBe(false);
 
@@ -164,6 +175,9 @@ describe('CadProcesso.vue', () => {
 
         const descricaoInput = wrapper.find('[data-testid="inp-processo-descricao"]');
         await descricaoInput.setValue('Novo Processo');
+
+        wrapper.vm.tipo = 'MAPEAMENTO';
+        await nextTick();
 
         const dataInput = wrapper.find('[data-testid="inp-processo-data-limite"]');
         await dataInput.setValue('2023-12-31');


### PR DESCRIPTION
💡 What: Changed the "Cadastro de Processo" form to require explicit selection of the process type instead of defaulting to "Mapeamento".
🎯 Why: Prevents accidental creation of "Mapeamento" processes when users intend to create other types but forget to change the default.
♿ Accessibility: Added a disabled placeholder option "-- Selecione o tipo --" to provide clear instruction.
Tests: Updated unit tests in CadProcesso.spec.ts to verify the new behavior.

---
*PR created automatically by Jules for task [4937895489697807663](https://jules.google.com/task/4937895489697807663) started by @lgalvao*