### PR TITLE
⚡ Bolt: Fix N+1 query in ProcessoRepo

### DIFF
--- a/backend/src/main/java/sgc/processo/model/ProcessoRepo.java
+++ b/backend/src/main/java/sgc/processo/model/ProcessoRepo.java
@@ -22,7 +22,14 @@ public interface ProcessoRepo extends JpaRepository<Processo, Long> {
             """)
     List<Processo> findBySituacao(@Param("situacao") SituacaoProcesso situacao);
 
-    List<Processo> findBySituacaoOrderByDataFinalizacaoDesc(SituacaoProcesso situacao);
+    /**
+     * Busca processos por situação ordenados por data de finalização.
+     * Utiliza LEFT JOIN FETCH para carregar participantes e evitar problemas de N+1.
+     */
+    @Query("""
+            SELECT DISTINCT p FROM Processo p LEFT JOIN FETCH p.participantes WHERE p.situacao = :situacao ORDER BY p.dataFinalizacao DESC
+            """)
+    List<Processo> findBySituacaoOrderByDataFinalizacaoDesc(@Param("situacao") SituacaoProcesso situacao);
 
     Page<Processo> findDistinctByParticipantes_CodigoInAndSituacaoNot(
             List<Long> codigos, SituacaoProcesso situacao, Pageable pageable);

--- a/backend/src/test/java/sgc/processo/service/ProcessoFacadeQueryTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoFacadeQueryTest.java
@@ -1,5 +1,6 @@
 package sgc.processo.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import sgc.comum.erros.ErroEntidadeNaoEncontrada;
 import sgc.fixture.ProcessoFixture;
 import sgc.fixture.SubprocessoFixture;
@@ -52,6 +54,11 @@ class ProcessoFacadeQueryTest {
 
     @InjectMocks
     private ProcessoFacade processoFacade;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(processoFacade, "self", processoFacade);
+    }
 
     @Nested
     @DisplayName("Consultas e Detalhes")


### PR DESCRIPTION
⚡ Bolt Performance Improvement: N+1 Query Fix

💡 What:
Replaced the derived query method `findBySituacaoOrderByDataFinalizacaoDesc` in `ProcessoRepo` with a custom `@Query` that uses `LEFT JOIN FETCH` to load the `participantes` collection eagerly.

🎯 Why:
The previous implementation lazily loaded `participantes`. When `ProcessoFacade.listarFinalizados()` was called, it fetched the list of processes and then, during DTO mapping, iterated over each process to access `participantes`, triggering a separate SQL query for each process (N+1 problem).

📊 Impact:
Reduces database round-trips significantly when listing finalized processes. Instead of 1 + N (or 1 + N/BatchSize) queries, it now executes a single query.

🔬 Measurement:
Verified by analysis of `ProcessoRepo` query and `ProcessoMapper` logic. Regression testing performed with `ProcessoFacadeQueryTest`.

Also addressed a test environment issue in `ProcessoFacadeQueryTest` where `self` injection was missing, causing `NullPointerException`.

---
*PR created automatically by Jules for task [11361791699006010216](https://jules.google.com/task/11361791699006010216) started by @lgalvao*