### PR TITLE
🎨 Palette: Add visual required indicators and accessible attributes to Process form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@ scenarios are handled gracefully and consistently by default without extra boile
 ## 2026-01-27 - [Explicit Choice vs Smart Default]
 **Learning:** For critical classifications like "Process Type", defaulting to the first option (e.g., "Mapeamento") prone to user error, as users often skip fields with pre-filled values.
 **Action:** Initialize such fields as null/empty and force an explicit user selection using a disabled placeholder option (e.g., "-- Selecione --"), ensuring the user makes a conscious decision.
+
+## 2026-01-29 - [Bootstrap Form Required Indicators]
+**Learning:** `BFormGroup` does not automatically add a required indicator (asterisk) based on validation rules or props. This leaves users guessing which fields are mandatory until they hit "Save".
+**Action:** Use the `#label` slot in `BFormGroup` to explicitly include a `<span class="text-danger" aria-hidden="true">*</span>` for required fields, ensuring the indicator is visually consistent.

--- a/frontend/src/views/CadProcesso.vue
+++ b/frontend/src/views/CadProcesso.vue
@@ -19,9 +19,11 @@
 
       <BFormGroup
           class="mb-3"
-          label="Descrição"
           label-for="descricao"
       >
+        <template #label>
+          Descrição <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <BFormInput
             id="descricao"
             ref="inputDescricaoRef"
@@ -30,6 +32,7 @@
             data-testid="inp-processo-descricao"
             placeholder="Descreva o processo"
             type="text"
+            required
         />
         <BFormInvalidFeedback :state="fieldErrors.descricao ? false : null">
           {{ fieldErrors.descricao }}
@@ -38,15 +41,18 @@
 
       <BFormGroup
           class="mb-3"
-          label="Tipo"
           label-for="tipo"
       >
+        <template #label>
+          Tipo <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <BFormSelect
             id="tipo"
             v-model="tipo"
             :options="tipoOptions"
             :state="fieldErrors.tipo ? false : null"
             data-testid="sel-processo-tipo"
+            required
         >
           <template #first>
             <BFormSelectOption :value="null" disabled>-- Selecione o tipo --</BFormSelectOption>
@@ -57,10 +63,10 @@
         </BFormInvalidFeedback>
       </BFormGroup>
 
-      <BFormGroup
-          class="mb-3"
-          label="Unidades participantes"
-      >
+      <BFormGroup class="mb-3">
+        <template #label>
+          Unidades participantes <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <div class="border rounded p-3" :class="{ 'border-danger': fieldErrors.unidades }">
           <ArvoreUnidades
               v-if="!unidadesStore.isLoading"
@@ -83,15 +89,18 @@
       <BFormGroup
           class="mb-3"
           description="Prazo para conclusão da primeira etapa (Mapeamento/Revisão)."
-          label="Data limite"
           label-for="dataLimite"
       >
+        <template #label>
+          Data limite <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <BFormInput
             id="dataLimite"
             v-model="dataLimite"
             :state="fieldErrors.dataLimite ? false : null"
             data-testid="inp-processo-data-limite"
             type="date"
+            required
         />
         <BFormInvalidFeedback :state="fieldErrors.dataLimite ? false : null">
           {{ fieldErrors.dataLimite }}

--- a/frontend/src/views/__tests__/CadProcesso.spec.ts
+++ b/frontend/src/views/__tests__/CadProcesso.spec.ts
@@ -63,7 +63,7 @@ describe('CadProcesso.vue', () => {
                     BContainer: { template: '<div><slot /></div>' },
                     BAlert: { template: '<div class="alert"><slot /></div>', props: ['modelValue', 'variant'] },
                     BForm: { template: '<form @submit.prevent><slot /></form>' },
-                    BFormGroup: { template: '<div><slot /></div>', props: ['label'] },
+                    BFormGroup: { template: '<div><slot name="label">{{ label }}</slot><slot /></div>', props: ['label'] },
                     BFormInput: {
                         template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
                         props: ['modelValue']
@@ -577,6 +577,27 @@ describe('CadProcesso.vue', () => {
         expect(focusMock).toHaveBeenCalled();
 
         querySelectorSpy.mockRestore();
+    });
+
+    it('displays required field indicators (asterisks)', async () => {
+        const { wrapper } = createWrapper();
+
+        const asterisks = wrapper.findAll('span.text-danger');
+
+        // Should have at least 4 asterisks (Description, Type, Units, Date Limit)
+        // Note: LoginView might use similar spans, but we are testing CadProcesso here.
+        // Based on our implementation plan, we are adding 4 asterisks.
+        // We verify that they are inside BFormGroup labels.
+
+        expect(asterisks.length).toBeGreaterThanOrEqual(4);
+
+        // We can check if specific labels contain the asterisk
+
+        // Since we stubbed BFormGroup to render slot 'label', we can check the text content of the wrapper
+        expect(wrapper.html()).toContain('Descrição <span class="text-danger" aria-hidden="true">*</span>');
+        expect(wrapper.html()).toContain('Tipo <span class="text-danger" aria-hidden="true">*</span>');
+        expect(wrapper.html()).toContain('Unidades participantes <span class="text-danger" aria-hidden="true">*</span>');
+        expect(wrapper.html()).toContain('Data limite <span class="text-danger" aria-hidden="true">*</span>');
     });
 
 });


### PR DESCRIPTION
This PR improves the UX of the Process Creation form (`CadProcesso.vue`) by adding explicit visual indicators (red asterisks) to required fields. It also improves accessibility by adding the `required` attribute to the underlying form inputs, ensuring screen readers announce the mandatory state.

Key changes:
- Replaced `label` prop with `<template #label>` in `BFormGroup` to allow custom HTML (asterisks).
- Added `required` attribute to `BFormInput` and `BFormSelect`.
- Updated unit tests to verify the presence of the visual indicators.


---
*PR created automatically by Jules for task [1645783711203527142](https://jules.google.com/task/1645783711203527142) started by @lgalvao*