### PR TITLE
Correção de testes unitários em ProcessoFacade

### DIFF
--- a/backend/src/test/java/sgc/processo/service/ProcessoFacadeCoverageTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoFacadeCoverageTest.java
@@ -17,6 +17,8 @@ import org.mockito.Mock;
 import static org.mockito.Mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.junit.jupiter.api.BeforeEach;
 
 import sgc.organizacao.UnidadeFacade;
 import sgc.organizacao.model.Unidade;
@@ -63,6 +65,11 @@ class ProcessoFacadeCoverageTest {
 
     @InjectMocks
     private ProcessoFacade facade;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(facade, "self", facade);
+    }
 
     @Test
     @DisplayName("atualizar - Erro Situacao Invalida")

--- a/backend/src/test/java/sgc/processo/service/ProcessoFacadeQueryTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoFacadeQueryTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import sgc.comum.erros.ErroEntidadeNaoEncontrada;
 import sgc.fixture.ProcessoFixture;
 import sgc.fixture.SubprocessoFixture;
@@ -52,6 +54,11 @@ class ProcessoFacadeQueryTest {
 
     @InjectMocks
     private ProcessoFacade processoFacade;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(processoFacade, "self", processoFacade);
+    }
 
     @Nested
     @DisplayName("Consultas e Detalhes")

--- a/backend/src/test/java/sgc/processo/service/ProcessoFacadeWorkflowTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoFacadeWorkflowTest.java
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import sgc.alerta.AlertaFacade;
 import sgc.fixture.ProcessoFixture;
@@ -75,6 +77,11 @@ class ProcessoFacadeWorkflowTest {
 
     @InjectMocks
     private ProcessoFacade processoFacade;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(processoFacade, "self", processoFacade);
+    }
 
     @Nested
     @DisplayName("Workflow e Inicialização")


### PR DESCRIPTION
Correção de testes unitários do backend que falhavam devido à falta de injeção do campo 'self' na classe ProcessoFacade. Utilizou-se ReflectionTestUtils para resolver o problema.

---
*PR created automatically by Jules for task [7657368580375943690](https://jules.google.com/task/7657368580375943690) started by @lgalvao*