### PR TITLE
⚡ Bolt: Resolve N+1 issue in Processo retrieval

### DIFF
--- a/backend/src/main/java/sgc/processo/model/ProcessoRepo.java
+++ b/backend/src/main/java/sgc/processo/model/ProcessoRepo.java
@@ -22,7 +22,12 @@ public interface ProcessoRepo extends JpaRepository<Processo, Long> {
             """)
     List<Processo> findBySituacao(@Param("situacao") SituacaoProcesso situacao);
 
-    List<Processo> findBySituacaoOrderByDataFinalizacaoDesc(SituacaoProcesso situacao);
+    @Query("""
+            SELECT DISTINCT p FROM Processo p LEFT JOIN FETCH p.participantes
+            WHERE p.situacao = :situacao
+            ORDER BY p.dataFinalizacao DESC
+            """)
+    List<Processo> listarPorSituacaoComParticipantes(@Param("situacao") SituacaoProcesso situacao);
 
     Page<Processo> findDistinctByParticipantes_CodigoInAndSituacaoNot(
             List<Long> codigos, SituacaoProcesso situacao, Pageable pageable);

--- a/backend/src/main/java/sgc/processo/service/ProcessoRepositoryService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoRepositoryService.java
@@ -60,7 +60,7 @@ public class ProcessoRepositoryService {
 
     @Transactional(readOnly = true)
     public List<Processo> findBySituacaoOrderByDataFinalizacaoDesc(SituacaoProcesso situacao) {
-        return processoRepo.findBySituacaoOrderByDataFinalizacaoDesc(situacao);
+        return processoRepo.listarPorSituacaoComParticipantes(situacao);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/sgc/processo/model/ProcessoRepoPerformanceTest.java
+++ b/backend/src/test/java/sgc/processo/model/ProcessoRepoPerformanceTest.java
@@ -1,0 +1,70 @@
+package sgc.processo.model;
+
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import jakarta.persistence.EntityManager;
+import sgc.organizacao.model.Unidade;
+import sgc.organizacao.model.UnidadeRepo;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ProcessoRepoPerformanceTest {
+
+    @Autowired
+    private ProcessoRepo processoRepo;
+
+    @Autowired
+    private UnidadeRepo unidadeRepo;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void listarPorSituacaoComParticipantes_deveCarregarParticipantesComFetch() {
+        // Arrange
+        Unidade unidade = new Unidade();
+        unidade.setNome("Unidade Teste");
+        unidade.setSigla("UT");
+        unidade.setTituloTitular("Titular");
+        unidadeRepo.save(unidade);
+
+        Processo processo = new Processo();
+        processo.setDescricao("Processo Finalizado");
+        processo.setSituacao(SituacaoProcesso.FINALIZADO);
+        processo.setTipo(TipoProcesso.MAPEAMENTO);
+        processo.getParticipantes().add(unidade);
+        processoRepo.save(processo);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // Act
+        List<Processo> processos = processoRepo.listarPorSituacaoComParticipantes(SituacaoProcesso.FINALIZADO);
+
+        // Assert
+        assertThat(processos).isNotEmpty();
+
+        for (Processo p : processos) {
+            assertThat(Hibernate.isInitialized(p.getParticipantes()))
+                .as("Participantes devem ser inicializados pelo JOIN FETCH. Processo: " + p.getCodigo())
+                .isTrue();
+        }
+
+        // Verify content for our created process
+        Processo returnedProcess = processos.stream()
+                .filter(p -> p.getCodigo().equals(processo.getCodigo()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(returnedProcess.getParticipantes()).hasSize(1);
+    }
+}


### PR DESCRIPTION
⚡ Bolt: Resolve N+1 issue in Processo retrieval

💡 What:
Replaced the derived query `findBySituacaoOrderByDataFinalizacaoDesc` in `ProcessoRepo` with a custom JPQL query `listarPorSituacaoComParticipantes` that uses `LEFT JOIN FETCH` to eagerly load the `participantes` collection.

🎯 Why:
The `ProcessoMapper` accesses `processo.getParticipantes()` during DTO mapping. Since the original query did not fetch this collection, Hibernate executed an additional query for each Processo in the list (N+1 problem), causing performance degradation when listing finalized processes.

📊 Impact:
Reduces database queries from N+1 to 1 for the "Listar Processos Finalizados" operation.

🔬 Measurement:
Added `ProcessoRepoPerformanceTest` which inserts a Processo with participants, clears the EntityManager, and verifies that `participantes` are initialized in the returned entities without triggering lazy loading.

---
*PR created automatically by Jules for task [1010661935677830564](https://jules.google.com/task/1010661935677830564) started by @lgalvao*