### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing input length validation and enforcement

### DIFF
--- a/backend/src/main/java/sgc/organizacao/UnidadeController.java
+++ b/backend/src/main/java/sgc/organizacao/UnidadeController.java
@@ -1,5 +1,6 @@
 package sgc.organizacao;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -42,7 +43,7 @@ public class UnidadeController {
     @PostMapping("/{codUnidade}/atribuicoes-temporarias")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> criarAtribuicaoTemporaria(
-            @PathVariable Long codUnidade, @RequestBody CriarAtribuicaoTemporariaRequest request) {
+            @PathVariable Long codUnidade, @Valid @RequestBody CriarAtribuicaoTemporariaRequest request) {
 
         unidadeService.criarAtribuicaoTemporaria(codUnidade, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/backend/src/main/java/sgc/organizacao/dto/CriarAtribuicaoTemporariaRequest.java
+++ b/backend/src/main/java/sgc/organizacao/dto/CriarAtribuicaoTemporariaRequest.java
@@ -1,5 +1,6 @@
 package sgc.organizacao.dto;
 
+import jakarta.validation.constraints.Size;
 import sgc.seguranca.sanitizacao.SanitizarHtml;
 
 import java.time.LocalDate;
@@ -9,5 +10,6 @@ public record CriarAtribuicaoTemporariaRequest(
         LocalDate dataInicio,
         LocalDate dataTermino,
         @SanitizarHtml
+        @Size(max = 500, message = "A justificativa deve ter no máximo 500 caracteres")
         String justificativa) {
 }

--- a/backend/src/main/java/sgc/processo/dto/AtualizarProcessoRequest.java
+++ b/backend/src/main/java/sgc/processo/dto/AtualizarProcessoRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import sgc.processo.model.TipoProcesso;
 import sgc.seguranca.sanitizacao.SanitizarHtml;
@@ -19,7 +20,7 @@ import java.util.List;
 public record AtualizarProcessoRequest(
                 Long codigo,
 
-                @NotBlank(message = "Preencha a descrição") @SanitizarHtml String descricao,
+                @NotBlank(message = "Preencha a descrição") @Size(max = 255, message = "A descrição deve ter no máximo 255 caracteres") @SanitizarHtml String descricao,
 
                 @NotNull(message = "Tipo do processo é obrigatório") TipoProcesso tipo,
 

--- a/backend/src/main/java/sgc/processo/dto/CriarProcessoRequest.java
+++ b/backend/src/main/java/sgc/processo/dto/CriarProcessoRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import sgc.processo.model.TipoProcesso;
 import sgc.seguranca.sanitizacao.SanitizarHtml;
@@ -17,7 +18,7 @@ import java.util.List;
  */
 @Builder
 public record CriarProcessoRequest(
-                @NotBlank(message = "Preencha a descrição") @SanitizarHtml String descricao,
+                @NotBlank(message = "Preencha a descrição") @Size(max = 255, message = "A descrição deve ter no máximo 255 caracteres") @SanitizarHtml String descricao,
 
                 @NotNull(message = "Tipo do processo é obrigatório") TipoProcesso tipo,
 

--- a/backend/src/test/java/sgc/organizacao/UnidadeControllerTest.java
+++ b/backend/src/test/java/sgc/organizacao/UnidadeControllerTest.java
@@ -74,6 +74,25 @@ class UnidadeControllerTest {
     }
 
     @Test
+    @DisplayName("Deve retornar 400 ao criar atribuição temporária com justificativa longa")
+    @WithMockUser(roles = "ADMIN")
+    void deveRetornar400AoCriarAtribuicaoTemporariaComJustificativaLonga() throws Exception {
+        // Act & Assert
+        mockMvc.perform(
+                        post("/api/unidades/1/atribuicoes-temporarias")
+                                .with(csrf())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "tituloEleitoralUsuario":"123",
+                                            "dataTermino":"2025-12-31",
+                                            "justificativa":"%s"
+                                        }
+                                        """.formatted("a".repeat(501))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("Deve retornar lista ao buscar todas as unidades")
     @WithMockUser
     void deveRetornarListaAoBuscarTodasUnidades() throws Exception {

--- a/backend/src/test/java/sgc/processo/ProcessoControllerTest.java
+++ b/backend/src/test/java/sgc/processo/ProcessoControllerTest.java
@@ -180,6 +180,27 @@ class ProcessoControllerTest {
                                     .content(objectMapper.writeValueAsString(req)))
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        @WithMockUser
+        @DisplayName("Deve retornar 400 Bad Request quando descrição excede o limite")
+        void deveRetornarBadRequestQuandoDescricaoExcedeLimite() throws Exception {
+            // Arrange
+            var req =
+                    new CriarProcessoRequest(
+                            "a".repeat(256),
+                            TipoProcesso.MAPEAMENTO,
+                            LocalDateTime.now().plusDays(30),
+                            List.of(1L));
+
+            // Act & Assert
+            mockMvc.perform(
+                            post(API_PROCESSOS)
+                                    .with(csrf())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isBadRequest());
+        }
     }
 
     @Nested


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing input validation on sensitive fields (`descricao` in `Processo`, `justificativa` in `AtribuicaoTemporaria`). Input constraints were ignored in `UnidadeController` due to missing `@Valid`.
🎯 Impact: Potential Denial of Service (DoS) via resource exhaustion, database truncation errors, and bypassing of other validation logic.
🔧 Fix:
- Added `@Size(max = 255)` to `Processo` DTOs.
- Added `@Size(max = 500)` to `CriarAtribuicaoTemporariaRequest`.
- Added `@Valid` to `UnidadeController.criarAtribuicaoTemporaria` to enforce validation.
✅ Verification: Added tests in `ProcessoControllerTest` and `UnidadeControllerTest` that confirm 400 Bad Request is returned when limits are exceeded.

---
*PR created automatically by Jules for task [12556979445916088965](https://jules.google.com/task/12556979445916088965) started by @lgalvao*