### PR TITLE
🎨 Palette: Fix visibility of inline edit controls on touch devices

### DIFF
--- a/frontend/src/components/common/InlineEditor.vue
+++ b/frontend/src/components/common/InlineEditor.vue
@@ -123,11 +123,15 @@ function cancel() {
 
 <style scoped>
 .fade-controls {
-  opacity: 0;
+  opacity: 1;
   transition: opacity 0.2s;
 }
 
 @media (hover: hover) {
+  .fade-controls {
+    opacity: 0;
+  }
+
   .d-flex:hover > .fade-controls,
   .d-flex:focus-within > .fade-controls {
     opacity: 1;

--- a/frontend_log.txt
+++ b/frontend_log.txt
@@ -1,0 +1,9 @@
+
+> sgc@1.0.0 dev
+> vite
+
+
+  VITE v7.3.1  ready in 475 ms
+
+  ➜  Local:   http://localhost:5173/
+  ➜  Network: use --host to expose


### PR DESCRIPTION
- Modified `frontend/src/components/common/InlineEditor.vue` to set default opacity of `.fade-controls` to 1.
- Added `@media (hover: hover)` query to restrict the "opacity 0" behavior to desktop/hover-capable devices.
- Verified that linting passes and existing tests (unrelated failures) are not affected.


---
*PR created automatically by Jules for task [3701362604432631084](https://jules.google.com/task/3701362604432631084) started by @lgalvao*