### PR TITLE
🎨 Palette: Add loading state to AceitarMapaModal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-30 - Unwired Props in Modals
+**Learning:** Found a `loading` prop in `AceitarMapaModal` that was defined but completely unused in the template. This indicates a pattern where the interface was prepared for feedback but the implementation was missed.
+**Action:** When seeing "dead" props in component definitions, check if they were meant for important UX states like loading/disabled and wire them up.

--- a/frontend/src/components/AceitarMapaModal.vue
+++ b/frontend/src/components/AceitarMapaModal.vue
@@ -35,6 +35,7 @@
             <BButton
                 data-testid="btn-aceite-mapa-cancelar"
                 variant="secondary"
+                :disabled="loading"
                 @click="$emit('fecharModal')"
             >
                 <i class="bi bi-x-circle me-1" aria-hidden="true" />
@@ -43,17 +44,19 @@
             <BButton
                 data-testid="btn-aceite-mapa-confirmar"
                 variant="success"
+                :disabled="loading"
                 @click="$emit('confirmarAceitacao', observacao)"
             >
-                <i class="bi bi-check-circle me-1" aria-hidden="true" />
-                Aceitar
+                <BSpinner v-if="loading" small class="me-1" aria-hidden="true" />
+                <i v-else class="bi bi-check-circle me-1" aria-hidden="true" />
+                {{ loading ? 'Processando...' : 'Aceitar' }}
             </BButton>
         </template>
     </BModal>
 </template>
 
 <script lang="ts" setup>
-import {BButton, BFormTextarea, BModal} from "bootstrap-vue-next";
+import {BButton, BFormTextarea, BModal, BSpinner} from "bootstrap-vue-next";
 import {computed, ref} from "vue";
 
 interface Props {

--- a/frontend/src/components/__tests__/AceitarMapaModal.spec.ts
+++ b/frontend/src/components/__tests__/AceitarMapaModal.spec.ts
@@ -105,4 +105,15 @@ describe("AceitarMapaModal.vue", () => {
         expect(wrapper.emitted("confirmarAceitacao")).toBeTruthy();
         expect(wrapper.emitted("confirmarAceitacao")?.[0]).toEqual([""]);
     });
+
+    it("deve desabilitar botões e mostrar spinner quando loading for true", () => {
+        const wrapper = createWrapper({ loading: true });
+
+        const btnCancelar = wrapper.find('[data-testid="btn-aceite-mapa-cancelar"]');
+        const btnConfirmar = wrapper.find('[data-testid="btn-aceite-mapa-confirmar"]');
+
+        expect(btnCancelar.attributes("disabled")).toBeDefined();
+        expect(btnConfirmar.attributes("disabled")).toBeDefined();
+        expect(btnConfirmar.text()).toContain("Processando...");
+    });
 });


### PR DESCRIPTION
This PR addresses a UX issue where the `AceitarMapaModal` component was receiving a `loading` prop but not using it. This resulted in no visual feedback for the user during the asynchronous "Aceitar" or "Homologar" action, and allowed for potential double-submissions.

Changes:
- Updated `AceitarMapaModal.vue` to use the `loading` prop to disable buttons and show a spinner.
- Added a unit test case to `AceitarMapaModal.spec.ts` to verify the loading state behavior.
- Added a journal entry in `.jules/palette.md` regarding the learning about unwired props.

Verified with unit tests and a Playwright script mocking the backend interaction.

---
*PR created automatically by Jules for task [11306700051934593070](https://jules.google.com/task/11306700051934593070) started by @lgalvao*