### PR TITLE
⚡ Bolt: Add indexes for Processo and Subprocesso filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-22 - Test Schema Inconsistency
+**Learning:** The test schema (`backend/src/test/resources/db/schema.sql`) was missing indexes present in the production schema (`backend/src/main/resources/db/schema.sql`). This can lead to performance tests (like H2-based ones) not accurately reflecting production behavior, or worse, hiding missing index issues.
+**Action:** When adding indexes, always verify and update both schema files.
+
+## 2024-05-22 - Broken Legacy Tests
+**Learning:** `ConfiguracaoFacadeTest` was failing compilation due to a partial refactoring (Entities to DTOs) that wasn't updated in the test. This blocked running the test suite.
+**Action:** Be prepared to perform "Good Samaritan" fixes on unrelated broken tests to unblock the build pipeline.

--- a/backend/src/main/resources/db/schema.sql
+++ b/backend/src/main/resources/db/schema.sql
@@ -950,3 +950,5 @@ create index if not exists idx_alerta_unidade_destino on sgc.alerta (unidade_des
 create index if not exists idx_alerta_processo on sgc.alerta (processo_codigo);
 create index if not exists idx_alerta_usuario_usuario on sgc.alerta_usuario (usuario_titulo);
 create index if not exists idx_unidade_processo_unidade on sgc.unidade_processo (unidade_codigo);
+create index if not exists idx_processo_situacao_data_finalizacao on sgc.processo (situacao, data_finalizacao);
+create index if not exists idx_subprocesso_situacao on sgc.subprocesso (situacao);

--- a/backend/src/test/java/sgc/configuracao/ConfiguracaoFacadeTest.java
+++ b/backend/src/test/java/sgc/configuracao/ConfiguracaoFacadeTest.java
@@ -8,6 +8,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sgc.comum.erros.ErroConfiguracao;
+import sgc.configuracao.dto.ParametroRequest;
+import sgc.configuracao.dto.ParametroResponse;
+import sgc.configuracao.mapper.ParametroMapper;
 import sgc.configuracao.model.Parametro;
 
 import java.util.List;
@@ -27,19 +30,27 @@ class ConfiguracaoFacadeTest {
     @Mock
     private ConfiguracaoService configuracaoService;
 
+    @Mock
+    private ParametroMapper parametroMapper;
+
     @Test
     @DisplayName("Deve buscar todos os parâmetros")
     void buscarTodos_sucesso() {
         // Arrange
         Parametro p1 = Parametro.builder().chave("CHAVE_1").valor("VALOR_1").descricao("Desc 1").build();
         Parametro p2 = Parametro.builder().chave("CHAVE_2").valor("VALOR_2").descricao("Desc 2").build();
+        ParametroResponse r1 = ParametroResponse.builder().chave("CHAVE_1").valor("VALOR_1").descricao("Desc 1").build();
+        ParametroResponse r2 = ParametroResponse.builder().chave("CHAVE_2").valor("VALOR_2").descricao("Desc 2").build();
+
         when(configuracaoService.buscarTodos()).thenReturn(List.of(p1, p2));
+        when(parametroMapper.toResponse(p1)).thenReturn(r1);
+        when(parametroMapper.toResponse(p2)).thenReturn(r2);
 
         // Act
-        List<Parametro> resultado = configuracaoFacade.buscarTodos();
+        List<ParametroResponse> resultado = configuracaoFacade.buscarTodos();
 
         // Assert
-        assertThat(resultado).hasSize(2).contains(p1, p2);
+        assertThat(resultado).hasSize(2).contains(r1, r2);
         verify(configuracaoService).buscarTodos();
     }
 
@@ -77,16 +88,23 @@ class ConfiguracaoFacadeTest {
     @DisplayName("Deve salvar lista de parâmetros")
     void salvar_sucesso() {
         // Arrange
-        Parametro p1 = Parametro.builder().chave("CHAVE_1").valor("VALOR_1").descricao("Desc 1").build();
-        List<Parametro> lista = List.of(p1);
-        when(configuracaoService.salvar(lista)).thenReturn(lista);
+        Long codigo = 1L;
+        ParametroRequest req1 = new ParametroRequest(codigo, "CHAVE_1", "Desc 1", "VALOR_1");
+        Parametro p1 = Parametro.builder().codigo(codigo).chave("CHAVE_1").valor("VALOR_OLD").descricao("Desc 1").build();
+        Parametro p1Salvo = Parametro.builder().codigo(codigo).chave("CHAVE_1").valor("VALOR_1").descricao("Desc 1").build();
+        ParametroResponse r1 = ParametroResponse.builder().codigo(codigo).chave("CHAVE_1").valor("VALOR_1").descricao("Desc 1").build();
+
+        when(configuracaoService.buscarPorId(codigo)).thenReturn(p1);
+        when(configuracaoService.salvar(anyList())).thenReturn(List.of(p1Salvo));
+        when(parametroMapper.toResponse(p1Salvo)).thenReturn(r1);
 
         // Act
-        List<Parametro> resultado = configuracaoFacade.salvar(lista);
+        List<ParametroResponse> resultado = configuracaoFacade.salvar(List.of(req1));
 
         // Assert
-        assertThat(resultado).isEqualTo(lista);
-        verify(configuracaoService).salvar(lista);
+        assertThat(resultado).hasSize(1).contains(r1);
+        verify(parametroMapper).atualizarEntidade(eq(req1), eq(p1));
+        verify(configuracaoService).salvar(anyList());
     }
 
     @Test

--- a/backend/src/test/resources/db/schema.sql
+++ b/backend/src/test/resources/db/schema.sql
@@ -931,3 +931,5 @@ alter table if exists sgc.ocupacao_critica
     add constraint fk_ocupacao_competencia foreign key (competencia_codigo) references sgc.competencia;
 
 create index if not exists idx_unidade_processo_unidade on sgc.unidade_processo (unidade_codigo);
+create index if not exists idx_processo_situacao_data_finalizacao on sgc.processo (situacao, data_finalizacao);
+create index if not exists idx_subprocesso_situacao on sgc.subprocesso (situacao);


### PR DESCRIPTION
💡 What: Added database indexes for `Processo` and `Subprocesso` filtering by status (`situacao`).
🎯 Why: `findBySituacao` and related queries were performing full table scans (or inefficient lookups) as identified by the lack of indexes in `schema.sql`. Usage of these queries is frequent in `ProcessoConsultaService`.
📊 Impact: Expected to significantly reduce query time for process listings, especially `listarPorSituacaoComParticipantes` which orders by `dataFinalizacao` (covered by the composite index).
🔬 Measurement: Verified via `ProcessoRepoPerformanceTest`. Although H2 is in-memory, the presence of indexes allows the optimizer to use them. Real-world impact will be seen on larger datasets in production.

---
*PR created automatically by Jules for task [8333376047812963160](https://jules.google.com/task/8333376047812963160) started by @lgalvao*