### PR TITLE
🎨 Palette: Add required field indicators to Process Creation form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - [Standardizing Required Field Indicators]
+**Learning:** `BFormGroup` in `bootstrap-vue-next` (and Vue generally) requires using the `#label` slot to inject HTML content like `<span class="text-danger">*</span>`, as the `label` prop only accepts strings. This pattern must be consistent across forms for accessibility and UX.
+**Action:** When adding required field indicators, always use `<template #label>Label <span class="text-danger" aria-hidden="true">*</span></template>` and ensure the `required` attribute is present on the input itself for browser validation.

--- a/frontend/src/views/CadProcesso.vue
+++ b/frontend/src/views/CadProcesso.vue
@@ -19,9 +19,11 @@
 
       <BFormGroup
           class="mb-3"
-          label="Descrição"
           label-for="descricao"
       >
+        <template #label>
+          Descrição <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <BFormInput
             id="descricao"
             ref="inputDescricaoRef"
@@ -30,6 +32,7 @@
             data-testid="inp-processo-descricao"
             placeholder="Descreva o processo"
             type="text"
+            required
         />
         <BFormInvalidFeedback :state="fieldErrors.descricao ? false : null">
           {{ fieldErrors.descricao }}
@@ -38,15 +41,18 @@
 
       <BFormGroup
           class="mb-3"
-          label="Tipo"
           label-for="tipo"
       >
+        <template #label>
+          Tipo <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <BFormSelect
             id="tipo"
             v-model="tipo"
             :options="tipoOptions"
             :state="fieldErrors.tipo ? false : null"
             data-testid="sel-processo-tipo"
+            required
         >
           <template #first>
             <BFormSelectOption :value="null" disabled>-- Selecione o tipo --</BFormSelectOption>
@@ -59,8 +65,10 @@
 
       <BFormGroup
           class="mb-3"
-          label="Unidades participantes"
       >
+        <template #label>
+          Unidades participantes <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <div class="border rounded p-3" :class="{ 'border-danger': fieldErrors.unidades }">
           <ArvoreUnidades
               v-if="!unidadesStore.isLoading"
@@ -83,15 +91,18 @@
       <BFormGroup
           class="mb-3"
           description="Prazo para conclusão da primeira etapa (Mapeamento/Revisão)."
-          label="Data limite"
           label-for="dataLimite"
       >
+        <template #label>
+          Data limite <span class="text-danger" aria-hidden="true">*</span>
+        </template>
         <BFormInput
             id="dataLimite"
             v-model="dataLimite"
             :state="fieldErrors.dataLimite ? false : null"
             data-testid="inp-processo-data-limite"
             type="date"
+            required
         />
         <BFormInvalidFeedback :state="fieldErrors.dataLimite ? false : null">
           {{ fieldErrors.dataLimite }}

--- a/frontend/src/views/__tests__/CadProcesso.spec.ts
+++ b/frontend/src/views/__tests__/CadProcesso.spec.ts
@@ -63,7 +63,7 @@ describe('CadProcesso.vue', () => {
                     BContainer: { template: '<div><slot /></div>' },
                     BAlert: { template: '<div class="alert"><slot /></div>', props: ['modelValue', 'variant'] },
                     BForm: { template: '<form @submit.prevent><slot /></form>' },
-                    BFormGroup: { template: '<div><slot /></div>', props: ['label'] },
+                    BFormGroup: { template: '<div><slot name="label">{{ label }}</slot><slot /></div>', props: ['label'] },
                     BFormInput: {
                         template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
                         props: ['modelValue']
@@ -520,7 +520,7 @@ describe('CadProcesso.vue', () => {
                 BContainer: { template: '<div><slot /></div>' },
                 BAlert: { template: '<div class="alert"><slot /></div>', props: ['modelValue', 'variant'] },
                 BForm: { template: '<form @submit.prevent><slot /></form>' },
-                BFormGroup: { template: '<div><slot /></div>', props: ['label'] },
+                BFormGroup: { template: '<div><slot name="label">{{ label }}</slot><slot /></div>', props: ['label'] },
                 BFormInput: { template: '<input />', props: ['modelValue'] },
                 BFormSelect: { template: '<select></select>', props: ['modelValue'] },
                 BButton: { template: '<button></button>' },


### PR DESCRIPTION
💡 What: Added visual red asterisks (*) to required fields (Descrição, Tipo, Unidades, Data limite) in `CadProcesso.vue` and added the `required` attribute to corresponding inputs.
🎯 Why: To provide immediate visual feedback to users about which fields are mandatory, improving the form completion rate and reducing validation errors. This aligns with the pattern used in the Login screen.
📸 Before/After: Screenshot verification confirmed the red asterisks are now present.
♿ Accessibility: Added `aria-hidden="true"` to the asterisk to avoid screen reader clutter, relying on the `required` attribute on inputs for semantic meaning. Updated test stubs to correctly verify label slots.

---
*PR created automatically by Jules for task [14737524541643974075](https://jules.google.com/task/14737524541643974075) started by @lgalvao*