### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Log Injection in LoginController

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The authentication flow relied on an in-memory `ConcurrentHashMap` (`autenticacoesRecentes`) to track "authenticated" users by username only. This allowed a race condition where an attacker could hijack a session by polling the authorization endpoint while a legitimate user was logging in.
 **Learning:** Storing authentication state in application memory based solely on user identity (without a unique session token bound to the client) is insecure and prone to race conditions, especially in a REST API which should be stateless.
 **Prevention:** Always use cryptographically signed tokens (like JWTs) or secure random session IDs stored in HttpOnly cookies to bind the authentication state to the client. Ensure that every step of a multi-step login process verifies this token.
+
+## 2026-01-29 - Log Injection via X-Forwarded-For
+**Vulnerability:** The `LoginController` extracted the client IP address from the `X-Forwarded-For` header and logged it directly without sanitization. This allowed attackers to inject fake log entries (Log Forging/CWE-117) by sending requests with newlines in the header.
+**Learning:** Even "system" headers like `X-Forwarded-For` are untrusted user input when the request comes from the internet. Standard Java loggers often do not automatically sanitize newlines.
+**Prevention:** Always sanitize untrusted input before logging. Replacing `\n` and `\r` with `_` is a simple and effective mitigation for log injection.

--- a/backend/src/main/java/sgc/seguranca/login/LoginController.java
+++ b/backend/src/main/java/sgc/seguranca/login/LoginController.java
@@ -146,6 +146,11 @@ public class LoginController {
         } else {
             ip = ip.split(",")[0].trim();
         }
+
+        // Sanitização contra Log Injection (CWE-117)
+        if (ip != null) {
+            return ip.replaceAll("[\\n\\r]", "_");
+        }
         return ip;
     }
 }

--- a/backend/src/test/java/sgc/seguranca/login/LoginControllerLogInjectionTest.java
+++ b/backend/src/test/java/sgc/seguranca/login/LoginControllerLogInjectionTest.java
@@ -1,0 +1,80 @@
+package sgc.seguranca.login;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import sgc.comum.erros.RestExceptionHandler;
+import sgc.organizacao.UsuarioFacade;
+import sgc.seguranca.login.dto.AutenticarRequest;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LoginController.class)
+@Import(RestExceptionHandler.class)
+@DisplayName("LoginController - Teste de Log Injection")
+class LoginControllerLogInjectionTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private LoginFacade loginFacade;
+
+    @MockitoBean
+    private UsuarioFacade usuarioService;
+
+    @MockitoBean
+    private LimitadorTentativasLogin limitadorTentativasLogin;
+
+    @MockitoBean
+    private GerenciadorJwt gerenciadorJwt;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("POST /api/usuarios/autenticar - Deve sanitizar IP no header X-Forwarded-For (Log Injection)")
+    @WithMockUser
+    void autenticar_DeveSanitizarIpLogInjection() throws Exception {
+        // Payload de Log Injection: Tenta injetar uma nova linha e um log falso
+        // O valor original poderia ser algo como: "10.0.0.1\nINFO User logged in as admin"
+        String ipMalicioso = "10.0.0.1\nINFO User logged in as admin";
+
+        // O valor sanitizado deve ter a nova linha removida ou substituída
+        // Vamos assumir que substituímos por sublinhado ou removemos.
+
+        AutenticarRequest req = AutenticarRequest.builder()
+                .tituloEleitoral("123")
+                .senha("senha")
+                .build();
+
+        when(loginFacade.autenticar("123", "senha")).thenReturn(true);
+
+        mockMvc.perform(post("/api/usuarios/autenticar")
+                        .with(csrf())
+                        .header("X-Forwarded-For", ipMalicioso)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+
+        // Verifica se o valor passado para o limitador (e consequentemente para o log) foi sanitizado.
+        // Esperamos que não contenha \n ou \r
+        verify(limitadorTentativasLogin).verificar("10.0.0.1_INFO User logged in as admin");
+    }
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Log Injection (CWE-117)
The `LoginController` was extracting the IP address from the `X-Forwarded-For` header and logging it without sanitization. This allowed attackers to inject fake log entries by including newlines in the header.

🎯 Impact: Attackers could forge log entries to mask their activities or confuse log analysis tools.

🔧 Fix: Modified `extrairIp` in `LoginController.java` to replace newline (`\n`) and carriage return (`\r`) characters with underscores (`_`) before returning the IP.

✅ Verification: Added `LoginControllerLogInjectionTest` which verifies that an IP with newlines is sanitized before being passed to the `LimitadorTentativasLogin` (which logs the IP).

---
*PR created automatically by Jules for task [6888636369541314925](https://jules.google.com/task/6888636369541314925) started by @lgalvao*