### PR TITLE
🎨 Palette: Make unit contact info interactive

### DIFF
--- a/frontend/src/views/UnidadeView.vue
+++ b/frontend/src/views/UnidadeView.vue
@@ -39,8 +39,22 @@
         <BCardBody>
           <p><strong>Titular:</strong> {{ titularDetalhes?.nome }}</p>
           <p class="ms-3">
-            <i aria-hidden="true" class="bi bi-telephone-fill me-2"/>{{ titularDetalhes?.ramal }}
-            <i aria-hidden="true" class="bi bi-envelope-fill ms-3 me-2"/>{{ titularDetalhes?.email }}
+            <i aria-hidden="true" class="bi bi-telephone-fill me-2"/>
+            <a
+                class="text-decoration-none text-body"
+                :href="`tel:${titularDetalhes?.ramal}`"
+                :aria-label="`Ligar para ${titularDetalhes?.ramal}`"
+            >
+              {{ titularDetalhes?.ramal }}
+            </a>
+            <i aria-hidden="true" class="bi bi-envelope-fill ms-3 me-2"/>
+            <a
+                class="text-decoration-none text-body"
+                :href="`mailto:${titularDetalhes?.email}`"
+                :aria-label="`Enviar e-mail para ${titularDetalhes?.email}`"
+            >
+              {{ titularDetalhes?.email }}
+            </a>
           </p>
           <template
               v-if="unidadeComResponsavelDinamico.responsavel &&
@@ -49,8 +63,22 @@
           >
             <p><strong>Responsável:</strong> {{ unidadeComResponsavelDinamico.responsavel.nome }}</p>
             <p class="ms-3">
-              <i aria-hidden="true" class="bi bi-telephone-fill me-2"/>{{ unidadeComResponsavelDinamico.responsavel.ramal }}
-              <i aria-hidden="true" class="bi bi-envelope-fill ms-3 me-2"/>{{ unidadeComResponsavelDinamico.responsavel.email }}
+              <i aria-hidden="true" class="bi bi-telephone-fill me-2"/>
+              <a
+                  class="text-decoration-none text-body"
+                  :href="`tel:${unidadeComResponsavelDinamico.responsavel.ramal}`"
+                  :aria-label="`Ligar para ${unidadeComResponsavelDinamico.responsavel.ramal}`"
+              >
+                {{ unidadeComResponsavelDinamico.responsavel.ramal }}
+              </a>
+              <i aria-hidden="true" class="bi bi-envelope-fill ms-3 me-2"/>
+              <a
+                  class="text-decoration-none text-body"
+                  :href="`mailto:${unidadeComResponsavelDinamico.responsavel.email}`"
+                  :aria-label="`Enviar e-mail para ${unidadeComResponsavelDinamico.responsavel.email}`"
+              >
+                {{ unidadeComResponsavelDinamico.responsavel.email }}
+              </a>
             </p>
           </template>
         </BCardBody>

--- a/frontend/src/views/__tests__/UnidadeView.spec.ts
+++ b/frontend/src/views/__tests__/UnidadeView.spec.ts
@@ -296,4 +296,35 @@ describe('UnidadeView.vue', () => {
 
         expect(logger.error).toHaveBeenCalledWith('Erro ao buscar titular:', expect.any(Error));
     });
+
+    it('renders clickable contact links for titular', async () => {
+        // Setup mock user with contact info
+        const mockUserWithContact = {
+            ...mockUsuario,
+            ramal: '1234',
+            email: 'test@example.com'
+        };
+        (buscarUsuarioPorTitulo as any).mockResolvedValue(mockUserWithContact);
+
+        const { wrapper } = createWrapper({
+            unidades: {
+                unidade: mockUnidade
+            }
+        });
+
+        await wrapper.vm.$nextTick();
+        await flushPromises();
+
+        // Check Ramal Link
+        const ramalLink = wrapper.find('a[href="tel:1234"]');
+        expect(ramalLink.exists()).toBe(true);
+        expect(ramalLink.text()).toBe('1234');
+        expect(ramalLink.attributes('aria-label')).toBe('Ligar para 1234');
+
+        // Check Email Link
+        const emailLink = wrapper.find('a[href="mailto:test@example.com"]');
+        expect(emailLink.exists()).toBe(true);
+        expect(emailLink.text()).toBe('test@example.com');
+        expect(emailLink.attributes('aria-label')).toBe('Enviar e-mail para test@example.com');
+    });
 });


### PR DESCRIPTION
💡 **What**: Converted plain text phone extension and email in `UnidadeView` to interactive `tel:` and `mailto:` links.
🎯 **Why**: Improves usability by allowing users to click to call or email directly, reducing friction.
♿ **Accessibility**: Added descriptive `aria-label` attributes to the links (e.g., "Ligar para 9999", "Enviar e-mail para...") to provide context for screen reader users.

**Changes:**
- Modified `frontend/src/views/UnidadeView.vue` to use `<a>` tags for contact info.
- Updated `frontend/src/views/__tests__/UnidadeView.spec.ts` to include a test case verifying the links.

---
*PR created automatically by Jules for task [10606620267712232909](https://jules.google.com/task/10606620267712232909) started by @lgalvao*