### PR TITLE
⚡ Bolt: Refactor Subprocesso batch operations to avoid N+1 queries

### DIFF
--- a/backend/src/main/java/sgc/processo/service/ProcessoFacade.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoFacade.java
@@ -208,22 +208,26 @@ public class ProcessoFacade {
         List<Long> unidadesHomologarCadastro = new ArrayList<>();
         List<Long> unidadesHomologarValidacao = new ArrayList<>();
 
-        for (Long codUnidade : req.unidadeCodigos()) {
-             SubprocessoDto spDto = subprocessoFacade.obterPorProcessoEUnidade(codProcesso, codUnidade);
-             
-             if (req.acao() == AcaoProcesso.ACEITAR) {
-                 if (isSituacaoCadastro(spDto.getSituacao())) {
-                     unidadesAceitarCadastro.add(codUnidade);
-                 } else {
-                     unidadesAceitarValidacao.add(codUnidade);
-                 }
-             } else if (req.acao() == AcaoProcesso.HOMOLOGAR) {
-                 if (isSituacaoCadastro(spDto.getSituacao())) {
-                     unidadesHomologarCadastro.add(codUnidade);
-                 } else {
-                     unidadesHomologarValidacao.add(codUnidade);
-                 }
-             }
+        if (!req.unidadeCodigos().isEmpty()) {
+            List<SubprocessoDto> subprocessos = subprocessoFacade.listarPorProcessoEUnidades(codProcesso, req.unidadeCodigos());
+
+            for (SubprocessoDto spDto : subprocessos) {
+                Long codUnidade = spDto.getCodUnidade();
+
+                if (req.acao() == AcaoProcesso.ACEITAR) {
+                    if (isSituacaoCadastro(spDto.getSituacao())) {
+                        unidadesAceitarCadastro.add(codUnidade);
+                    } else {
+                        unidadesAceitarValidacao.add(codUnidade);
+                    }
+                } else if (req.acao() == AcaoProcesso.HOMOLOGAR) {
+                    if (isSituacaoCadastro(spDto.getSituacao())) {
+                        unidadesHomologarCadastro.add(codUnidade);
+                    } else {
+                        unidadesHomologarValidacao.add(codUnidade);
+                    }
+                }
+            }
         }
 
         executarAcoesBatch(codProcesso, usuario, unidadesAceitarCadastro, unidadesAceitarValidacao, unidadesHomologarCadastro, unidadesHomologarValidacao);

--- a/backend/src/main/java/sgc/subprocesso/model/SubprocessoRepo.java
+++ b/backend/src/main/java/sgc/subprocesso/model/SubprocessoRepo.java
@@ -45,6 +45,15 @@ public interface SubprocessoRepo extends JpaRepository<Subprocesso, Long> {
             select s from Subprocesso s
               join fetch s.unidade u
             where s.processo.codigo = :codProcesso
+              and s.unidade.codigo in :unidadeCodigos""")
+    List<Subprocesso> findByProcessoCodigoAndUnidadeCodigoInWithUnidade(
+            @Param("codProcesso") Long codProcesso,
+            @Param("unidadeCodigos") List<Long> unidadeCodigos);
+
+    @Query("""
+            select s from Subprocesso s
+              join fetch s.unidade u
+            where s.processo.codigo = :codProcesso
               and s.situacao in :situacoes""")
     List<Subprocesso> findByProcessoCodigoAndSituacaoInWithUnidade(
             @Param("codProcesso") Long codProcesso,

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoFacade.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoFacade.java
@@ -104,6 +104,11 @@ public class SubprocessoFacade {
         return crudService.obterPorProcessoEUnidade(codProcesso, codUnidade);
     }
 
+    @Transactional(readOnly = true)
+    public List<SubprocessoDto> listarPorProcessoEUnidades(Long codProcesso, List<Long> codUnidades) {
+        return crudService.listarPorProcessoEUnidades(codProcesso, codUnidades);
+    }
+
     @Transactional
     public SubprocessoDto criar(CriarSubprocessoRequest request) {
         return crudService.criar(request);
@@ -275,17 +280,19 @@ public class SubprocessoFacade {
 
     @Transactional
     public void aceitarCadastroEmBloco(List<Long> codUnidades, Long codProcesso, Usuario usuario) {
-        for (Long codUnidade : codUnidades) {
-            SubprocessoDto sp = crudService.obterPorProcessoEUnidade(codProcesso, codUnidade);
-            cadastroWorkflowService.aceitarCadastroEmBloco(List.of(sp.getCodigo()), usuario);
+        List<SubprocessoDto> subprocessos = crudService.listarPorProcessoEUnidades(codProcesso, codUnidades);
+        List<Long> ids = subprocessos.stream().map(SubprocessoDto::getCodigo).toList();
+        if (!ids.isEmpty()) {
+            cadastroWorkflowService.aceitarCadastroEmBloco(ids, usuario);
         }
     }
 
     @Transactional
     public void homologarCadastroEmBloco(List<Long> codUnidades, Long codProcesso, Usuario usuario) {
-        for (Long codUnidade : codUnidades) {
-            SubprocessoDto sp = crudService.obterPorProcessoEUnidade(codProcesso, codUnidade);
-            cadastroWorkflowService.homologarCadastroEmBloco(List.of(sp.getCodigo()), usuario);
+        List<SubprocessoDto> subprocessos = crudService.listarPorProcessoEUnidades(codProcesso, codUnidades);
+        List<Long> ids = subprocessos.stream().map(SubprocessoDto::getCodigo).toList();
+        if (!ids.isEmpty()) {
+            cadastroWorkflowService.homologarCadastroEmBloco(ids, usuario);
         }
     }
 
@@ -349,25 +356,28 @@ public class SubprocessoFacade {
     @Transactional
     public void disponibilizarMapaEmBloco(List<Long> codUnidades, Long codProcesso, DisponibilizarMapaRequest request,
             Usuario usuario) {
-        for (Long codUnidade : codUnidades) {
-            SubprocessoDto sp = crudService.obterPorProcessoEUnidade(codProcesso, codUnidade);
-            mapaWorkflowService.disponibilizarMapaEmBloco(List.of(sp.getCodigo()), request, usuario);
+        List<SubprocessoDto> subprocessos = crudService.listarPorProcessoEUnidades(codProcesso, codUnidades);
+        List<Long> ids = subprocessos.stream().map(SubprocessoDto::getCodigo).toList();
+        if (!ids.isEmpty()) {
+            mapaWorkflowService.disponibilizarMapaEmBloco(ids, request, usuario);
         }
     }
 
     @Transactional
     public void aceitarValidacaoEmBloco(List<Long> codUnidades, Long codProcesso, Usuario usuario) {
-        for (Long codUnidade : codUnidades) {
-            SubprocessoDto sp = crudService.obterPorProcessoEUnidade(codProcesso, codUnidade);
-            mapaWorkflowService.aceitarValidacaoEmBloco(List.of(sp.getCodigo()), usuario);
+        List<SubprocessoDto> subprocessos = crudService.listarPorProcessoEUnidades(codProcesso, codUnidades);
+        List<Long> ids = subprocessos.stream().map(SubprocessoDto::getCodigo).toList();
+        if (!ids.isEmpty()) {
+            mapaWorkflowService.aceitarValidacaoEmBloco(ids, usuario);
         }
     }
 
     @Transactional
     public void homologarValidacaoEmBloco(List<Long> codUnidades, Long codProcesso, Usuario usuario) {
-        for (Long codUnidade : codUnidades) {
-            SubprocessoDto sp = crudService.obterPorProcessoEUnidade(codProcesso, codUnidade);
-            mapaWorkflowService.homologarValidacaoEmBloco(List.of(sp.getCodigo()), usuario);
+        List<SubprocessoDto> subprocessos = crudService.listarPorProcessoEUnidades(codProcesso, codUnidades);
+        List<Long> ids = subprocessos.stream().map(SubprocessoDto::getCodigo).toList();
+        if (!ids.isEmpty()) {
+            mapaWorkflowService.homologarValidacaoEmBloco(ids, usuario);
         }
     }
 

--- a/backend/src/main/java/sgc/subprocesso/service/crud/SubprocessoCrudService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/crud/SubprocessoCrudService.java
@@ -158,4 +158,15 @@ public class SubprocessoCrudService {
     public boolean verificarAcessoUnidadeAoProcesso(Long codProcesso, List<Long> codigosUnidadesHierarquia) {
         return subprocessoRepo.existsByProcessoCodigoAndUnidadeCodigoIn(codProcesso, codigosUnidadesHierarquia);
     }
+
+    @Transactional(readOnly = true)
+    public List<SubprocessoDto> listarPorProcessoEUnidades(Long codProcesso, List<Long> codUnidades) {
+        if (codUnidades == null || codUnidades.isEmpty()) {
+            return List.of();
+        }
+        return subprocessoRepo.findByProcessoCodigoAndUnidadeCodigoInWithUnidade(codProcesso, codUnidades)
+                .stream()
+                .map(subprocessoMapper::toDto)
+                .toList();
+    }
 }

--- a/backend/src/test/java/sgc/processo/service/ProcessoFacadeBlocoTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoFacadeBlocoTest.java
@@ -141,7 +141,7 @@ class ProcessoFacadeBlocoTest {
             processoFacade.executarAcaoEmBloco(100L, req);
 
             // Assert - não deve buscar subprocessos
-            verify(subprocessoFacade, never()).obterPorProcessoEUnidade(anyLong(), anyLong());
+            verify(subprocessoFacade, never()).listarPorProcessoEUnidades(anyLong(), anyList());
         }
     }
 
@@ -156,14 +156,15 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp1 = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
             SubprocessoDto sp2 = SubprocessoDto.builder()
+                .codUnidade(2L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 2L)).thenReturn(sp2);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L, 2L))).thenReturn(List.of(sp1, sp2));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L, 2L),
@@ -189,14 +190,15 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp1 = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
             SubprocessoDto sp2 = SubprocessoDto.builder()
+                .codUnidade(2L)
                 .situacao(SituacaoSubprocesso.REVISAO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 2L)).thenReturn(sp2);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L, 2L))).thenReturn(List.of(sp1, sp2));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L, 2L),
@@ -222,22 +224,24 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto spCadastro1 = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
             SubprocessoDto spCadastro2 = SubprocessoDto.builder()
+                .codUnidade(2L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA)
                 .build();
             SubprocessoDto spValidacao1 = SubprocessoDto.builder()
+                .codUnidade(3L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
             SubprocessoDto spValidacao2 = SubprocessoDto.builder()
+                .codUnidade(4L)
                 .situacao(SituacaoSubprocesso.REVISAO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(spCadastro1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 2L)).thenReturn(spCadastro2);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 3L)).thenReturn(spValidacao1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 4L)).thenReturn(spValidacao2);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L, 2L, 3L, 4L)))
+                .thenReturn(List.of(spCadastro1, spCadastro2, spValidacao1, spValidacao2));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L, 2L, 3L, 4L),
@@ -263,10 +267,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -293,14 +298,15 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp1 = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
             SubprocessoDto sp2 = SubprocessoDto.builder()
+                .codUnidade(2L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 2L)).thenReturn(sp2);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L, 2L))).thenReturn(List.of(sp1, sp2));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L, 2L),
@@ -326,14 +332,15 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp1 = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
             SubprocessoDto sp2 = SubprocessoDto.builder()
+                .codUnidade(2L)
                 .situacao(SituacaoSubprocesso.REVISAO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 2L)).thenReturn(sp2);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L, 2L))).thenReturn(List.of(sp1, sp2));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L, 2L),
@@ -359,22 +366,24 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto spCadastro1 = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
             SubprocessoDto spCadastro2 = SubprocessoDto.builder()
+                .codUnidade(2L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA)
                 .build();
             SubprocessoDto spValidacao1 = SubprocessoDto.builder()
+                .codUnidade(3L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
             SubprocessoDto spValidacao2 = SubprocessoDto.builder()
+                .codUnidade(4L)
                 .situacao(SituacaoSubprocesso.REVISAO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(spCadastro1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 2L)).thenReturn(spCadastro2);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 3L)).thenReturn(spValidacao1);
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 4L)).thenReturn(spValidacao2);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L, 2L, 3L, 4L)))
+                .thenReturn(List.of(spCadastro1, spCadastro2, spValidacao1, spValidacao2));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L, 2L, 3L, 4L),
@@ -400,10 +409,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -430,10 +440,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -457,10 +468,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -484,10 +496,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -511,10 +524,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -551,7 +565,7 @@ class ProcessoFacadeBlocoTest {
             processoFacade.executarAcaoEmBloco(100L, req);
 
             // Assert - não deve chamar nenhum método de batch
-            verify(subprocessoFacade, never()).obterPorProcessoEUnidade(anyLong(), anyLong());
+            verify(subprocessoFacade, never()).listarPorProcessoEUnidades(anyLong(), anyList());
             verify(subprocessoFacade, never()).aceitarCadastroEmBloco(anyList(), anyLong(), any());
             verify(subprocessoFacade, never()).aceitarValidacaoEmBloco(anyList(), anyLong(), any());
             verify(subprocessoFacade, never()).homologarCadastroEmBloco(anyList(), anyLong(), any());
@@ -566,10 +580,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -592,10 +607,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -618,10 +634,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),
@@ -644,10 +661,11 @@ class ProcessoFacadeBlocoTest {
             when(usuarioService.obterUsuarioAutenticado()).thenReturn(usuario);
 
             SubprocessoDto sp = SubprocessoDto.builder()
+                .codUnidade(1L)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO)
                 .build();
 
-            when(subprocessoFacade.obterPorProcessoEUnidade(100L, 1L)).thenReturn(sp);
+            when(subprocessoFacade.listarPorProcessoEUnidades(100L, List.of(1L))).thenReturn(List.of(sp));
 
             AcaoEmBlocoRequest req = new AcaoEmBlocoRequest(
                 List.of(1L),

--- a/backend/src/test/java/sgc/subprocesso/service/crud/SubprocessoCrudServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/crud/SubprocessoCrudServiceTest.java
@@ -368,4 +368,25 @@ class SubprocessoCrudServiceTest {
         assertThat(sp.getMapa()).isNotNull();
         assertThat(sp.getMapa().getCodigo()).isEqualTo(5L);
     }
+
+    @Test
+    @DisplayName("Deve listar subprocessos por processo e unidades")
+    void deveListarPorProcessoEUnidades() {
+        Subprocesso sp = new Subprocesso();
+        when(subprocessoRepo.findByProcessoCodigoAndUnidadeCodigoInWithUnidade(1L, List.of(2L)))
+                .thenReturn(List.of(sp));
+        when(subprocessoMapper.toDto(sp)).thenReturn(SubprocessoDto.builder().build());
+
+        List<SubprocessoDto> lista = service.listarPorProcessoEUnidades(1L, List.of(2L));
+        assertThat(lista).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("Deve retornar lista vazia quando unidades nulo ou vazio")
+    void deveRetornarVazioQuandoUnidadesNuloOuVazio() {
+        assertThat(service.listarPorProcessoEUnidades(1L, null)).isEmpty();
+        assertThat(service.listarPorProcessoEUnidades(1L, List.of())).isEmpty();
+
+        verify(subprocessoRepo, never()).findByProcessoCodigoAndUnidadeCodigoInWithUnidade(anyLong(), anyList());
+    }
 }


### PR DESCRIPTION
⚡ Bolt: Refactor Subprocesso batch operations to avoid N+1 queries

💡 What:
- Implemented `findByProcessoCodigoAndUnidadeCodigoInWithUnidade` in `SubprocessoRepo`.
- Implemented `listarPorProcessoEUnidades` in `SubprocessoCrudService` and `SubprocessoFacade`.
- Refactored `ProcessoFacade.processarAcoesAceiteHomologacao` to use batch fetching.
- Refactored `SubprocessoFacade` bulk methods (`aceitarCadastroEmBloco`, etc.) to use batch fetching.

🎯 Why:
- The previous implementation iterated over unit codes and fetched subprocesses one by one, causing N+1 query issues during bulk operations (selecting 50 units would trigger 50+ queries).

📊 Impact:
- Reduces database roundtrips for fetching subprocesses in bulk operations from N to 1.

 microscope Measurement:
- Verified via unit tests ensuring `listarPorProcessoEUnidades` is called once instead of multiple `obterPorProcessoEUnidade` calls.


---
*PR created automatically by Jules for task [12400385602777959998](https://jules.google.com/task/12400385602777959998) started by @lgalvao*