### PR TITLE
Frontend Quality Check and Fixes

### DIFF
--- a/frontend/src/components/processo/ProcessoInfo.vue
+++ b/frontend/src/components/processo/ProcessoInfo.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-const props = withDefaults(
+withDefaults(
   defineProps<{
     tipoLabel?: string;
     situacaoLabel?: string;
@@ -28,6 +28,10 @@ const props = withDefaults(
     showUnidades?: boolean;
   }>(),
   {
+    tipoLabel: '',
+    situacaoLabel: '',
+    dataLimite: '',
+    numUnidades: 0,
     showTipo: true,
     showSituacao: true,
     showDataLimite: true,

--- a/frontend/src/views/CadMapa.vue
+++ b/frontend/src/views/CadMapa.vue
@@ -88,7 +88,6 @@
 
 <script lang="ts" setup>
 import {BButton, BContainer,} from "bootstrap-vue-next";
-import EmptyState from "@/components/EmptyState.vue";
 import PageHeader from "@/components/layout/PageHeader.vue";
 import LoadingButton from "@/components/ui/LoadingButton.vue";
 import ErrorAlert from "@/components/common/ErrorAlert.vue";
@@ -103,7 +102,6 @@ import {useMapasStore} from "@/stores/mapas";
 import {useSubprocessosStore} from "@/stores/subprocessos";
 import {useUnidadesStore} from "@/stores/unidades";
 import type {Atividade, Competencia} from "@/types/tipos";
-import CompetenciaCard from "@/components/CompetenciaCard.vue";
 import ModalConfirmacao from "@/components/ModalConfirmacao.vue";
 
 // Lazy loading de componentes pesados ou modais

--- a/frontend/src/views/__tests__/CadAtividadesCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadAtividadesCoverage.spec.ts
@@ -3,6 +3,7 @@ import {flushPromises, mount} from "@vue/test-utils";
 import CadAtividades from "@/views/CadAtividades.vue";
 import {useSubprocessosStore} from "@/stores/subprocessos";
 import {useAtividadesStore} from "@/stores/atividades";
+import {useAnalisesStore} from "@/stores/analises";
 import {useFeedbackStore} from "@/stores/feedback";
 import * as subprocessoService from "@/services/subprocessoService";
 import {createTestingPinia} from "@pinia/testing";
@@ -106,6 +107,9 @@ describe("CadAtividadesCoverage.spec.ts", () => {
 
         const atividadesStore = useAtividadesStore(pinia) as any;
         atividadesStore.removerConhecimento.mockResolvedValue({});
+
+        const analisesStore = useAnalisesStore(pinia) as any;
+        analisesStore.obterAnalisesPorSubprocesso.mockReturnValue([]);
 
         const feedbackStore = useFeedbackStore(pinia) as any;
 

--- a/frontend/src/views/__tests__/SubprocessoView.spec.ts
+++ b/frontend/src/views/__tests__/SubprocessoView.spec.ts
@@ -140,7 +140,7 @@ describe('SubprocessoView.vue', () => {
         await (processoService.reabrirCadastro as any)(cod, just);
         feedbackStore.show('Cadastro reaberto', 'O cadastro foi reaberto com sucesso', 'success');
         return true;
-      } catch (error) {
+      } catch {
         feedbackStore.show('Erro', 'Não foi possível reabrir o cadastro', 'danger');
         return false;
       }
@@ -150,7 +150,7 @@ describe('SubprocessoView.vue', () => {
         await (processoService.reabrirRevisaoCadastro as any)(cod, just);
         feedbackStore.show('Revisão reaberta', 'A revisão foi reaberta com sucesso', 'success');
         return true;
-      } catch (error) {
+      } catch {
         feedbackStore.show('Erro', 'Não foi possível reabrir a revisão', 'danger');
         return false;
       }
@@ -162,7 +162,7 @@ describe('SubprocessoView.vue', () => {
         await (processoService.enviarLembrete as any)(codProcesso, codUnidade);
         feedbackStore.show('Lembrete enviado', 'O lembrete foi enviado com sucesso', 'success');
         return true;
-      } catch (error) {
+      } catch {
         feedbackStore.show('Erro', 'Não foi possível enviar o lembrete', 'danger');
         return false;
       }


### PR DESCRIPTION
Performed a comprehensive quality check on the frontend as requested. 

Fixed the following issues:
1. `ProcessoInfo.vue`: Removed unused `props` variable and added default values for optional props to satisfy ESLint.
2. `CadMapa.vue`: Cleaned up unused imports (`EmptyState` and `CompetenciaCard`).
3. `SubprocessoView.spec.ts`: Replaced unused catch variables with parameterless catch blocks to satisfy ESLint.
4. `CadAtividadesCoverage.spec.ts`: Mocked `analisesStore.obterAnalisesPorSubprocesso` to return an empty array, resolving a Vue prop type warning for the `historico` prop in `HistoricoAnaliseModal`.

Verified that all frontend unit tests pass without Vue warnings, ESLint passes without warnings, and root typecheck is successful.

---
*PR created automatically by Jules for task [3701728473543068060](https://jules.google.com/task/3701728473543068060) started by @lgalvao*