### PR TITLE
🎨 Palette: Add visual indicators for required fields

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-02-02 - [Explaining Disabled States]
 **Learning:** Disabled form elements (like checkboxes in `UnidadeTreeNode`) can confuse users if the reason for the disabled state isn't clear. Since disabled elements don't trigger mouse events reliably in all browsers/frameworks, standard tooltips might fail.
 **Action:** When an element is disabled due to business logic (e.g., ineligibility), apply `v-b-tooltip` to the label text (not the input) and add `cursor: help` to indicate interactivity. This ensures the user can discover why the option is unavailable.
+
+## 2026-02-03 - [Consistent Required Field Indicators]
+**Learning:** Inconsistent visual indicators for required fields (some use red asterisks, others rely solely on browser validation) create confusion about what is mandatory, especially in configuration forms.
+**Action:** Standardize all required fields to use `<span class="text-danger" aria-hidden="true">*</span>` in the label, even when using native HTML inputs inside Vue components.

--- a/frontend/src/components/configuracoes/AdministradoresSection.vue
+++ b/frontend/src/components/configuracoes/AdministradoresSection.vue
@@ -70,7 +70,7 @@
         @shown="() => inputTituloRef?.focus()"
     >
       <div class="mb-3">
-        <label for="usuarioTitulo" class="form-label">Título</label>
+        <label for="usuarioTitulo" class="form-label">Título <span class="text-danger" aria-hidden="true">*</span></label>
         <input
             id="usuarioTitulo"
             ref="inputTituloRef"

--- a/frontend/src/components/configuracoes/ParametrosSection.vue
+++ b/frontend/src/components/configuracoes/ParametrosSection.vue
@@ -25,7 +25,7 @@
       <form v-else @submit.prevent="salvar">
         <div class="mb-3">
           <label for="diasInativacao" class="form-label">
-            Dias para inativação de processos (DIAS_INATIVACAO_PROCESSO)
+            Dias para inativação de processos (DIAS_INATIVACAO_PROCESSO) <span class="text-danger" aria-hidden="true">*</span>
           </label>
           <input
             id="diasInativacao"
@@ -43,7 +43,7 @@
 
         <div class="mb-3">
           <label for="diasAlertaNovo" class="form-label">
-            Dias para indicação de alerta como novo (DIAS_ALERTA_NOVO)
+            Dias para indicação de alerta como novo (DIAS_ALERTA_NOVO) <span class="text-danger" aria-hidden="true">*</span>
           </label>
           <input
             id="diasAlertaNovo"

--- a/frontend/src/components/configuracoes/__tests__/ParametrosSection.spec.ts
+++ b/frontend/src/components/configuracoes/__tests__/ParametrosSection.spec.ts
@@ -1,0 +1,74 @@
+import {mount} from '@vue/test-utils';
+import {createTestingPinia} from '@pinia/testing';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {axe} from 'vitest-axe';
+import ParametrosSection from '@/components/configuracoes/ParametrosSection.vue';
+import {useConfiguracoesStore} from '@/stores/configuracoes';
+
+describe('ParametrosSection', () => {
+    let wrapper: any;
+    let configuracoesStore: any;
+
+    beforeEach(async () => {
+        const pinia = createTestingPinia({
+            stubActions: false,
+        });
+
+        configuracoesStore = useConfiguracoesStore(pinia);
+        configuracoesStore.parametros = [
+            { codigo: 1, chave: 'DIAS_INATIVACAO_PROCESSO', valor: '30', descricao: 'Desc 1' },
+            { codigo: 2, chave: 'DIAS_ALERTA_NOVO', valor: '5', descricao: 'Desc 2' }
+        ];
+        configuracoesStore.getDiasInativacaoProcesso = vi.fn().mockReturnValue(30);
+        configuracoesStore.getDiasAlertaNovo = vi.fn().mockReturnValue(5);
+        configuracoesStore.carregarConfiguracoes = vi.fn().mockResolvedValue([]);
+
+        // Wrap in main for accessibility landmarks
+        const App = {
+            template: '<main><ParametrosSection /></main>',
+            components: { ParametrosSection }
+        };
+
+        wrapper = mount(App, {
+            global: {
+                plugins: [pinia],
+                stubs: {
+                    LoadingButton: {
+                        template: '<button :disabled="loading" type="submit">{{ text }}<slot /></button>',
+                        props: ['loading', 'variant', 'size', 'icon', 'text']
+                    }
+                }
+            }
+        });
+
+        await wrapper.vm.$nextTick();
+    });
+
+    it('deve renderizar o formulário corretamente', () => {
+        expect(wrapper.find('form').exists()).toBe(true);
+        expect(wrapper.find('#diasInativacao').exists()).toBe(true);
+        expect(wrapper.find('#diasAlertaNovo').exists()).toBe(true);
+    });
+
+    it('deve passar nos testes de acessibilidade', async () => {
+        const results = await axe(wrapper.element);
+        expect(results).toHaveNoViolations();
+    });
+
+    it('deve ter campos obrigatórios', () => {
+        const inputInativacao = wrapper.find('#diasInativacao');
+        const inputAlerta = wrapper.find('#diasAlertaNovo');
+
+        expect(inputInativacao.attributes('required')).toBeDefined();
+        expect(inputAlerta.attributes('required')).toBeDefined();
+    });
+
+    it('deve ter indicador visual de obrigatoriedade', () => {
+        const labels = wrapper.findAll('label');
+        expect(labels.length).toBeGreaterThan(0);
+        for (const label of labels) {
+            expect(label.find('.text-danger').exists()).toBe(true);
+            expect(label.find('.text-danger').text()).toBe('*');
+        }
+    });
+});


### PR DESCRIPTION
Implemented a micro-UX improvement by adding visual indicators (red asterisks) to required fields in the `ConfiguracoesView` components (`ParametrosSection` and `AdministradoresSection`). This ensures consistency with the rest of the application and clarifies mandatory fields for users.

Also added a new test file `ParametrosSection.spec.ts` that includes accessibility checks using `vitest-axe` to prevent future regressions.

---
*PR created automatically by Jules for task [13125767967222272559](https://jules.google.com/task/13125767967222272559) started by @lgalvao*