### PR TITLE
Fix NPE in ValidadorDadosOrgService email validation

### DIFF
--- a/backend/src/main/java/sgc/organizacao/service/ValidadorDadosOrgService.java
+++ b/backend/src/main/java/sgc/organizacao/service/ValidadorDadosOrgService.java
@@ -126,7 +126,7 @@ public class ValidadorDadosOrgService implements ApplicationRunner {
                             .formatted(u.getSigla(), tituloTitular));
                 } else {
                     String email = titular.getEmail();
-                    if (email.isBlank()) {
+                    if (email == null || email.isBlank()) {
                         violacoes.add("Titular %s da unidade %s não possui email cadastrado"
                                 .formatted(titular.getNome(), u.getSigla()));
                     }


### PR DESCRIPTION
Fixed a NullPointerException in `ValidadorDadosOrgService` that occurred when a unit's titular had a null email. The validation logic now correctly handles null values by treating them as invalid (blank), consistent with the error message "Titular ... não possui email cadastrado". This ensures the application startup validation is robust against incomplete data. Verified by running backend unit tests (`./gradlew :backend:unitTest`).

---
*PR created automatically by Jules for task [16041970060781926610](https://jules.google.com/task/16041970060781926610) started by @lgalvao*