### PR TITLE
🎨 Palette: Add tooltip to disabled tree nodes

### DIFF
--- a/frontend/src/components/UnidadeTreeNode.vue
+++ b/frontend/src/components/UnidadeTreeNode.vue
@@ -29,6 +29,7 @@
           @update:model-value="(val) => onToggle(unidade, val as boolean)"
       >
         <span
+            v-b-tooltip.hover="!isHabilitado(unidade) ? 'Esta unidade não está disponível para seleção' : ''"
             :class="{ 'text-muted': !isHabilitado(unidade) }"
             class="unidade-label"
             :style="!isHabilitado(unidade) ? { cursor: 'help' } : {}"


### PR DESCRIPTION
Added a tooltip to disabled nodes in the unit tree (`UnidadeTreeNode.vue`) to explain why they are not selectable. This enhances UX by clarifying disabled states and utilizing the `help` cursor to invite interaction. Validated with existing tests and a custom Playwright verification script.

---
*PR created automatically by Jules for task [3927806798119036086](https://jules.google.com/task/3927806798119036086) started by @lgalvao*