### PR TITLE
🎨 Palette: Improve accessibility of history table

### DIFF
--- a/frontend/src/views/HistoricoView.vue
+++ b/frontend/src/views/HistoricoView.vue
@@ -32,8 +32,11 @@
               v-for="proc in processos"
               v-else
               :key="proc.codigo"
-              style="cursor: pointer;"
+              class="cursor-pointer"
+              tabindex="0"
               @click="verDetalhes(proc.codigo)"
+              @keydown.enter.prevent="verDetalhes(proc.codigo)"
+              @keydown.space.prevent="verDetalhes(proc.codigo)"
             >
               <td>
                 <div class="fw-bold">{{ proc.descricao }}</div>
@@ -94,3 +97,12 @@ onMounted(() => {
   carregarHistorico();
 });
 </script>
+
+<style scoped>
+tbody tr:focus-visible {
+  outline: 2px solid var(--bs-primary);
+  background-color: var(--bs-table-hover-bg);
+  z-index: 1; /* Ensure outline sits on top of adjacent borders */
+  position: relative;
+}
+</style>

--- a/frontend/src/views/__tests__/HistoricoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/HistoricoViewCoverage.spec.ts
@@ -1,0 +1,68 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { describe, it, expect, vi } from "vitest";
+import { createTestingPinia } from "@pinia/testing";
+import HistoricoView from "@/views/HistoricoView.vue";
+import { useProcessosStore } from "@/stores/processos";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { TipoProcesso, SituacaoProcesso } from "@/types/tipos";
+
+describe("HistoricoView Coverage", () => {
+  it("renders correctly and rows are accessible", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: { template: '<div>Home</div>' } },
+        { path: '/processo/:id', component: { template: '<div>Processo</div>' } }
+      ],
+    });
+
+    // We mock push but we need the router to be functional for initial render
+    const pushSpy = vi.spyOn(router, "push");
+
+    const wrapper = mount(HistoricoView, {
+      global: {
+        plugins: [
+          router,
+          createTestingPinia({
+            createSpy: vi.fn,
+            stubActions: true,
+            initialState: {
+              "processos-core": {
+                processosFinalizados: [
+                  {
+                    codigo: 1,
+                    descricao: "Processo Teste",
+                    tipo: TipoProcesso.MAPEAMENTO,
+                    tipoLabel: "Mapeamento",
+                    dataFinalizacaoFormatada: "01/01/2023",
+                    situacao: SituacaoProcesso.FINALIZADO,
+                  },
+                ],
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    await flushPromises();
+
+    const store = useProcessosStore();
+    expect(store.processosFinalizados).toHaveLength(1);
+
+    // Find the row
+    const row = wrapper.find("tbody tr.cursor-pointer");
+    expect(row.exists()).toBe(true);
+    expect(row.text()).toContain("Processo Teste");
+
+    // Check accessibility attributes (expecting failure)
+    expect(row.attributes("tabindex")).toBe("0");
+
+    // Simulate keyboard interaction
+    await row.trigger("keydown.enter");
+    expect(pushSpy).toHaveBeenCalledWith("/processo/1");
+
+    await row.trigger("keydown.space");
+    expect(pushSpy).toHaveBeenCalledWith("/processo/1");
+  });
+});


### PR DESCRIPTION
💡 What: Added keyboard navigation support and visual focus indicators to the clickable table rows in the Process History view.
🎯 Why: Keyboard-only users were unable to access or navigate to process details from the history table because the rows were only clickable via mouse.
📸 Before/After: Added focus outline and tabindex.
♿ Accessibility:
- Added `tabindex="0"` to table rows.
- Added `Enter` and `Space` key handlers.
- Added visible focus outline (`:focus-visible`) for keyboard users.

---
*PR created automatically by Jules for task [7709285592747453189](https://jules.google.com/task/7709285592747453189) started by @lgalvao*