### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/visual-capture/capture.test.ts
+++ b/frontend/src/visual-capture/capture.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from 'vitest';
-import { render } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { page } from '@vitest/browser/context';
 import App from '../App.vue';
 import { createPinia, setActivePinia } from 'pinia';
@@ -10,7 +10,7 @@ describe('Visual Capture', () => {
     setActivePinia(createPinia());
     
     // We mount the component
-    const wrapper = render(App, {
+    mount(App, {
       global: {
         plugins: [router]
       }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -42,7 +42,8 @@
     "spec/**/*.d.ts",
     "vitest.setup.ts",
     "vite.config.ts",
-    "vitest.config.ts"
+    "vitest.config.ts",
+    "vitest.browser.config.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Performed a quality check on the frontend and fixed several errors:
1. Typecheck: Fixed an error in `src/visual-capture/capture.test.ts` where `render` was incorrectly imported from `@vue/test-utils` (should be `mount`).
2. Lint: Resolved an ESLint parsing error for `vitest.browser.config.ts` by adding it to the `include` array in `frontend/tsconfig.json`.
3. Lint: Fixed a warning in `src/visual-capture/capture.test.ts` regarding an unused `wrapper` variable.
All quality checks (typecheck, lint, and unit tests) now pass successfully.

---
*PR created automatically by Jules for task [14416625277284502070](https://jules.google.com/task/14416625277284502070) started by @lgalvao*