### PR TITLE
Fix frontend type errors and lint warnings

### DIFF
--- a/frontend/src/mappers/__tests__/atividades.spec.ts
+++ b/frontend/src/mappers/__tests__/atividades.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { SituacaoSubprocesso } from '@/types/tipos';
 import {
   mapAtividadeToModel,
   mapConhecimentoToModel,
@@ -36,14 +37,14 @@ describe('atividades mappers', () => {
   });
 
   it('mapSubprocessoSituacaoToModel maps correctly', () => {
-    const dto = { codigo: 1, situacao: 'S1', situacaoLabel: 'L1' };
+    const dto = { codigo: 1, situacao: SituacaoSubprocesso.NAO_INICIADO, situacaoLabel: 'L1' };
     expect(mapSubprocessoSituacaoToModel(dto)).toEqual(dto);
   });
 
   it('mapAtividadeOperacaoResponseToModel maps correctly', () => {
     const dto = {
       atividade: { codigo: 1, descricao: 'A1', conhecimentos: [] },
-      subprocesso: { codigo: 1, situacao: 'S1', situacaoLabel: 'L1' },
+      subprocesso: { codigo: 1, situacao: SituacaoSubprocesso.NAO_INICIADO, situacaoLabel: 'L1' },
       atividadesAtualizadas: [{ codigo: 2, descricao: 'A2', conhecimentos: [] }]
     };
     const model = mapAtividadeOperacaoResponseToModel(dto as any);
@@ -55,7 +56,7 @@ describe('atividades mappers', () => {
   it('mapAtividadeOperacaoResponseToModel handles null atividade', () => {
     const dto = {
       atividade: null,
-      subprocesso: { codigo: 1, situacao: 'S1', situacaoLabel: 'L1' },
+      subprocesso: { codigo: 1, situacao: SituacaoSubprocesso.NAO_INICIADO, situacaoLabel: 'L1' },
       atividadesAtualizadas: []
     };
     const model = mapAtividadeOperacaoResponseToModel(dto as any);
@@ -100,7 +101,7 @@ describe('atividades mappers', () => {
   it('mapAtividadeOperacaoResponseToModel filters out null atividadesAtualizadas', () => {
     const dto = {
       atividade: null,
-      subprocesso: { codigo: 1, situacao: 'S1', situacaoLabel: 'L1' },
+      subprocesso: { codigo: 1, situacao: SituacaoSubprocesso.NAO_INICIADO, situacaoLabel: 'L1' },
       atividadesAtualizadas: [null, { codigo: 1, descricao: 'A1', conhecimentos: [] }]
     };
     const model = mapAtividadeOperacaoResponseToModel(dto as any);

--- a/frontend/src/views/Processo.vue
+++ b/frontend/src/views/Processo.vue
@@ -119,7 +119,6 @@ const {
   textoModalBloco,
   rotuloBotaoBloco,
   mensagemSucessoAcaoBloco,
-  unidadesElegiveisPorAcao,
   abrirDetalhesUnidade,
   finalizarProcesso,
   confirmarFinalizacao,

--- a/frontend/src/views/Relatorios.vue
+++ b/frontend/src/views/Relatorios.vue
@@ -56,7 +56,6 @@ const {
   mostrarModalAndamentoGeral,
   processosFiltrados,
   mapasVigentes,
-  diagnosticosGaps,
   diagnosticosGapsFiltrados,
   abrirModalMapasVigentes,
   abrirModalDiagnosticosGaps,

--- a/frontend/src/views/__tests__/CadMapa.spec.ts
+++ b/frontend/src/views/__tests__/CadMapa.spec.ts
@@ -716,7 +716,7 @@ describe("CadMapa.vue", () => {
         (wrapper.vm as any).mostrarModalExcluirCompetencia = true;
         await nextTick();
         // findComponent with the data-testid of the root element in the stub
-        const modal = wrapper.findComponent('[data-testid="mdl-excluir-competencia"]');
+        const modal = wrapper.findComponent('[data-testid="mdl-excluir-competencia"]') as any;
         await modal.vm.$emit('update:modelValue', false);
         expect((wrapper.vm as any).mostrarModalExcluirCompetencia).toBe(false);
     });

--- a/frontend/src/views/__tests__/Relatorios.spec.ts
+++ b/frontend/src/views/__tests__/Relatorios.spec.ts
@@ -41,7 +41,6 @@ describe("Relatorios.vue", () => {
   let wrapper: any;
   let processosStore: any;
   let mapasStore: any;
-  let perfilStore: any;
 
   const createWrapper = (initialState = {}) => {
     return mount(Relatorios, {


### PR DESCRIPTION
This PR fixes several type errors and lint warnings found during a quality check of the frontend.

Changes:
- **`frontend/src/mappers/__tests__/atividades.spec.ts`**: Replaced string literals with `SituacaoSubprocesso` enum values to match the `SubprocessoSituacaoDto` interface.
- **`frontend/src/views/__tests__/CadMapa.spec.ts`**: Added a type cast to `any` for the result of `findComponent` to allow access to the `vm` property, resolving a TypeScript error.
- **`frontend/src/views/Processo.vue`**: Removed unused `unidadesElegiveisPorAcao` destructuring.
- **`frontend/src/views/Relatorios.vue`**: Removed unused `diagnosticosGaps` destructuring.
- **`frontend/src/views/__tests__/Relatorios.spec.ts`**: Removed unused `perfilStore` declaration.

All quality checks (`npm run typecheck`, `npm run lint`, `npm test`) now pass successfully.

---
*PR created automatically by Jules for task [13558298266605442154](https://jules.google.com/task/13558298266605442154) started by @lgalvao*