### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/components/configuracoes/__tests__/AdministradoresSection.spec.ts
+++ b/frontend/src/components/configuracoes/__tests__/AdministradoresSection.spec.ts
@@ -13,8 +13,8 @@ vi.mock("@/services/administradorService", () => ({
 
 describe("AdministradoresSection.vue", () => {
     const mockAdmins = [
-        { nome: "Admin 1", tituloEleitoral: "111", matricula: "M1", unidadeSigla: "U1" },
-        { nome: "Admin 2", tituloEleitoral: "222", matricula: "M2", unidadeSigla: "U2" }
+        { nome: "Admin 1", tituloEleitoral: "111", matricula: "M1", unidadeSigla: "U1", unidadeCodigo: 1 },
+        { nome: "Admin 2", tituloEleitoral: "222", matricula: "M2", unidadeSigla: "U2", unidadeCodigo: 2 }
     ];
 
     beforeEach(() => {


### PR DESCRIPTION
Performed a quality check on the frontend and fixed a typecheck error in the AdministradoresSection unit test.

Key changes:
- Added missing `unidadeCodigo` property to `mockAdmins` in `frontend/src/components/configuracoes/__tests__/AdministradoresSection.spec.ts`.
- Verified that `npm run typecheck`, `npm run lint`, and `npm test` all pass successfully from the root project.

---
*PR created automatically by Jules for task [17781633692168514085](https://jules.google.com/task/17781633692168514085) started by @lgalvao*