### PR TITLE
Frontend quality check and fix

### DIFF
--- a/frontend/src/views/__tests__/HistoricoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/HistoricoViewCoverage.spec.ts
@@ -27,7 +27,7 @@ describe("HistoricoView Coverage", () => {
             createSpy: vi.fn,
             stubActions: true,
             initialState: {
-              "processos-core": {
+              "processos": {
                 processosFinalizados: [
                   {
                     codigo: 1,


### PR DESCRIPTION
Performed a quality check on the frontend, including typechecking, linting, and unit tests.
Found one unit test failure in `HistoricoViewCoverage.spec.ts` due to an outdated store ID ('processos-core' instead of 'processos').
Fixed the store ID in the test file and verified that all quality checks now pass.

---
*PR created automatically by Jules for task [12517831044984356710](https://jules.google.com/task/12517831044984356710) started by @lgalvao*