### PR TITLE
Clean up redundant comments in backend controllers and facades

### DIFF
--- a/backend/src/main/java/sgc/analise/AnaliseController.java
+++ b/backend/src/main/java/sgc/analise/AnaliseController.java
@@ -18,12 +18,6 @@ import sgc.subprocesso.service.SubprocessoFacade;
 
 import java.util.List;
 
-/**
- * Controlador REST para gerenciar as análises de subprocessos.
- *
- * <p>Fornece endpoints para criar e listar análises relacionadas às fases de cadastro e validação
- * de um subprocesso.
- */
 @RestController
 @RequestMapping("/api/subprocessos/{codSubprocesso}")
 @RequiredArgsConstructor
@@ -32,12 +26,6 @@ public class AnaliseController {
     private final AnaliseFacade analiseFacade;
     private final SubprocessoFacade subprocessoFacade;
 
-    /**
-     * Recupera o histórico de análises associadas à fase de cadastro de um subprocesso.
-     *
-     * @param codigo O código do subprocesso.
-     * @return Uma lista de {@link AnaliseHistoricoDto} contendo o histórico de análises de cadastro.
-     */
     @GetMapping("/analises-cadastro")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Lista o histórico de análises de cadastro")
@@ -46,17 +34,6 @@ public class AnaliseController {
         return analiseFacade.listarHistoricoCadastro(codigo);
     }
 
-    /**
-     * Registra uma nova análise para a fase de cadastro de um subprocesso.
-     *
-     * <p>Este endpoint recebe os dados da análise a partir de um corpo estruturado. A análise é
-     * associada ao subprocesso identificado pelo código na URL.
-     *
-     * @param codSubprocesso O código do subprocesso ao qual a análise pertence.
-     * @param request        O DTO contendo os dados da análise. Campos esperados incluem 'observacoes',
-     *                       'siglaUnidade', 'tituloUsuario' e 'motivo'.
-     * @return O DTO {@link AnaliseHistoricoDto} recém-criado.
-     */
     @PostMapping("/analises-cadastro")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
     @ResponseStatus(HttpStatus.CREATED)
@@ -67,12 +44,6 @@ public class AnaliseController {
         return criarAnalise(codSubprocesso, request, TipoAnalise.CADASTRO);
     }
 
-    /**
-     * Recupera o histórico de análises associadas à fase de validação de um subprocesso.
-     *
-     * @param codSubprocesso O código do subprocesso.
-     * @return Uma lista de {@link AnaliseHistoricoDto} contendo o histórico de análises de validação.
-     */
     @GetMapping("/analises-validacao")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Lista o histórico de análises de validação")
@@ -83,17 +54,6 @@ public class AnaliseController {
                 .toList();
     }
 
-    /**
-     * Registra uma nova análise para a fase de validação de um subprocesso.
-     *
-     * <p>Assim como na análise de cadastro, este endpoint recebe os dados da análise a partir de um
-     * corpo estruturado e a associa ao subprocesso correspondente.
-     *
-     * @param codSubprocesso O código do subprocesso ao qual a análise pertence.
-     * @param request        O DTO contendo os dados da análise. Campos esperados incluem 'observacoes',
-     *                       'siglaUnidade', 'tituloUsuario' e 'motivo'.
-     * @return O DTO {@link AnaliseHistoricoDto} recém-criado.
-     */
     @PostMapping("/analises-validacao")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
     @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/sgc/organizacao/UnidadeController.java
+++ b/backend/src/main/java/sgc/organizacao/UnidadeController.java
@@ -25,9 +25,6 @@ import java.util.Set;
 import static sgc.processo.model.TipoProcesso.DIAGNOSTICO;
 import static sgc.processo.model.TipoProcesso.REVISAO;
 
-/**
- * Controle para operações relacionadas a unidades organizacionais
- */
 @RestController
 @RequestMapping("/api/unidades")
 @RequiredArgsConstructor
@@ -36,13 +33,6 @@ public class UnidadeController {
     private final UnidadeFacade unidadeService;
     private final ProcessoFacade processoFacade;
 
-    /**
-     * Cria uma nova atribuição temporária para um usuário em uma unidade.
-     *
-     * @param codUnidade O Código da unidade.
-     * @param request    Os dados da atribuição.
-     * @return Resposta vazia com status 201 (Created).
-     */
     @PostMapping("/{codUnidade}/atribuicoes-temporarias")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> criarAtribuicaoTemporaria(
@@ -52,21 +42,12 @@ public class UnidadeController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    /**
-     * Busca todas as atribuições temporárias.
-     *
-     * @return Lista de atribuições temporárias.
-     */
     @GetMapping("/atribuicoes")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<AtribuicaoTemporariaDto>> buscarTodasAtribuicoes() {
         return ResponseEntity.ok(unidadeService.buscarTodasAtribuicoes());
     }
 
-    /**
-     * Busca todas as unidades em estrutura hierárquica Endpoint usado pela tela de cadastro de
-     * processo para selecionar unidades participantes
-     */
     @GetMapping
     @JsonView(OrganizacaoViews.Publica.class)
     public ResponseEntity<List<UnidadeDto>> buscarTodasUnidades() {
@@ -74,14 +55,6 @@ public class UnidadeController {
         return ResponseEntity.ok(hierarquia);
     }
 
-    /**
-     * Busca a árvore de unidades indicando a elegibilidade de cada uma para participar de um
-     * processo.
-     *
-     * @param tipoProcesso O tipo de processo a ser criado.
-     * @param codProcesso  O código do processo (opcional, para edição).
-     * @return A lista de unidades raiz com a árvore de filhas e a elegibilidade.
-     */
     @GetMapping("/arvore-com-elegibilidade")
     @JsonView(OrganizacaoViews.Publica.class)
     public ResponseEntity<List<UnidadeDto>> buscarArvoreComElegibilidade(
@@ -97,25 +70,12 @@ public class UnidadeController {
         return ResponseEntity.ok(arvore);
     }
 
-    /**
-     * Verifica se a unidade possui mapa de competências vigente Usado pelo frontend para determinar
-     * se deve exibir opções de revisão
-     *
-     * @param codUnidade O código da unidade
-     * @return Um objeto com o campo temMapaVigente (boolean)
-     */
     @GetMapping("/{codUnidade}/mapa-vigente")
     public ResponseEntity<Map<String, Boolean>> verificarMapaVigente(@PathVariable Long codUnidade) {
         boolean temMapaVigente = unidadeService.verificarMapaVigente(codUnidade);
         return ResponseEntity.ok(Map.of("temMapaVigente", temMapaVigente));
     }
 
-    /**
-     * Busca usuários de uma unidade específica.
-     *
-     * @param codUnidade O código da unidade
-     * @return Lista de usuários da unidade
-     */
     @GetMapping("/{codUnidade}/usuarios")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR', 'CHEFE')")
     @JsonView(OrganizacaoViews.Publica.class)
@@ -124,12 +84,6 @@ public class UnidadeController {
         return ResponseEntity.ok(usuarios);
     }
 
-    /**
-     * Busca uma unidade específica pela sua sigla.
-     *
-     * @param siglaUnidade A sigla da unidade.
-     * @return Os dados da unidade.
-     */
     @GetMapping("/sigla/{siglaUnidade}")
     @JsonView(OrganizacaoViews.Publica.class)
     public ResponseEntity<UnidadeDto> buscarUnidadePorSigla(
@@ -138,12 +92,6 @@ public class UnidadeController {
         return ResponseEntity.ok(unidade);
     }
 
-    /**
-     * Busca uma unidade específica pelo seu código.
-     *
-     * @param codigo O código da unidade.
-     * @return Os dados da unidade.
-     */
     @GetMapping("/{codigo}")
     @JsonView(OrganizacaoViews.Publica.class)
     public ResponseEntity<UnidadeDto> buscarUnidadePorCodigo(@PathVariable Long codigo) {
@@ -151,24 +99,12 @@ public class UnidadeController {
         return ResponseEntity.ok(unidade);
     }
 
-    /**
-     * Busca a árvore de uma unidade específica (incluindo subunidades).
-     *
-     * @param codigo O código da unidade.
-     * @return A unidade com sua árvore de subunidades.
-     */
     @GetMapping("/{codigo}/arvore")
     @JsonView(OrganizacaoViews.Publica.class)
     public ResponseEntity<UnidadeDto> buscarArvoreUnidade(@PathVariable Long codigo) {
         return ResponseEntity.ok(unidadeService.buscarArvore(codigo));
     }
 
-    /**
-     * Busca as siglas de todas as unidades subordinadas (diretas e indiretas) e a própria unidade.
-     *
-     * @param sigla A sigla da unidade raiz.
-     * @return Lista de siglas.
-     */
     @GetMapping("/sigla/{sigla}/subordinadas")
     public ResponseEntity<List<String>> buscarSiglasSubordinadas(
             @PathVariable @Pattern(regexp = "^[a-zA-Z0-9_.-]+$") String sigla) {
@@ -176,12 +112,6 @@ public class UnidadeController {
         return ResponseEntity.ok(siglas);
     }
 
-    /**
-     * Busca a sigla da unidade superior imediata.
-     *
-     * @param sigla A sigla da unidade.
-     * @return A sigla da unidade superior ou 204 se não houver.
-     */
     @GetMapping("/sigla/{sigla}/superior")
     public ResponseEntity<String> buscarSiglaSuperior(@PathVariable @Pattern(regexp = "^[a-zA-Z0-9_.-]+$") String sigla) {
         return unidadeService

--- a/backend/src/main/java/sgc/processo/ProcessoController.java
+++ b/backend/src/main/java/sgc/processo/ProcessoController.java
@@ -42,14 +42,6 @@ public class ProcessoController {
                 TipoProcesso.DIAGNOSTICO, processoFacade::iniciarProcessoDiagnostico);
     }
 
-    /**
-     * Cria um novo processo.
-     *
-     * @param requisicao O DTO com os dados para a criação do processo.
-     * @return Um {@link ResponseEntity} com status 201 Created, o URI do novo
-     *         processo e o {@link
-     *         Processo} criado no corpo da resposta.
-     */
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     @JsonView(ProcessoViews.Publica.class)
@@ -59,14 +51,6 @@ public class ProcessoController {
         return ResponseEntity.created(uri).body(criado);
     }
 
-    /**
-     * Retorna códigos de unidades que já participam de processos ativos do tipo
-     * especificado ou de um processo específico.
-     *
-     * @param tipo        Tipo do processo (MAPEAMENTO, REVISAO, DIAGNOSTICO)
-     * @param codProcesso Código opcional do processo a ser considerado
-     * @return Objeto contendo lista de unidades desabilitadas
-     */
     @GetMapping("/status-unidades")
     @Operation(summary = "Retorna unidades desabilitadas por tipo e processo")
     public ResponseEntity<Map<String, List<Long>>> obterStatusUnidades(
@@ -75,13 +59,6 @@ public class ProcessoController {
         return ResponseEntity.ok(Map.of("unidadesDesabilitadas", unidadesDesabilitadas));
     }
 
-    /**
-     * Busca e retorna um processo pelo seu código.
-     *
-     * @param codigo O código do processo a ser buscado.
-     * @return Um {@link ResponseEntity} contendo o {@link ProcessoDto} ou status
-     *         404 Not Found.
-     */
     @GetMapping("/{codigo}")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR', 'CHEFE')")
     @JsonView(ProcessoViews.Publica.class)
@@ -92,14 +69,6 @@ public class ProcessoController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    /**
-     * Atualiza um processo existente.
-     *
-     * @param codigo     O código do processo a ser atualizado.
-     * @param requisicao O DTO com os novos dados do processo.
-     * @return Um {@link ResponseEntity} com status 200 OK e o {@link ProcessoDto}
-     *         atualizado.
-     */
     @PostMapping("/{codigo}/atualizar")
     @PreAuthorize("hasRole('ADMIN')")
     @JsonView(ProcessoViews.Publica.class)
@@ -109,12 +78,6 @@ public class ProcessoController {
         return ResponseEntity.ok(atualizado);
     }
 
-    /**
-     * Exclui um processo.
-     *
-     * @param codigo O código do processo a ser excluído.
-     * @return Um {@link ResponseEntity} com status 204 No Content.
-     */
     @PostMapping("/{codigo}/excluir")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> excluir(@PathVariable Long codigo) {
@@ -122,12 +85,6 @@ public class ProcessoController {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Lista todos os processos que estão com a situação 'FINALIZADO'.
-     *
-     * @return Um {@link ResponseEntity} com a lista de {@link ProcessoDto}
-     *         finalizados.
-     */
     @GetMapping("/finalizados")
     @Operation(summary = "Lista todos os processos com situação FINALIZADO")
     @JsonView(ProcessoViews.Publica.class)
@@ -135,11 +92,6 @@ public class ProcessoController {
         return ResponseEntity.ok(processoFacade.listarFinalizados());
     }
 
-    /**
-     * Lista todos os processos que estão com a situação 'EM_ANDAMENTO'.
-     *
-     * @return Um {@link ResponseEntity} com a lista de {@link ProcessoDto} ativos.
-     */
     @GetMapping("/ativos")
     @Operation(summary = "Lista todos os processos com situação EM_ANDAMENTO")
     @JsonView(ProcessoViews.Publica.class)
@@ -147,15 +99,6 @@ public class ProcessoController {
         return ResponseEntity.ok(processoFacade.listarAtivos());
     }
 
-    /**
-     * Retorna os detalhes completos de um processo, incluindo as unidades
-     * participantes e o resumo
-     * de seus respectivos subprocessos.
-     *
-     * @param codigo O código do processo a ser detalhado.
-     * @param usuario Usuário autenticado (injetado automaticamente).
-     * @return Um {@link ResponseEntity} com o {@link ProcessoDetalheDto}.
-     */
     @GetMapping("/{codigo}/detalhes")
     @PreAuthorize("hasRole('ADMIN') or @processoFacade.checarAcesso(authentication, #codigo)")
     public ResponseEntity<ProcessoDetalheDto> obterDetalhes(
@@ -174,12 +117,6 @@ public class ProcessoController {
         return ResponseEntity.ok(processoFacade.obterContextoCompleto(codigo, usuario));
     }
 
-    /**
-     * Inicia um processo, disparando a criação dos subprocessos e notificações.
-     *
-     * @param codigo O código do processo a ser iniciado.
-     * @return Um {@link ResponseEntity} com status 200 OK.
-     */
     @PostMapping("/{codigo}/iniciar")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Inicia um processo")
@@ -198,14 +135,6 @@ public class ProcessoController {
         return ResponseEntity.ok(processoAtualizado);
     }
 
-    /**
-     * Finaliza um processo, tornando os mapas de seus subprocessos homologados como
-     * os novos mapas
-     * vigentes para as respectivas unidades.
-     *
-     * @param codigo O código do processo a ser finalizado.
-     * @return Um {@link ResponseEntity} com status 200 OK.
-     */
     @PostMapping("/{codigo}/finalizar")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Finaliza um processo (CDU-21)")
@@ -214,14 +143,6 @@ public class ProcessoController {
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * Retorna códigos de unidades que já participam de processos ativos do tipo
-     * especificado. Útil
-     * para desabilitar checkboxes no frontend durante criação/edição de processos.
-     *
-     * @param tipo Tipo do processo (MAPEAMENTO, REVISAO, DIAGNOSTICO)
-     * @return Lista de códigos de unidades bloqueadas
-     */
     @GetMapping("/unidades-bloqueadas")
     @Operation(summary = "Lista unidades que já participam de processos ativos por tipo")
     public ResponseEntity<List<Long>> listarUnidadesBloqueadas(@RequestParam String tipo) {
@@ -229,14 +150,6 @@ public class ProcessoController {
         return ResponseEntity.ok(unidadesBloqueadas);
     }
 
-    /**
-     * Retorna uma lista de subprocessos elegíveis para ações em bloco
-     * (aceite/homologação) para o
-     * usuário autenticado.
-     *
-     * @param codigo O código do processo.
-     * @return Lista de DTOs representando os subprocessos elegíveis.
-     */
     @GetMapping("/{codigo}/subprocessos-elegiveis")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
     @Operation(summary = "Lista subprocessos elegíveis para ações em bloco")
@@ -246,14 +159,6 @@ public class ProcessoController {
         return ResponseEntity.ok(elegiveis);
     }
 
-    /**
-     * Retorna todos os subprocessos de um processo. Utilizado pelo frontend para
-     * exibir a árvore de
-     * unidades e seus subprocessos.
-     *
-     * @param codigo O código do processo.
-     * @return Lista de subprocessos do processo.
-     */
     @GetMapping("/{codigo}/subprocessos")
     @Operation(summary = "Lista todos os subprocessos de um processo")
     @JsonView(SubprocessoViews.Publica.class)
@@ -262,9 +167,6 @@ public class ProcessoController {
         return ResponseEntity.ok(subprocessos);
     }
 
-    /**
-     * Envia um lembrete de prazo para uma unidade.
-     */
     @PostMapping("/{codigo}/enviar-lembrete")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Envia lembrete de prazo para unidade")
@@ -273,14 +175,6 @@ public class ProcessoController {
             @RequestBody @Valid EnviarLembreteRequest request) {
         processoFacade.enviarLembrete(codigo, request.unidadeCodigo());
     }
-    /**
-     * Executa uma ação em bloco (aceitar, homologar, disponibilizar) para múltiplas unidades
-     * de um processo.
-     *
-     * @param codigo O código do processo.
-     * @param request O DTO com a lista de unidades e a ação.
-     * @return Um {@link ResponseEntity} com status 200 OK.
-     */
     @PostMapping("/{codigo}/acao-em-bloco")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR', 'CHEFE')")
     @Operation(summary = "Executa ação em bloco para um processo")

--- a/backend/src/main/java/sgc/processo/service/ProcessoFacade.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoFacade.java
@@ -31,9 +31,6 @@ import java.util.Set;
 import static sgc.processo.model.AcaoProcesso.*;
 import static sgc.subprocesso.model.SituacaoSubprocesso.*;
 
-/**
- * Orquestra operações de Processo.
- */
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -51,9 +48,6 @@ public class ProcessoFacade {
     private final ProcessoFinalizador processoFinalizador;
     private final NotificacaoModelosService notificacaoModelosService;
 
-    /**
-     * Busca um processo por ID ou lança exceção se não encontrado.
-     */
     private Processo buscarPorId(Long id) {
         return processoConsultaService.buscarProcessoCodigo(id);
     }

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoCadastroController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoCadastroController.java
@@ -40,28 +40,12 @@ public class SubprocessoCadastroController {
     private final AnaliseFacade analiseFacade;
     private final OrganizacaoFacade organizacaoFacade;
 
-    /**
-     * Obtém o histórico de análises da fase de cadastro de um subprocesso.
-     *
-     * @param codigo O código do subprocesso.
-     * @return Uma {@link List} de {@link AnaliseHistoricoDto} com o histórico.
-     */
     @GetMapping("/{codigo}/historico-cadastro")
     @PreAuthorize("isAuthenticated()")
     public List<AnaliseHistoricoDto> obterHistoricoCadastro(@PathVariable Long codigo) {
         return analiseFacade.listarHistoricoCadastro(codigo);
     }
 
-    /**
-     * Disponibiliza o cadastro de atividades de um subprocesso para a próxima etapa
-     * de análise.
-     *
-     * <p>
-     * Ação restrita a usuários com perfil 'CHEFE' (CDU-08).
-     *
-     * @param codSubprocesso O código do subprocesso.
-     * @return Um {@link ResponseEntity} com uma mensagem de sucesso.
-     */
     @PostMapping("/{codigo}/cadastro/disponibilizar")
     @PreAuthorize("hasRole('CHEFE')")
     @Operation(summary = "Disponibiliza o cadastro de atividades para análise")
@@ -88,22 +72,6 @@ public class SubprocessoCadastroController {
         return ResponseEntity.ok(new MensagemResponse("Cadastro de atividades disponibilizado"));
     }
 
-    /**
-     * Disponibiliza a revisão do cadastro de atividades para a próxima etapa de
-     * análise.
-     *
-     * <p>
-     * Ação restrita a usuários com perfil 'CHEFE' (CDU-12).
-     *
-     * <p>
-     * Antes de disponibilizar, o método valida se todas as atividades do
-     * subprocesso possuem
-     * pelo menos um conhecimento associado.
-     *
-     * @param codigo O código do subprocesso.
-     * @return Um {@link ResponseEntity} com uma mensagem de sucesso.
-     * @throws ErroValidacao se existirem atividades sem conhecimentos.
-     */
     @PostMapping("/{codigo}/disponibilizar-revisao")
     @PreAuthorize("hasRole('CHEFE')")
     @Operation(summary = "Disponibiliza a revisão do cadastro de atividades para análise")
@@ -126,12 +94,6 @@ public class SubprocessoCadastroController {
         return ResponseEntity.ok(new MensagemResponse("Revisão do cadastro de atividades disponibilizada"));
     }
 
-    /**
-     * Obtém os dados de cadastro de um subprocesso.
-     *
-     * @param codigo O código do subprocesso.
-     * @return O {@link Subprocesso} com os dados do cadastro.
-     */
     @JsonView(MapaViews.Publica.class)
     @GetMapping("/{codigo}/cadastro")
     @PreAuthorize("isAuthenticated()")
@@ -139,17 +101,6 @@ public class SubprocessoCadastroController {
         return subprocessoFacade.buscarSubprocesso(codigo);
     }
 
-    /**
-     * Devolve o cadastro de um subprocesso para o responsável pela unidade para que
-     * sejam feitos
-     * ajustes.
-     *
-     * <p>
-     * Ação restrita a usuários com perfil 'ADMIN' ou 'GESTOR' (CDU-13).
-     *
-     * @param codigo  O código do subprocesso.
-     * @param request O DTO contendo o motivo e as observações da devolução.
-     */
     @PostMapping("/{codigo}/devolver-cadastro")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
     @Operation(summary = "Devolve o cadastro de atividades para o responsável")
@@ -165,16 +116,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.devolverCadastro(codigo, sanitizedObservacoes, usuario);
     }
 
-    /**
-     * Aceita o cadastro de um subprocesso, movendo-o para a próxima etapa do fluxo
-     * de trabalho.
-     *
-     * <p>
-     * Ação restrita a usuários com perfil 'ADMIN' ou 'GESTOR' (CDU-13).
-     *
-     * @param codigo  O código do subprocesso.
-     * @param request O DTO contendo as observações da aceitação.
-     */
     @PostMapping("/{codigo}/aceitar-cadastro")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
     @Operation(summary = "Aceita o cadastro de atividades")
@@ -189,15 +130,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.aceitarCadastro(codigo, sanitizedObservacoes, usuario);
     }
 
-    /**
-     * Homologa o cadastro de um subprocesso.
-     *
-     * <p>
-     * Ação restrita a usuários com perfil 'ADMIN' (CDU-13).
-     *
-     * @param codigo  O código do subprocesso.
-     * @param request O DTO contendo as observações da homologação.
-     */
     @PostMapping("/{codigo}/homologar-cadastro")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Homologa o cadastro de atividades")
@@ -212,14 +144,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.homologarCadastro(codigo, sanitizedObservacoes, usuario);
     }
 
-    /**
-     * Devolve a revisão de um cadastro de subprocesso para o responsável pela
-     * unidade para que
-     * sejam feitos ajustes.
-     *
-     * @param codigo  O código do subprocesso.
-     * @param request O DTO contendo o motivo e as observações da devolução.
-     */
     @PostMapping("/{codigo}/devolver-revisao-cadastro")
     @Operation(summary = "Devolve a revisão do cadastro de atividades para o responsável")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
@@ -234,12 +158,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.devolverRevisaoCadastro(codigo, sanitizedObservacoes, usuario);
     }
 
-    /**
-     * Aceita a revisão do cadastro de um subprocesso.
-     *
-     * @param codigo  O código do subprocesso.
-     * @param request O DTO contendo as observações da aceitação.
-     */
     @PostMapping("/{codigo}/aceitar-revisao-cadastro")
     @Operation(summary = "Aceita a revisão do cadastro de atividades")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
@@ -254,15 +172,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.aceitarRevisaoCadastro(codigo, sanitizedObservacoes, usuario);
     }
 
-    /**
-     * Homologa a revisão do cadastro de um subprocesso.
-     *
-     * <p>
-     * Esta ação é restrita a usuários com o perfil 'ADMIN'.
-     *
-     * @param codigo  O código do subprocesso.
-     * @param request O DTO contendo as observações da homologação.
-     */
     @PostMapping("/{codigo}/homologar-revisao-cadastro")
     @Operation(summary = "Homologa a revisão do cadastro de atividades")
     @PreAuthorize("hasRole('ADMIN')")
@@ -277,16 +186,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.homologarRevisaoCadastro(codigo, sanitizedObservacoes, usuario);
     }
 
-    /**
-     * Importa atividades de um subprocesso de origem para o subprocesso de destino.
-     *
-     * <p>
-     * Ação restrita a usuários com perfil 'CHEFE'.
-     *
-     * @param codigo  O código do subprocesso de destino.
-     * @param request O DTO contendo o código do subprocesso de origem.
-     * @return Um {@link Map} com uma mensagem de sucesso.
-     */
     @PostMapping("/{codigo}/importar-atividades")
     @PreAuthorize("hasRole('CHEFE')")
     @Transactional
@@ -297,10 +196,6 @@ public class SubprocessoCadastroController {
         return Map.of("message", "Atividades importadas.");
     }
 
-    /**
-     * Aceita o cadastro de atividades de múltiplas unidades em bloco.
-     * (CDU-22)
-     */
     @PostMapping("/{codigo}/aceitar-cadastro-bloco")
     @PreAuthorize("hasAnyRole('GESTOR', 'ADMIN')")
     @Operation(summary = "Aceita cadastros em bloco")
@@ -311,10 +206,6 @@ public class SubprocessoCadastroController {
         subprocessoFacade.aceitarCadastroEmBloco(request.subprocessos(), codigo, usuario);
     }
 
-    /**
-     * Homologa o cadastro de atividades de múltiplas unidades em bloco.
-     * (CDU-23)
-     */
     @PostMapping("/{codigo}/homologar-cadastro-bloco")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Homologa cadastros em bloco")

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoCrudController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoCrudController.java
@@ -28,12 +28,6 @@ public class SubprocessoCrudController {
     private final SubprocessoFacade subprocessoFacade;
     private final OrganizacaoFacade organizacaoFacade;
 
-    /**
-     * Obtém as permissões do usuário para um subprocesso.
-     *
-     * @param codigo O código do subprocesso.
-     * @return DTO com as permissões calculadas.
-     */
     @GetMapping("/{codigo}/permissoes")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<SubprocessoPermissoesDto> obterPermissoes(@PathVariable Long codigo) {
@@ -55,11 +49,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.ok(subprocessoFacade.obterSituacao(codigo));
     }
 
-    /**
-     * Lista todos os subprocessos.
-     *
-     * @return Uma {@link List} de {@link Subprocesso}.
-     */
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
     @JsonView(SubprocessoViews.Publica.class)
@@ -67,12 +56,6 @@ public class SubprocessoCrudController {
         return subprocessoFacade.listar();
     }
 
-    /**
-     * Obtém os detalhes de um subprocesso específico.
-     *
-     * @param codigo O código do subprocesso.
-     * @return Os detalhes do subprocesso.
-     */
     @GetMapping("/{codigo}")
     @PreAuthorize("isAuthenticated()")
     @JsonView(SubprocessoViews.Publica.class)
@@ -80,13 +63,6 @@ public class SubprocessoCrudController {
         return subprocessoFacade.obterDetalhes(codigo);
     }
 
-    /**
-     * Busca um subprocesso por código do processo e sigla da unidade.
-     *
-     * @param codProcesso  O código do processo.
-     * @param siglaUnidade A sigla da unidade.
-     * @return O {@link Subprocesso} encontrado.
-     */
     @GetMapping("/buscar")
     @PreAuthorize("isAuthenticated()")
     @JsonView(SubprocessoViews.Publica.class)
@@ -97,14 +73,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.ok(sp);
     }
 
-    /**
-     * Cria um novo subprocesso.
-     *
-     * @param request O DTO com os dados do subprocesso a ser criado.
-     * @return Um {@link ResponseEntity} com status 201 Created, o URI do novo
-     *         subprocesso e o
-     *         {@link Subprocesso} criado no corpo da resposta.
-     */
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     @JsonView(SubprocessoViews.Publica.class)
@@ -114,14 +82,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.created(uri).body(salvo);
     }
 
-    /**
-     * Atualiza um subprocesso existente.
-     *
-     * @param codigo  O código do subprocesso a ser atualizado.
-     * @param request O DTO com os novos dados do subprocesso.
-     * @return Um {@link ResponseEntity} com status 200 OK e o
-     *         {@link Subprocesso} atualizado.
-     */
     @PostMapping("/{codigo}/atualizar")
     @PreAuthorize("hasRole('ADMIN')")
     @JsonView(SubprocessoViews.Publica.class)
@@ -131,12 +91,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.ok(atualizado);
     }
 
-    /**
-     * Exclui um subprocesso.
-     *
-     * @param codigo O código do subprocesso a ser excluído.
-     * @return Um {@link ResponseEntity} com status 204 No Content.
-     */
     @PostMapping("/{codigo}/excluir")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> excluir(@PathVariable Long codigo) {
@@ -144,9 +98,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * Altera a data limite de um subprocesso.
-     */
     @PostMapping("/{codigo}/data-limite")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> alterarDataLimite(
@@ -156,9 +107,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * Reabre o cadastro de um subprocesso.
-     */
     @PostMapping("/{codigo}/reabrir-cadastro")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Reabre o cadastro de um subprocesso")
@@ -169,9 +117,6 @@ public class SubprocessoCrudController {
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * Reabre a revisão de cadastro de um subprocesso.
-     */
     @PostMapping("/{codigo}/reabrir-revisao-cadastro")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Reabre a revisão de cadastro de um subprocesso")

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoMapaController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoMapaController.java
@@ -40,9 +40,6 @@ public class SubprocessoMapaController {
     private final MapaFacade mapaFacade;
     private final AnaliseFacade analiseFacade;
 
-    /**
-     * Verifica os impactos que a disponibilização do mapa atual causará.
-     */
     @GetMapping("/{codigo}/impactos-mapa")
     @PreAuthorize("isAuthenticated()")
     @JsonView(MapaViews.Publica.class)
@@ -51,9 +48,6 @@ public class SubprocessoMapaController {
         return mapaFacade.verificarImpactos(subprocesso, usuario);
     }
 
-    /**
-     * Obtém o mapa associado ao subprocesso.
-     */
     @GetMapping("/{codigo}/mapa")
     @PreAuthorize("isAuthenticated()")
     @JsonView(MapaViews.Publica.class)
@@ -62,9 +56,6 @@ public class SubprocessoMapaController {
         return sp.getMapa();
     }
 
-    /**
-     * Disponibiliza o mapa para validação.
-     */
     @PostMapping("/{codigo}/disponibilizar-mapa")
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Disponibiliza o mapa para validação")
@@ -85,9 +76,6 @@ public class SubprocessoMapaController {
         return mapaFacade.obterMapaParaVisualizacao(subprocesso);
     }
 
-    /**
-     * Salva as alterações feitas no mapa de competências.
-     */
     @PostMapping("/{codigo}/mapa")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Salva as alterações do mapa")
@@ -98,9 +86,6 @@ public class SubprocessoMapaController {
         return subprocessoFacade.salvarMapaSubprocesso(codigo, request);
     }
 
-    /**
-     * Obtém o mapa completo associado ao subprocesso para visualização ou edição.
-     */
     @GetMapping("/{codigo}/mapa-completo")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Obtém o mapa completo para edição/visualização")
@@ -111,9 +96,6 @@ public class SubprocessoMapaController {
         return ResponseEntity.ok(mapa);
     }
 
-    /**
-     * Salva o mapa completo em uma única operação.
-     */
     @PostMapping("/{codigo}/mapa-completo")
     @PreAuthorize("isAuthenticated()")
     @Operation(summary = "Salva o mapa completo (batch)")
@@ -126,9 +108,6 @@ public class SubprocessoMapaController {
         return ResponseEntity.ok(mapa);
     }
 
-    /**
-     * Permite que um usuário apresente sugestões de melhoria para um mapa de competências.
-     */
     @PostMapping("/{codigo}/apresentar-sugestoes")
     @PreAuthorize("hasRole('CHEFE')")
     @Operation(summary = "Apresenta sugestões de melhoria para o mapa")
@@ -139,18 +118,12 @@ public class SubprocessoMapaController {
         subprocessoFacade.apresentarSugestoes(codigo, request.texto(), usuario);
     }
 
-    /**
-     * Obtém as sugestões de melhoria que foram apresentadas para o mapa de um subprocesso.
-     */
     @GetMapping("/{codigo}/sugestoes")
     @PreAuthorize("isAuthenticated()")
     public Map<String, Object> obterSugestoes(@PathVariable Long codigo) {
         return subprocessoFacade.obterSugestoes(codigo);
     }
 
-    /**
-     * Obtém o histórico de análises da fase de validação de um subprocesso.
-     */
     @GetMapping("/{codigo}/historico-validacao")
     @PreAuthorize("isAuthenticated()")
     public List<AnaliseValidacaoHistoricoDto> obterHistoricoValidacao(@PathVariable Long codigo) {


### PR DESCRIPTION
This PR removes unnecessary and redundant comments from the backend codebase, specifically targeting:
- `ProcessoController.java`
- `SubprocessoCadastroController.java`
- `SubprocessoCrudController.java`
- `SubprocessoMapaController.java`
- `AnaliseController.java`
- `UnidadeController.java`
- `ProcessoFacade.java`

The goal is to reduce noise and improve code readability by relying on self-documenting code and Swagger/OpenAPI annotations (`@Operation`) for API documentation.

Backend tests were run and the failure in `CDU34IntegrationTest` was confirmed to be pre-existing.

---
*PR created automatically by Jules for task [9518870930746807675](https://jules.google.com/task/9518870930746807675) started by @lgalvao*