### PR TITLE
Clean up unnecessary Javadoc comments

### DIFF
--- a/backend/src/main/java/sgc/comum/erros/ErroInterno.java
+++ b/backend/src/main/java/sgc/comum/erros/ErroInterno.java
@@ -9,8 +9,6 @@ public abstract class ErroInterno extends RuntimeException {
     /**
      * Construtor com mensagem de erro.
      * A mensagem será logada mas não exposta ao usuário final.
-     *
-     * @param message descrição técnica do erro para logs e depuração
      */
     protected ErroInterno(String message) {
         super(message);

--- a/backend/src/main/java/sgc/comum/repo/ComumRepo.java
+++ b/backend/src/main/java/sgc/comum/repo/ComumRepo.java
@@ -19,12 +19,6 @@ public class ComumRepo {
 
     /**
      * Busca uma entidade pelo seu ID.
-     *
-     * @param <T>    Tipo da entidade
-     * @param classe Classe da entidade
-     * @param id     Identificador único
-     * @return A entidade encontrada
-     * @throws ErroEntidadeNaoEncontrada se a entidade não existir
      */
     public <T> T buscar(Class<T> classe, Object id) {
         T entidade = em.find(classe, id);
@@ -36,13 +30,6 @@ public class ComumRepo {
 
     /**
      * Busca uma única entidade por um campo específico.
-     *
-     * @param <T>    Tipo da entidade
-     * @param classe Classe da entidade
-     * @param campo  Nome do campo
-     * @param valor  Valor do campo
-     * @return A entidade encontrada
-     * @throws ErroEntidadeNaoEncontrada se a entidade não existir
      */
     public <T> T buscar(Class<T> classe, String campo, Object valor) {
         try {
@@ -56,12 +43,6 @@ public class ComumRepo {
 
     /**
      * Busca uma única entidade por múltiplos campos.
-     *
-     * @param <T>     Tipo da entidade
-     * @param classe  Classe da entidade
-     * @param filtros Mapa de campo -> valor
-     * @return A entidade encontrada
-     * @throws ErroEntidadeNaoEncontrada se a entidade não existir ou não atender aos critérios
      */
     public <T> T buscar(Class<T> classe, Map<String, Object> filtros) {
         StringBuilder jpql = new StringBuilder("SELECT e FROM " + classe.getSimpleName() + " e WHERE 1=1");
@@ -78,12 +59,6 @@ public class ComumRepo {
 
     /**
      * Busca uma entidade pela sua sigla.
-     *
-     * @param <T>    Tipo da entidade
-     * @param classe Classe da entidade
-     * @param sigla  Sigla da entidade
-     * @return A entidade encontrada
-     * @throws ErroEntidadeNaoEncontrada se a entidade não existir
      */
     public <T> T buscarPorSigla(Class<T> classe, String sigla) {
         return buscar(classe, "sigla", sigla);

--- a/backend/src/main/java/sgc/comum/util/FormatadorData.java
+++ b/backend/src/main/java/sgc/comum/util/FormatadorData.java
@@ -15,9 +15,6 @@ public class FormatadorData {
 
     /**
      * Formata uma data no padrão brasileiro (dd/MM/yyyy).
-     *
-     * @param data a data a ser formatada
-     * @return a data formatada ou null se a data for null
      */
     public static String formatarData(LocalDateTime data) {
         return data == null ? "-" : data.format(FORMATO_BR);
@@ -25,9 +22,6 @@ public class FormatadorData {
 
     /**
      * Formata uma data com hora no padrão brasileiro (dd/MM/yyyy HH:mm).
-     *
-     * @param data a data a ser formatada
-     * @return a data formatada ou null se a data for null
      */
     public static String formatarDataHora(LocalDateTime data) {
         return data == null ? "-" : data.format(FORMATO_BR_COM_HORA);

--- a/backend/src/main/java/sgc/painel/PainelController.java
+++ b/backend/src/main/java/sgc/painel/PainelController.java
@@ -29,12 +29,6 @@ public class PainelController {
      *
      * <p>A visibilidade dos processos é determinada pelo perfil do usuário e pela
      * unidade selecionada.
-     *
-     * @param perfil   O perfil do usuário (e.g., 'ADMIN', 'GESTOR'), que define as regras de acesso.
-     * @param unidade  O código da unidade para filtrar os processos.
-     * @param pageable As informações de paginação.
-     * @return Um {@link ResponseEntity} contendo uma página {@link Page} de {@link
-     * ProcessoResumoDto}.
      */
     @GetMapping("/processos")
     @PreAuthorize("isAuthenticated()")
@@ -53,11 +47,6 @@ public class PainelController {
      *
      * <p>Os alertas podem ser filtrados pelo título de eleitor do usuário ou pelo código da
      * unidade.
-     *
-     * @param usuarioTitulo Título de eleitor do usuário para filtrar os alertas (opcional).
-     * @param unidade       código da unidade para filtrar os alertas.
-     * @param pageable      As informações de paginação.
-     * @return Um {@link ResponseEntity} contendo uma página {@link Page} de {@link Alerta}.
      */
     @GetMapping("/alertas")
     @PreAuthorize("isAuthenticated()")

--- a/backend/src/main/java/sgc/painel/PainelFacade.java
+++ b/backend/src/main/java/sgc/painel/PainelFacade.java
@@ -39,12 +39,6 @@ public class PainelFacade {
      * - GESTOR: vê processos da unidade e de todas as subordinadas (recursivamente)
      * - CHEFE e SERVIDOR: veem processos APENAS da própria unidade
      * - Processos no estado 'CRIADO' são omitidos para perfis não-ADMIN
-     *
-     * @param perfil        O perfil do usuário (obrigatório).
-     * @param codigoUnidade O código da unidade do usuário (obrigatório).
-     * @param pageable      As informações de paginação.
-     * @return Uma página {@link Page} de {@link ProcessoResumoDto}.
-     * @throws IllegalArgumentException se o perfil for nulo or em branco.
      */
     public Page<ProcessoResumoDto> listarProcessos(Perfil perfil, Long codigoUnidade, Pageable pageable) {
         Pageable sortedPageable = garantirOrdenacaoPadrao(pageable);
@@ -87,11 +81,6 @@ public class PainelFacade {
      *
      * <p>Os alertas são filtrados pela unidade fornecida.
      * O título do usuário é utilizado para verificar o status de leitura.
-     *
-     * @param usuarioTitulo Título de eleitor do usuário (opcional).
-     * @param codigoUnidade Código da unidade (obrigatório).
-     * @param pageable      As informações de paginação.
-     * @return Uma página {@link Page} de {@link Alerta}.
      */
     @Transactional
     public Page<Alerta> listarAlertas(String usuarioTitulo, Long codigoUnidade, Pageable pageable) {

--- a/backend/src/main/java/sgc/seguranca/login/LoginFacade.java
+++ b/backend/src/main/java/sgc/seguranca/login/LoginFacade.java
@@ -51,10 +51,6 @@ public class LoginFacade {
 
     /**
      * Autentica um usuário com título de eleitor e senha.
-     *
-     * @param tituloEleitoral Título de eleitor do usuário
-     * @param senha           Senha do usuário
-     * @return true se a autenticação for bem-sucedida
      */
     public boolean autenticar(String tituloEleitoral, String senha) {
         if (ambienteTestes) {
@@ -76,9 +72,6 @@ public class LoginFacade {
     /**
      * Retorna os perfis e unidades que o usuário pode acessar.
      * Requer autenticação prévia.
-     *
-     * @param tituloEleitoral Título de eleitor do usuário
-     * @return Lista de perfis e unidades disponíveis
      */
     @Transactional(readOnly = true)
     public List<PerfilUnidadeDto> autorizar(String tituloEleitoral) {
@@ -87,9 +80,6 @@ public class LoginFacade {
 
     /**
      * Finaliza o login gerando um token JWT para o perfil e unidade escolhidos.
-     *
-     * @param request Dados da requisição de entrada
-     * @return Token JWT
      */
     @Transactional(readOnly = true)
     public String entrar(EntrarRequest request) {


### PR DESCRIPTION
This PR removes obvious Javadoc tags (@param, @return, @throws) from several backend classes where the parameter names and method signatures are self-explanatory. This cleanup aims to reduce noise and improve code readability, as per the task requirements.

---
*PR created automatically by Jules for task [3709817007000671407](https://jules.google.com/task/3709817007000671407) started by @lgalvao*