### PR TITLE
test(frontend): implement PBT for eligibility invariant

### DIFF
--- a/pbt-status.md
+++ b/pbt-status.md
@@ -10,7 +10,7 @@ This file tracks the implementation progress of Property-Based Tests (PBT) based
 
 ## 1. Unit Selection Tree (Árvore de Seleção de Unidades)
 - [x] Invariant: Selection State (3-State Logic) (Frontend PBT)
-- [ ] Invariant: Eligibility
+- [x] Invariant: Eligibility (Frontend PBT)
 - [ ] Invariant: Submission (Backend validation)
 - [x] Property: Monotonicity (Frontend PBT)
 - [ ] Property: Idempotence


### PR DESCRIPTION
Implemented a new Property-Based Test in `frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts` to verify the "Eligibility Invariant".
The test generates random tree structures with mixed `isElegivel` and `tipo` properties and asserts that no matter the user interactions, only eligible units are selected.
Updated `pbt-status.md` to mark "Invariant: Eligibility" as implemented.

---
*PR created automatically by Jules for task [322100481042219499](https://jules.google.com/task/322100481042219499) started by @lgalvao*