### PR TITLE
feat: Implement PBT properties and backend validation for process submission

### DIFF
--- a/backend/src/main/java/sgc/processo/service/ProcessoManutencaoService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoManutencaoService.java
@@ -40,6 +40,11 @@ public class ProcessoManutencaoService {
             participantes.add(unidade);
         }
 
+        processoValidador.validarTiposUnidades(new ArrayList<>(participantes))
+                .ifPresent(msg -> {
+                    throw new ErroProcesso(msg);
+                });
+
         TipoProcesso tipoProcesso = req.tipo();
 
         if (tipoProcesso == REVISAO || tipoProcesso == DIAGNOSTICO) {
@@ -93,6 +98,11 @@ public class ProcessoManutencaoService {
         for (Long codigoUnidade : requisicao.unidades()) {
             participantes.add(unidadeService.buscarEntidadePorId(codigoUnidade));
         }
+
+        processoValidador.validarTiposUnidades(new ArrayList<>(participantes))
+                .ifPresent(msg -> {
+                    throw new ErroProcesso(msg);
+                });
 
         processo.sincronizarParticipantes(participantes);
 

--- a/backend/src/main/java/sgc/processo/service/ProcessoValidador.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoValidador.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sgc.organizacao.UnidadeFacade;
+import sgc.organizacao.model.TipoUnidade;
 import sgc.organizacao.model.Unidade;
 import sgc.processo.erros.ErroProcesso;
 import sgc.processo.model.Processo;
@@ -81,5 +82,29 @@ class ProcessoValidador {
         }
 
         log.info("Todos os subprocessos do processo {} estão homologados", processo.getCodigo());
+    }
+
+    /**
+     * Valida se as unidades participantes são elegíveis (não são INTERMEDIARIA).
+     *
+     * @param unidades lista de unidades a validar
+     * @return Optional com mensagem de erro se houver unidade inválida
+     */
+    public Optional<String> validarTiposUnidades(List<Unidade> unidades) {
+        if (unidades == null || unidades.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<String> unidadesInvalidas = unidades.stream()
+                .filter(u -> u.getTipo() == TipoUnidade.INTERMEDIARIA)
+                .map(Unidade::getSigla)
+                .toList();
+
+        if (!unidadesInvalidas.isEmpty()) {
+            return Optional.of("Unidades do tipo INTERMEDIARIA não podem participar de processos: "
+                    + String.join(", ", unidadesInvalidas));
+        }
+
+        return Optional.empty();
     }
 }

--- a/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServiceValidationTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServiceValidationTest.java
@@ -1,0 +1,67 @@
+package sgc.processo.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.organizacao.UnidadeFacade;
+import sgc.organizacao.model.TipoUnidade;
+import sgc.organizacao.model.Unidade;
+import sgc.processo.dto.CriarProcessoRequest;
+import sgc.processo.erros.ErroProcesso;
+import sgc.processo.model.ProcessoRepo;
+import sgc.processo.model.TipoProcesso;
+import sgc.testutils.UnidadeTestBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProcessoManutencaoServiceValidationTest")
+class ProcessoManutencaoServiceValidationTest {
+
+    @Mock
+    private ProcessoRepo processoRepo;
+    @Mock
+    private UnidadeFacade unidadeService;
+    @Mock
+    private ProcessoValidador processoValidador;
+    @Mock
+    private ProcessoConsultaService processoConsultaService;
+
+    @InjectMocks
+    private ProcessoManutencaoService service;
+
+    @Test
+    @DisplayName("Deve impedir criação de processo com unidade INTERMEDIARIA")
+    void deveImpedirCriacaoComUnidadeIntermediaria() {
+        // Given
+        CriarProcessoRequest request = CriarProcessoRequest.builder()
+                .descricao("Processo Teste")
+                .tipo(TipoProcesso.MAPEAMENTO)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
+                .unidades(List.of(1L))
+                .build();
+
+        Unidade unidadeIntermediaria = UnidadeTestBuilder.umaDe().comCodigo("1")
+                .comTipo(TipoUnidade.INTERMEDIARIA)
+                .build();
+
+        when(unidadeService.buscarEntidadePorId(1L)).thenReturn(unidadeIntermediaria);
+
+        when(processoValidador.validarTiposUnidades(anyList()))
+                .thenReturn(Optional.of("Unidades do tipo INTERMEDIARIA não podem participar de processos: COORD_11"));
+
+        // When/Then
+        assertThatThrownBy(() -> service.criar(request))
+                .isInstanceOf(ErroProcesso.class)
+                .hasMessageContaining("Unidades do tipo INTERMEDIARIA não podem participar de processos");
+    }
+}

--- a/frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts
+++ b/frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts
@@ -222,4 +222,37 @@ describe('ArvoreUnidades Property-Based Tests', () => {
       )
     );
   });
+
+  it('should satisfy Idempotence: Selecting an already selected unit (or tree) should result in the same state', () => {
+    fc.assert(
+      fc.property(fc.nat({ max: 100 }), (seed) => { // Using seed to generate deterministic tree
+         // Generate tree
+         const tree = generateTree(3, 2, seed);
+         const allNodes = flatten(tree);
+         if (allNodes.length === 0) return;
+
+         const wrapper = mount(ArvoreUnidades, {
+            props: {
+              unidades: tree,
+              modelValue: []
+            }
+         });
+         const vm = wrapper.vm as any;
+
+         // Pick a random node
+         const nodeIndex = seed % allNodes.length;
+         const node = allNodes[nodeIndex];
+
+         // Select it once
+         vm.toggle(node, true);
+         const stateAfterFirst = [...vm.modelValue].sort((a: number, b: number) => a - b);
+
+         // Select it again
+         vm.toggle(node, true);
+         const stateAfterSecond = [...vm.modelValue].sort((a: number, b: number) => a - b);
+
+         expect(stateAfterFirst).toEqual(stateAfterSecond);
+      })
+    );
+  });
 });

--- a/pbt-status.md
+++ b/pbt-status.md
@@ -11,9 +11,9 @@ This file tracks the implementation progress of Property-Based Tests (PBT) based
 ## 1. Unit Selection Tree (Árvore de Seleção de Unidades)
 - [x] Invariant: Selection State (3-State Logic) (Frontend PBT)
 - [x] Invariant: Eligibility (Frontend PBT)
-- [ ] Invariant: Submission (Backend validation)
+- [x] Invariant: Submission (Backend validation)
 - [x] Property: Monotonicity (Frontend PBT)
-- [ ] Property: Idempotence
+- [x] Property: Idempotence
 
 ## 2. Process Management (Gerenciamento de Processos)
 - [x] Invariant: Creation Validity (Partial - Backend Logic tested)


### PR DESCRIPTION
This PR implements two key items from the Property-Based Testing plan (`pbt-status.md`):

1.  **Backend Validation for Submission**: 
    - Implemented logic in `ProcessoValidador.validarTiposUnidades` to ensure that units of type `INTERMEDIARIA` are never accepted as participants in a process.
    - Integrated this validation into `ProcessoManutencaoService` (create and update methods).
    - Added a new unit test `ProcessoManutencaoServiceValidationTest` to verify this behavior.

2.  **Frontend Idempotence Property**:
    - Added a property-based test case in `frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts` using `fast-check`.
    - Verifies that selecting an already selected unit (or tree) results in the same selection state (Idempotence).

The `pbt-status.md` file has been updated to mark these items as implemented. Invariants for "Immutability after Start" and "State Transitions" were verified but left unchecked in the status file as no new PBT tests were added for them, maintaining strict adherence to PBT tracking.

---
*PR created automatically by Jules for task [8335269693057526088](https://jules.google.com/task/8335269693057526088) started by @lgalvao*