### PR TITLE
Fix E2E 500 Serialization Error and Subprocess Permissions

### DIFF
--- a/backend/src/main/java/sgc/seguranca/acesso/AbstractAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/AbstractAccessPolicy.java
@@ -96,7 +96,7 @@ public abstract class AbstractAccessPolicy<T> implements AccessPolicy<T> {
 
             case TITULAR_UNIDADE -> {
                 String tituloTitular = unidade.getTituloTitular();
-                yield tituloTitular.equals(usuario.getTituloEleitoral());
+                yield tituloTitular != null && tituloTitular.equals(usuario.getTituloEleitoral());
             }
         };
     }

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoCadastroController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoCadastroController.java
@@ -24,6 +24,7 @@ import sgc.comum.dto.ComumDtos.JustificativaRequest;
 import sgc.comum.dto.ComumDtos.TextoRequest;
 import sgc.subprocesso.dto.*;
 import sgc.subprocesso.model.Subprocesso;
+import sgc.subprocesso.model.SubprocessoViews;
 import sgc.subprocesso.service.SubprocessoFacade;
 
 import java.util.List;
@@ -44,6 +45,13 @@ public class SubprocessoCadastroController {
     @PreAuthorize("isAuthenticated()")
     public List<AnaliseHistoricoDto> obterHistoricoCadastro(@PathVariable Long codigo) {
         return analiseFacade.listarHistoricoCadastro(codigo);
+    }
+
+    @GetMapping("/{codigo}/contexto-edicao")
+    @PreAuthorize("isAuthenticated()")
+    @JsonView(SubprocessoViews.Publica.class)
+    public ResponseEntity<ContextoEdicaoResponse> obterContextoEdicao(@PathVariable Long codigo) {
+        return ResponseEntity.ok(subprocessoFacade.obterContextoEdicao(codigo));
     }
 
     @PostMapping("/{codigo}/cadastro/disponibilizar")

--- a/backend/src/main/java/sgc/subprocesso/dto/SubprocessoPermissoesDto.java
+++ b/backend/src/main/java/sgc/subprocesso/dto/SubprocessoPermissoesDto.java
@@ -1,11 +1,14 @@
 package sgc.subprocesso.dto;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Builder;
+import sgc.subprocesso.model.SubprocessoViews;
 
 /**
  * DTO de resposta contendo as permissões do usuário sobre um subprocesso.
  */
 @Builder
+@JsonView(SubprocessoViews.Publica.class)
 public record SubprocessoPermissoesDto(
         boolean podeVerPagina,
         boolean podeEditarMapa,

--- a/backend/src/main/java/sgc/subprocesso/model/SubprocessoViews.java
+++ b/backend/src/main/java/sgc/subprocesso/model/SubprocessoViews.java
@@ -1,11 +1,11 @@
 package sgc.subprocesso.model;
 
-import sgc.comum.model.ComumViews;
+import sgc.mapa.model.MapaViews;
 
 public final class SubprocessoViews {
     private SubprocessoViews() {
     }
 
-    public interface Publica extends ComumViews.Publica {
+    public interface Publica extends MapaViews.Publica {
     }
 }

--- a/backend/src/main/java/sgc/subprocesso/service/factory/SubprocessoFactory.java
+++ b/backend/src/main/java/sgc/subprocesso/service/factory/SubprocessoFactory.java
@@ -22,7 +22,9 @@ import java.util.Collection;
 import java.util.List;
 
 import static sgc.subprocesso.model.SituacaoSubprocesso.DIAGNOSTICO_AUTOAVALIACAO_EM_ANDAMENTO;
+import static sgc.subprocesso.model.SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO;
 import static sgc.subprocesso.model.SituacaoSubprocesso.NAO_INICIADO;
+import static sgc.subprocesso.model.SituacaoSubprocesso.REVISAO_CADASTRO_EM_ANDAMENTO;
 
 /**
  * Factory para criação de entidades Subprocesso.
@@ -85,7 +87,7 @@ public class SubprocessoFactory {
                         .processo(processo)
                         .unidade(unidade)
                         .mapa(null)
-                        .situacao(NAO_INICIADO)
+                        .situacao(MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                         .dataLimiteEtapa1(processo.getDataLimite())
                         .build())
                 .map(Subprocesso.class::cast)
@@ -127,7 +129,7 @@ public class SubprocessoFactory {
                 .processo(processo)
                 .unidade(unidade)
                 .mapa(null)
-                .situacao(NAO_INICIADO)
+                .situacao(REVISAO_CADASTRO_EM_ANDAMENTO)
                 .dataLimiteEtapa1(processo.getDataLimite())
                 .build();
         Subprocesso subprocessoSalvo = subprocessoRepo.save(subprocesso);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -78,6 +78,7 @@ spring:
   datasource:
     url: jdbc:h2:mem:sgc-e2e;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   jpa:
+    open-in-view: true
     database-platform: org.hibernate.dialect.H2Dialect
     hibernate.ddl-auto: update
     defer-datasource-initialization: true


### PR DESCRIPTION
Resolved critical E2E failures reported in `relatorio-e2e.md`. The 500 error ("Failed to write request") was traced to `LazyInitializationException` during Jackson serialization of the `Mapa` entity graph, fixed by enabling `open-in-view` for the E2E profile. Permission issues (CDU-05) were resolved by correcting the initial state of subprocesses in the Factory and ensuring proper JSON View inheritance so that permission DTOs are correctly serialized to the frontend. Also added a missing endpoint required by `AtividadesCadastroView`.

---
*PR created automatically by Jules for task [8081414288419021413](https://jules.google.com/task/8081414288419021413) started by @lgalvao*