### PR TITLE
Fix security vulnerability in SubprocessoAtividadeService import

### DIFF
--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoAtividadeService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoAtividadeService.java
@@ -73,6 +73,8 @@ class SubprocessoAtividadeService {
 
         Subprocesso spOrigem = repo.buscar(Subprocesso.class, codSubprocessoOrigem);
 
+        accessControlService.verificarPermissao(usuario, Acao.VISUALIZAR_SUBPROCESSO, spOrigem);
+
         // Importar atividades diretamente (sem evento assíncrono)
         copiaMapaService.importarAtividadesDeOutroMapa(
                 spOrigem.getMapa().getCodigo(),


### PR DESCRIPTION
This PR addresses a critical security vulnerability in `SubprocessoAtividadeService.importarAtividades` where the user could import activities from a subprocess they did not have access to. 

Changes:
1.  **Security Fix:** Added a mandatory permission check (`VISUALIZAR_SUBPROCESSO`) on the origin subprocess before proceeding with the import.
2.  **Test Coverage:** Added a new test case `deveLancarExcecaoQuandoSemPermissaoOrigem` to `SubprocessoAtividadeServiceTest` and updated existing tests to mock the new interaction.
3.  **Documentation:** Updated `plano-melhoria-testes.md` to mark `ProcessoRepoTest` as implemented and the import vulnerability as fixed.

Verified by running `SubprocessoAtividadeServiceTest` (10/10 passed) and `ProcessoRepoTest` (5/5 passed).

---
*PR created automatically by Jules for task [6766287061123076626](https://jules.google.com/task/6766287061123076626) started by @lgalvao*