### PR TITLE
Add Pact provider verification for backend

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -76,6 +76,10 @@ dependencies {
     // Testes de Mutação
     testImplementation("org.pitest:pitest-junit5-plugin:1.2.3")
 
+    // Testes de Contrato (Pact)
+    testImplementation("au.com.dius.pact.provider:junit5:4.6.14")
+    testImplementation("au.com.dius.pact.provider:spring:4.6.14")
+
     // Documentação da API
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1")
     testImplementation("io.swagger.parser.v3:swagger-parser:2.1.37")

--- a/backend/src/test/java/sgc/pact/FrontendBackendPactTest.java
+++ b/backend/src/test/java/sgc/pact/FrontendBackendPactTest.java
@@ -1,0 +1,97 @@
+package sgc.pact;
+
+import au.com.dius.pact.provider.junit5.HttpTestTarget;
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import sgc.processo.model.Processo;
+import sgc.processo.model.SituacaoProcesso;
+import sgc.processo.model.TipoProcesso;
+import sgc.processo.service.ProcessoFacade;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Provider("Backend")
+@PactFolder("../frontend/pact/pacts")
+class FrontendBackendPactTest {
+
+    @LocalServerPort
+    private int port;
+
+    @MockitoBean
+    private ProcessoFacade processoFacade;
+
+    @TestTemplate
+    @ExtendWith(PactVerificationInvocationContextProvider.class)
+    void pactVerificationTestTemplate(PactVerificationContext context) {
+        context.verifyInteraction();
+    }
+
+    @BeforeEach
+    void before(PactVerificationContext context) {
+        context.setTarget(new HttpTestTarget("localhost", port));
+    }
+
+    @State("processo 1 existe")
+    void processo1Existe() {
+        Processo processo = Processo.builder()
+                .codigo(1L)
+                .descricao("Processo de Teste")
+                .situacao(SituacaoProcesso.CRIADO)
+                .tipo(TipoProcesso.MAPEAMENTO)
+                .dataCriacao(LocalDateTime.of(2023, 1, 1, 0, 0, 0))
+                .dataLimite(LocalDateTime.of(2023, 12, 31, 23, 59, 59))
+                .build();
+
+        when(processoFacade.obterPorId(1L)).thenReturn(Optional.of(processo));
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        @Primary
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .addFilterBefore(new Filter() {
+                    @Override
+                    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+                        SecurityContextHolder.getContext().setAuthentication(
+                            new UsernamePasswordAuthenticationToken("user", "password", List.of(new SimpleGrantedAuthority("ROLE_ADMIN")))
+                        );
+                        chain.doFilter(request, response);
+                    }
+                }, UsernamePasswordAuthenticationFilter.class);
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
Added Pact provider tests to backend to verify frontend-backend alignment. Configured backend/build.gradle.kts with Pact dependencies and created sgc.pact.FrontendBackendPactTest using HttpTestTarget to bypass Spring Test version incompatibilities. Updated frontend pact generation verification.

---
*PR created automatically by Jules for task [4523160259272978617](https://jules.google.com/task/4523160259272978617) started by @lgalvao*