### PR TITLE
Add Storybook stories for common components

### DIFF
--- a/frontend/src/components/comum/CampoTexto.stories.ts
+++ b/frontend/src/components/comum/CampoTexto.stories.ts
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import CampoTexto from './CampoTexto.vue';
+import { ref } from 'vue';
+
+const meta: Meta<typeof CampoTexto> = {
+  title: 'Comum/CampoTexto',
+  component: CampoTexto,
+  tags: ['autodocs'],
+  argTypes: {
+    label: { control: 'text' },
+    placeholder: { control: 'text' },
+    obrigatorio: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    erro: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CampoTexto>;
+
+export const Default: Story = {
+  args: {
+    id: 'campo-texto-default',
+    label: 'Nome',
+    placeholder: 'Digite seu nome',
+    modelValue: '',
+  },
+  render: (args) => ({
+    components: { CampoTexto },
+    setup() {
+      const valor = ref(args.modelValue);
+      return { args, valor };
+    },
+    template: `
+      <CampoTexto
+        v-bind="args"
+        v-model="valor"
+      />
+      <div class="mt-2 text-muted small">Valor atual: {{ valor }}</div>
+    `,
+  }),
+};
+
+export const Required: Story = {
+  args: {
+    id: 'campo-texto-required',
+    label: 'Email',
+    obrigatorio: true,
+    modelValue: '',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    id: 'campo-texto-disabled',
+    label: 'Código',
+    modelValue: '12345',
+    disabled: true,
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    id: 'campo-texto-error',
+    label: 'Senha',
+    modelValue: '123',
+    erro: 'A senha deve ter no mínimo 8 caracteres.',
+  },
+};

--- a/frontend/src/components/comum/EmptyState.stories.ts
+++ b/frontend/src/components/comum/EmptyState.stories.ts
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import EmptyState from './EmptyState.vue';
+import { BButton } from 'bootstrap-vue-next';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Comum/EmptyState',
+  component: EmptyState,
+  tags: ['autodocs'],
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    icon: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const Default: Story = {
+  args: {
+    title: 'Nenhum item encontrado',
+    description: 'Tente ajustar os filtros de busca.',
+    icon: 'bi-search',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    icon: 'bi-inbox',
+    title: 'Caixa de entrada vazia',
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    title: 'Sem resultados',
+    description: 'Não encontramos nada com os termos pesquisados.',
+  },
+};
+
+export const FullContent: Story = {
+  args: {
+    title: 'Bem-vindo',
+    description: 'Comece adicionando um novo item.',
+    icon: 'bi-plus-circle',
+  },
+  render: (args) => ({
+    components: { EmptyState, BButton },
+    setup() {
+      return { args };
+    },
+    template: `
+      <EmptyState v-bind="args">
+        <BButton variant="primary">Adicionar Novo</BButton>
+      </EmptyState>
+    `,
+  }),
+};

--- a/frontend/src/components/comum/ErrorAlert.stories.ts
+++ b/frontend/src/components/comum/ErrorAlert.stories.ts
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ErrorAlert from './ErrorAlert.vue';
+
+const meta: Meta<typeof ErrorAlert> = {
+  title: 'Comum/ErrorAlert',
+  component: ErrorAlert,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['danger', 'warning', 'info'],
+    },
+    error: { control: 'object' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ErrorAlert>;
+
+export const Default: Story = {
+  args: {
+    error: { message: 'Ocorreu um erro inesperado.' },
+    variant: 'danger',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    error: { message: 'Atenção: Ação irreversível.' },
+    variant: 'warning',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    error: { message: 'Informação: Processo iniciado.' },
+    variant: 'info',
+  },
+};
+
+export const WithDetails: Story = {
+  args: {
+    error: {
+      message: 'Falha na validação',
+      details: 'O campo "Nome" é obrigatório.',
+    },
+    variant: 'danger',
+  },
+};

--- a/frontend/src/components/comum/ModalConfirmacao.stories.ts
+++ b/frontend/src/components/comum/ModalConfirmacao.stories.ts
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ModalConfirmacao from './ModalConfirmacao.vue';
+import { BButton } from 'bootstrap-vue-next';
+import { ref } from 'vue';
+
+const meta: Meta<typeof ModalConfirmacao> = {
+  title: 'Comum/ModalConfirmacao',
+  component: ModalConfirmacao,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'danger', 'warning', 'success', 'info'],
+    },
+    okTitle: { control: 'text' },
+    cancelTitle: { control: 'text' },
+    loading: { control: 'boolean' },
+    titulo: { control: 'text' },
+    mensagem: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ModalConfirmacao>;
+
+const Template = (args: any) => ({
+  components: { ModalConfirmacao, BButton },
+  setup() {
+    const show = ref(false);
+    return { args, show };
+  },
+  template: `
+    <div>
+      <BButton @click="show = true">Abrir Modal</BButton>
+      <ModalConfirmacao
+        v-bind="args"
+        v-model="show"
+        @confirmar="() => { show = false; }"
+      />
+    </div>
+  `,
+});
+
+export const Default: Story = {
+  render: Template,
+  args: {
+    titulo: 'Confirmação',
+    mensagem: 'Tem certeza que deseja realizar esta ação?',
+    modelValue: false,
+  },
+};
+
+export const Danger: Story = {
+  render: Template,
+  args: {
+    titulo: 'Excluir Item',
+    mensagem: 'Esta ação não poderá ser desfeita.',
+    variant: 'danger',
+    okTitle: 'Sim, excluir',
+    modelValue: false,
+  },
+};
+
+export const Loading: Story = {
+  render: Template,
+  args: {
+    titulo: 'Processando...',
+    mensagem: 'Aguarde enquanto processamos sua solicitação.',
+    loading: true,
+    okTitle: 'Confirmar',
+    modelValue: false,
+  },
+};
+
+export const CustomTitles: Story = {
+  render: Template,
+  args: {
+    titulo: 'Enviar Proposta?',
+    mensagem: 'Sua proposta será enviada para análise.',
+    okTitle: 'Enviar Agora',
+    cancelTitle: 'Revisar',
+    variant: 'success',
+    modelValue: false,
+  },
+};


### PR DESCRIPTION
This PR adds Storybook stories for four common components: `EmptyState`, `ErrorAlert`, `CampoTexto`, and `ModalConfirmacao`. This will help in visualizing the components in different states and with various props, facilitating development and ensuring consistent usage across the application.

---
*PR created automatically by Jules for task [14255361629924550718](https://jules.google.com/task/14255361629924550718) started by @lgalvao*