### PR TITLE
Add Storybook stories for TabelaProcessos, CompetenciaCard, and ArvoreUnidades

### DIFF
--- a/frontend/src/components/mapa/CompetenciaCard.stories.ts
+++ b/frontend/src/components/mapa/CompetenciaCard.stories.ts
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import CompetenciaCard from './CompetenciaCard.vue';
+import type { Competencia, Atividade } from '@/types/tipos';
+
+const meta: Meta<typeof CompetenciaCard> = {
+  title: 'Mapa/CompetenciaCard',
+  component: CompetenciaCard,
+  tags: ['autodocs'],
+  argTypes: {
+    podeEditar: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CompetenciaCard>;
+
+const mockAtividades: Atividade[] = [
+  {
+    codigo: 1,
+    descricao: 'Desenvolver API REST',
+    conhecimentos: [
+      { codigo: 1, descricao: 'Java' },
+      { codigo: 2, descricao: 'Spring Boot' },
+    ],
+  },
+  {
+    codigo: 2,
+    descricao: 'Criar componentes Vue',
+    conhecimentos: [
+      { codigo: 3, descricao: 'Vue.js' },
+      { codigo: 4, descricao: 'TypeScript' },
+    ],
+  },
+  {
+    codigo: 3,
+    descricao: 'Configurar CI/CD',
+    conhecimentos: [],
+  },
+];
+
+const mockCompetencia: Competencia = {
+  codigo: 10,
+  descricao: 'Desenvolvimento Fullstack',
+  atividades: [],
+  atividadesAssociadas: [1, 2],
+};
+
+export const Default: Story = {
+  args: {
+    competencia: mockCompetencia,
+    atividades: mockAtividades,
+    podeEditar: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    competencia: mockCompetencia,
+    atividades: mockAtividades,
+    podeEditar: false,
+  },
+};
+
+export const ComAtividadeSemConhecimento: Story = {
+  args: {
+    competencia: {
+      ...mockCompetencia,
+      atividadesAssociadas: [3],
+    },
+    atividades: mockAtividades,
+    podeEditar: true,
+  },
+};

--- a/frontend/src/components/processo/TabelaProcessos.stories.ts
+++ b/frontend/src/components/processo/TabelaProcessos.stories.ts
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import TabelaProcessos from './TabelaProcessos.vue';
+import { SituacaoProcesso, TipoProcesso, type ProcessoResumo } from '@/types/tipos';
+
+const meta: Meta<typeof TabelaProcessos> = {
+  title: 'Processo/TabelaProcessos',
+  component: TabelaProcessos,
+  tags: ['autodocs'],
+  argTypes: {
+    criterioOrdenacao: {
+      control: 'select',
+      options: ['descricao', 'tipo', 'situacao', 'dataFinalizacao'],
+    },
+    direcaoOrdenacaoAsc: { control: 'boolean' },
+    showDataFinalizacao: { control: 'boolean' },
+    compacto: { control: 'boolean' },
+    mostrarCtaVazio: { control: 'boolean' },
+    textoCtaVazio: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TabelaProcessos>;
+
+const mockProcessos: ProcessoResumo[] = [
+  {
+    codigo: 1,
+    descricao: 'Processo de Mapeamento 2023',
+    situacao: SituacaoProcesso.EM_ANDAMENTO,
+    tipo: TipoProcesso.MAPEAMENTO,
+    dataLimite: '2023-12-31',
+    dataCriacao: '2023-01-01',
+    unidadeCodigo: 101,
+    unidadeNome: 'Departamento de TI',
+    unidadesParticipantes: 'TI, RH',
+  },
+  {
+    codigo: 2,
+    descricao: 'Revisão Anual',
+    situacao: SituacaoProcesso.CRIADO,
+    tipo: TipoProcesso.REVISAO,
+    dataLimite: '2024-06-30',
+    dataCriacao: '2024-01-15',
+    unidadeCodigo: 102,
+    unidadeNome: 'Recursos Humanos',
+    unidadesParticipantes: 'RH',
+  },
+  {
+    codigo: 3,
+    descricao: 'Diagnóstico Geral',
+    situacao: SituacaoProcesso.FINALIZADO,
+    tipo: TipoProcesso.DIAGNOSTICO,
+    dataLimite: '2022-12-31',
+    dataCriacao: '2022-01-01',
+    dataFinalizacao: '2022-12-20',
+    unidadeCodigo: 100,
+    unidadeNome: 'Diretoria',
+    unidadesParticipantes: 'Todas',
+  },
+];
+
+export const Default: Story = {
+  args: {
+    processos: mockProcessos,
+    criterioOrdenacao: 'descricao',
+    direcaoOrdenacaoAsc: true,
+  },
+};
+
+export const ComDataFinalizacao: Story = {
+  args: {
+    processos: mockProcessos,
+    criterioOrdenacao: 'dataFinalizacao',
+    direcaoOrdenacaoAsc: false,
+    showDataFinalizacao: true,
+  },
+};
+
+export const Compacto: Story = {
+  args: {
+    processos: mockProcessos.slice(0, 2),
+    criterioOrdenacao: 'descricao',
+    direcaoOrdenacaoAsc: true,
+    compacto: true,
+  },
+};
+
+export const Vazio: Story = {
+  args: {
+    processos: [],
+    criterioOrdenacao: 'descricao',
+    direcaoOrdenacaoAsc: true,
+    mostrarCtaVazio: true,
+    textoCtaVazio: 'Criar novo processo',
+  },
+};

--- a/frontend/src/components/unidade/ArvoreUnidades.stories.ts
+++ b/frontend/src/components/unidade/ArvoreUnidades.stories.ts
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ArvoreUnidades from './ArvoreUnidades.vue';
+import type { Unidade } from '@/types/tipos';
+import { ref } from 'vue';
+
+const meta: Meta<typeof ArvoreUnidades> = {
+  title: 'Unidade/ArvoreUnidades',
+  component: ArvoreUnidades,
+  tags: ['autodocs'],
+  argTypes: {
+    modoSelecao: { control: 'boolean' },
+    ocultarRaiz: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ArvoreUnidades>;
+
+const mockUnidades: Unidade[] = [
+  {
+    codigo: 1,
+    nome: 'Presidência',
+    sigla: 'PRES',
+    isElegivel: false,
+    filhas: [
+      {
+        codigo: 2,
+        nome: 'Diretoria de Tecnologia',
+        sigla: 'DITEC',
+        isElegivel: true,
+        filhas: [
+          {
+            codigo: 3,
+            nome: 'Coordenação de Desenvolvimento',
+            sigla: 'CODES',
+            isElegivel: true,
+          },
+          {
+            codigo: 4,
+            nome: 'Coordenação de Infraestrutura',
+            sigla: 'COINF',
+            isElegivel: true,
+          },
+        ],
+      },
+      {
+        codigo: 5,
+        nome: 'Diretoria Administrativa',
+        sigla: 'DIRAD',
+        isElegivel: true,
+        filhas: [],
+      },
+    ],
+  },
+];
+
+export const Default: Story = {
+  args: {
+    unidades: mockUnidades,
+    modelValue: [],
+    modoSelecao: true,
+    ocultarRaiz: false,
+  },
+  render: (args) => ({
+    components: { ArvoreUnidades },
+    setup() {
+      const selected = ref(args.modelValue);
+      return { args, selected };
+    },
+    template: `
+      <div>
+        <ArvoreUnidades v-bind="args" v-model="selected" />
+        <div class="mt-3">
+          <strong>Selecionados IDs:</strong> {{ selected }}
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const ComPreSelecao: Story = {
+  args: {
+    unidades: mockUnidades,
+    modelValue: [3, 5],
+    modoSelecao: true,
+    ocultarRaiz: false,
+  },
+  render: (args) => ({
+    components: { ArvoreUnidades },
+    setup() {
+      const selected = ref(args.modelValue);
+      return { args, selected };
+    },
+    template: `
+      <div>
+        <ArvoreUnidades v-bind="args" v-model="selected" />
+        <div class="mt-3">
+          <strong>Selecionados IDs:</strong> {{ selected }}
+        </div>
+      </div>
+    `,
+  }),
+};
+
+export const ApenasVisualizacao: Story = {
+  args: {
+    unidades: mockUnidades,
+    modelValue: [2, 3, 4], // DITEC and children
+    modoSelecao: false,
+    ocultarRaiz: false,
+  },
+};
+
+export const OcultandoRaiz: Story = {
+  args: {
+    unidades: mockUnidades,
+    modelValue: [],
+    modoSelecao: true,
+    ocultarRaiz: true,
+  },
+  render: (args) => ({
+    components: { ArvoreUnidades },
+    setup() {
+      const selected = ref(args.modelValue);
+      return { args, selected };
+    },
+    template: `
+      <div>
+        <p class="text-muted">A raiz "Presidência" deve estar oculta, mostrando apenas seus filhos diretos.</p>
+        <ArvoreUnidades v-bind="args" v-model="selected" />
+        <div class="mt-3">
+          <strong>Selecionados IDs:</strong> {{ selected }}
+        </div>
+      </div>
+    `,
+  }),
+};


### PR DESCRIPTION
Added Storybook stories for `TabelaProcessos`, `CompetenciaCard`, and `ArvoreUnidades` components. Verified with `typecheck` and `lint`.

---
*PR created automatically by Jules for task [302854989811518000](https://jules.google.com/task/302854989811518000) started by @lgalvao*