### PR TITLE
Fix CDU-08/10 Tests and Cross-Unit Import Permission

### DIFF
--- a/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
@@ -6,6 +6,7 @@ import sgc.organizacao.model.Perfil;
 import sgc.organizacao.model.Usuario;
 import sgc.organizacao.model.UsuarioPerfilRepo;
 import sgc.organizacao.service.HierarquiaService;
+import sgc.processo.model.SituacaoProcesso;
 import sgc.subprocesso.model.SituacaoSubprocesso;
 import sgc.subprocesso.model.Subprocesso;
 
@@ -251,6 +252,12 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
         }
 
         // 3. Verifica hierarquia
+        // CASO ESPECIAL: Permitir VISUALIZAR_SUBPROCESSO se o processo estiver FINALIZADO,
+        // independentemente da hierarquia. Isso permite importação de atividades (Knowledge Base).
+        if (acao == VISUALIZAR_SUBPROCESSO && sp.getProcesso().getSituacao() == SituacaoProcesso.FINALIZADO) {
+            return true;
+        }
+
         if (!verificaHierarquia(usuario, sp.getUnidade(), regras.requisitoHierarquia)) {
             String motivo = obterMotivoNegacaoHierarquia(usuario, sp.getUnidade(), regras.requisitoHierarquia);
             log.info("Permissão negada para {}: {}", usuario.getTituloEleitoral(), motivo);

--- a/backend/src/test/java/sgc/integracao/CDU10IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU10IntegrationTest.java
@@ -139,6 +139,9 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         jdbcTemplate.update("UPDATE SGC.VW_UNIDADE SET titulo_titular = ? WHERE codigo = ?",
                 usuario.getTituloEleitoral(), unidade.getCodigo());
 
+        jdbcTemplate.update("INSERT INTO SGC.VW_RESPONSABILIDADE (unidade_codigo, usuario_titulo, usuario_matricula, tipo, data_inicio) VALUES (?, ?, ?, 'TITULAR', ?)",
+                unidade.getCodigo(), usuario.getTituloEleitoral(), usuario.getMatricula(), LocalDateTime.now());
+
         unidade.setTituloTitular(usuario.getTituloEleitoral());
         unidade.setMatriculaTitular(usuario.getMatricula());
     }


### PR DESCRIPTION
This PR addresses failures in E2E (`cdu-10.spec.ts`) and Integration (`CDU08IntegrationTest`, `CDU10IntegrationTest`) tests identified during a full quality check.

Key changes:
1.  **Frontend/E2E Alignment:** Fixed mismatch between frontend status labels ("Revisão em andamento") and test expectations ("Revisão de cadastro em andamento") by updating `formatters.ts`.
2.  **Backend Serialization:** Fixed missing `@JsonView` on `Movimentacao` entity which caused empty history lists in the UI and tests.
3.  **Cross-Unit Import (CDU-08):** Modified `SubprocessoAccessPolicy` to allow users to view subprocesses of **Finalized** processes regardless of hierarchy. This aligns with the requirement to import activities from a list of finalized processes (Knowledge Base feature).
4.  **Test Fixes:**
    - Refactored `CDU08IntegrationTest` to model the cross-unit import scenario correctly (Source=Finalized, Dest=Active).
    - Fixed `CDU10IntegrationTest` failure by ensuring the `VW_RESPONSABILIDADE` table is populated, satisfying the `TITULAR_UNIDADE` security check.
    - Improved robustness of `cdu-10.spec.ts` E2E test.

---
*PR created automatically by Jules for task [13560703791926963259](https://jules.google.com/task/13560703791926963259) started by @lgalvao*