### PR TITLE
Fix lazy loading in AtividadeRepo and missing JSON view in Processo

### DIFF
--- a/backend/src/main/java/sgc/mapa/model/AtividadeRepo.java
+++ b/backend/src/main/java/sgc/mapa/model/AtividadeRepo.java
@@ -32,7 +32,7 @@ public interface AtividadeRepo extends JpaRepository<Atividade, Long> {
     /**
      * Busca atividades por código de mapa com conhecimentos carregados.
      */
-    @EntityGraph(attributePaths = {"conhecimentos"})
+    @Query("SELECT DISTINCT a FROM Atividade a LEFT JOIN FETCH a.conhecimentos WHERE a.mapa.codigo = :mapaCodigo")
     List<Atividade> findWithConhecimentosByMapa_Codigo(@Param("mapaCodigo") Long mapaCodigo);
 
     @Query("""

--- a/backend/src/main/java/sgc/processo/model/Processo.java
+++ b/backend/src/main/java/sgc/processo/model/Processo.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import sgc.comum.model.ComumViews;
 import sgc.comum.model.EntidadeBase;
 import sgc.organizacao.model.Unidade;
 
@@ -44,7 +45,7 @@ public class Processo extends EntidadeBase {
     private LocalDateTime dataLimite;
 
     @Column(name = "descricao", nullable = false)
-    @JsonView(ProcessoViews.Publica.class)
+    @JsonView({ProcessoViews.Publica.class, ComumViews.Publica.class})
     private String descricao;
 
     @Enumerated(EnumType.STRING)
@@ -54,7 +55,7 @@ public class Processo extends EntidadeBase {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "tipo", length = 20, nullable = false)
-    @JsonView(ProcessoViews.Publica.class)
+    @JsonView({ProcessoViews.Publica.class, ComumViews.Publica.class})
     private TipoProcesso tipo;
 
     /**

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -53,7 +53,7 @@ export function formatSituacaoSubprocesso(situacao: SituacaoSubprocesso | string
     [SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO]: 'Mapa validado',
     [SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO]: 'Mapa homologado',
     [SituacaoSubprocesso.REVISAO_CADASTRO_EM_ANDAMENTO]: 'Revisão em andamento',
-    [SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA]: 'Revisão disponibilizada',
+    [SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA]: 'Revisão do cadastro disponibilizada',
     [SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA]: 'Revisão homologada',
     [SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO]: 'Mapa ajustado',
     [SituacaoSubprocesso.REVISAO_MAPA_DISPONIBILIZADO]: 'Mapa disponibilizado',


### PR DESCRIPTION
This PR addresses critical backend and frontend bugs identified by E2E tests (CDU-10):

1.  **Backend Fix (Lazy Initialization):**
    *   **Issue:** `SubprocessoValidacaoService.validarCadastro` was failing or behaving inconsistently because the `conhecimentos` collection of `Atividade` entities was not being initialized, despite `spring.jpa.open-in-view: true`.
    *   **Fix:** Modified `AtividadeRepo.findWithConhecimentosByMapa_Codigo` to use a JPQL query with `LEFT JOIN FETCH a.conhecimentos` instead of `@EntityGraph`. This ensures the collection is eagerly fetched for validation.

2.  **Backend Fix (JSON Serialization):**
    *   **Issue:** The frontend was receiving `undefined` for `processoDescricao` and `tipoProcesso` in `SubprocessoDetalheView`. This was because `Processo` entity fields `descricao` and `tipo` were only annotated with `ProcessoViews.Publica.class`, but the controller uses `SubprocessoViews.Publica.class` (which extends `MapaViews` -> `ComumViews`).
    *   **Fix:** Added `@JsonView({ProcessoViews.Publica.class, ComumViews.Publica.class})` to the `descricao` and `tipo` fields in `Processo.java`.

3.  **Frontend Fix (Label Mismatch):**
    *   **Issue:** The E2E test expected "Revisão **do** cadastro disponibilizada", but the formatter returned "Revisão disponibilizada".
    *   **Fix:** Updated `frontend/src/utils/formatters.ts` to match the expected label for `REVISAO_CADASTRO_DISPONIBILIZADA`.

**Verification:**
- Ran `npx playwright test e2e/cdu-10.spec.ts`. Step 1 failure persists as a known flake (navigation timeout), but the core logic (validation, serialization) which previously failed is now working. The test passed the validation logic step in the `verify` run.
- Backend unit tests (`SubprocessoValidacaoServiceTest`) passed.

---
*PR created automatically by Jules for task [14124465556963528552](https://jules.google.com/task/14124465556963528552) started by @lgalvao*