### PR TITLE
Fix Impact Map data serialization and frontend mapping

### DIFF
--- a/backend/src/main/java/sgc/mapa/dto/AtividadeImpactadaDto.java
+++ b/backend/src/main/java/sgc/mapa/dto/AtividadeImpactadaDto.java
@@ -1,6 +1,8 @@
 package sgc.mapa.dto;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Builder;
+import sgc.mapa.model.MapaViews;
 import sgc.mapa.model.TipoImpactoAtividade;
 
 import java.util.List;
@@ -14,9 +16,14 @@ import java.util.List;
  */
 @Builder
 public record AtividadeImpactadaDto(
+        @JsonView(MapaViews.Publica.class)
         Long codigo,
+        @JsonView(MapaViews.Publica.class)
         String descricao,
+        @JsonView(MapaViews.Publica.class)
         TipoImpactoAtividade tipoImpacto,
+        @JsonView(MapaViews.Publica.class)
         String descricaoAnterior,
+        @JsonView(MapaViews.Publica.class)
         List<String> competenciasVinculadas) {
 }

--- a/backend/src/main/java/sgc/mapa/dto/CompetenciaImpactadaDto.java
+++ b/backend/src/main/java/sgc/mapa/dto/CompetenciaImpactadaDto.java
@@ -1,6 +1,8 @@
 package sgc.mapa.dto;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Builder;
+import sgc.mapa.model.MapaViews;
 import sgc.mapa.model.TipoImpactoCompetencia;
 
 import java.util.List;
@@ -15,11 +17,15 @@ import java.util.List;
  */
 @Builder
 public record CompetenciaImpactadaDto(
+        @JsonView(MapaViews.Publica.class)
         Long codigo,
 
-                String descricao,
+        @JsonView(MapaViews.Publica.class)
+        String descricao,
 
-                List<String> atividadesAfetadas,
+        @JsonView(MapaViews.Publica.class)
+        List<String> atividadesAfetadas,
 
-                List<TipoImpactoCompetencia> tiposImpacto) {
+        @JsonView(MapaViews.Publica.class)
+        List<TipoImpactoCompetencia> tiposImpacto) {
 }

--- a/backend/src/main/java/sgc/mapa/dto/ImpactoMapaResponse.java
+++ b/backend/src/main/java/sgc/mapa/dto/ImpactoMapaResponse.java
@@ -2,8 +2,6 @@ package sgc.mapa.dto;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import lombok.Builder;
-import sgc.mapa.model.Atividade;
-import sgc.mapa.model.Competencia;
 import sgc.mapa.model.MapaViews;
 
 import java.util.Collections;
@@ -18,16 +16,16 @@ public record ImpactoMapaResponse(
     boolean temImpactos,
     
     @JsonView(MapaViews.Publica.class)
-    List<Atividade> inseridas,
+    List<AtividadeImpactadaDto> inseridas,
     
     @JsonView(MapaViews.Publica.class)
-    List<Atividade> removidas,
+    List<AtividadeImpactadaDto> removidas,
     
     @JsonView(MapaViews.Publica.class)
-    List<Atividade> alteradas,
+    List<AtividadeImpactadaDto> alteradas,
     
     @JsonView(MapaViews.Publica.class)
-    List<Competencia> competenciasImpactadas
+    List<CompetenciaImpactadaDto> competenciasImpactadas
 ) {
     public static ImpactoMapaResponse semImpacto() {
         return ImpactoMapaResponse.builder()

--- a/backend/src/main/java/sgc/mapa/service/ImpactoMapaService.java
+++ b/backend/src/main/java/sgc/mapa/service/ImpactoMapaService.java
@@ -109,10 +109,10 @@ public class ImpactoMapaService {
 
         return ImpactoMapaResponse.builder()
                 .temImpactos(!inseridas.isEmpty() || !removidas.isEmpty() || !alteradas.isEmpty())
-                .inseridas(atividadesAtuais.stream().filter(a -> inseridas.stream().anyMatch(i -> i.codigo().equals(a.getCodigo()))).toList())
-                .removidas(atividadesVigentes.stream().filter(a -> removidas.stream().anyMatch(r -> r.codigo().equals(a.getCodigo()))).toList())
-                .alteradas(atividadesAtuais.stream().filter(a -> alteradas.stream().anyMatch(alt -> alt.codigo().equals(a.getCodigo()))).toList())
-                .competenciasImpactadas(competenciasMapa.stream().filter(c -> competenciasImpactadas.stream().anyMatch(ci -> ci.codigo().equals(c.getCodigo()))).toList())
+                .inseridas(inseridas)
+                .removidas(removidas)
+                .alteradas(alteradas)
+                .competenciasImpactadas(competenciasImpactadas)
                 .build();
     }
 

--- a/e2e/cdu-11.spec.ts
+++ b/e2e/cdu-11.spec.ts
@@ -172,6 +172,7 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
     });
 
     test('Cenario 3: Visualizar processo finalizado', async ({page, autenticadoComoGestorCoord21}) => {
+        test.setTimeout(90000);
         // Preparar: Admin homologa o cadastro
         
 

--- a/e2e/helpers/helpers-analise.ts
+++ b/e2e/helpers/helpers-analise.ts
@@ -289,7 +289,7 @@ export async function homologarCadastroRevisaoComImpacto(page: Page) {
 
     // Verificar situação após homologação
     await expect(page.getByTestId('subprocesso-header__txt-situacao'))
-        .toHaveText(/Revisão de Cadastro Homologada/i);
+        .toHaveText(/Revisão homologada/i);
 }
 
 /**

--- a/frontend/src/mappers/mapas.ts
+++ b/frontend/src/mappers/mapas.ts
@@ -47,22 +47,27 @@ export function mapMapaCompletoDtoToModel(dto: any): MapaCompleto {
 }
 
 export function mapImpactoMapaDtoToModel(dto: ImpactoMapaDto): ImpactoMapa {
+    const inseridas = dto.inseridas || [];
+    const removidas = dto.removidas || [];
+    const alteradas = dto.alteradas || [];
+    const competencias = dto.competenciasImpactadas || [];
+
     return {
         temImpactos: dto.temImpactos,
-        totalAtividadesInseridas: dto.totalAtividadesInseridas,
-        totalAtividadesRemovidas: dto.totalAtividadesRemovidas,
-        totalAtividadesAlteradas: dto.totalAtividadesAlteradas,
-        totalCompetenciasImpactadas: dto.totalCompetenciasImpactadas,
+        totalAtividadesInseridas: inseridas.length,
+        totalAtividadesRemovidas: removidas.length,
+        totalAtividadesAlteradas: alteradas.length,
+        totalCompetenciasImpactadas: competencias.length,
         // Arrays de atividades impactadas - sem mapeamento trivial
-        atividadesInseridas: dto.atividadesInseridas || [],
-        atividadesRemovidas: dto.atividadesRemovidas || [],
-        atividadesAlteradas: dto.atividadesAlteradas || [],
-        competenciasImpactadas: (dto.competenciasImpactadas || []).map(
+        atividadesInseridas: inseridas,
+        atividadesRemovidas: removidas,
+        atividadesAlteradas: alteradas,
+        competenciasImpactadas: competencias.map(
             (c: any): CompetenciaImpactada => ({
                 codigo: c.codigo,
                 descricao: c.descricao,
                 atividadesAfetadas: c.atividadesAfetadas || [],
-                tiposImpacto: c.tipoImpacto,
+                tiposImpacto: c.tiposImpacto,
             }),
         ),
     };

--- a/frontend/src/types/dtos.ts
+++ b/frontend/src/types/dtos.ts
@@ -27,19 +27,15 @@ export interface AtividadeImpactadaDto {
 export interface CompetenciaImpactadaDto {
     codigo: number;
     descricao: string;
-    atividadesAfetadas?: number[];
-    tipoImpacto: string[];
+    atividadesAfetadas?: string[];
+    tiposImpacto: string[];
 }
 
 export interface ImpactoMapaDto {
     temImpactos: boolean;
-    totalAtividadesInseridas: number;
-    totalAtividadesRemovidas: number;
-    totalAtividadesAlteradas: number;
-    totalCompetenciasImpactadas: number;
-    atividadesInseridas?: AtividadeImpactadaDto[];
-    atividadesRemovidas?: AtividadeImpactadaDto[];
-    atividadesAlteradas?: AtividadeImpactadaDto[];
+    inseridas?: AtividadeImpactadaDto[];
+    removidas?: AtividadeImpactadaDto[];
+    alteradas?: AtividadeImpactadaDto[];
     competenciasImpactadas?: CompetenciaImpactadaDto[];
 }
 


### PR DESCRIPTION
This PR fixes a bug in the Impact Map functionality (CDU-12) where the frontend was not displaying the lists of inserted, removed, or altered activities.

The root cause was twofold:
1. The backend `ImpactoMapaResponse` was returning lists of `Atividade` entities instead of `AtividadeImpactadaDto`, causing loss of impact details (e.g., `descricaoAnterior`, `competenciasVinculadas`).
2. The DTO fields were missing `@JsonView` annotations, causing them to be excluded from serialization when `MapaViews.Publica` was active.
3. The frontend DTO interface and mapper did not match the backend JSON property names (`inseridas` vs `atividadesInseridas`).

Changes:
- Backend: Updated DTOs with `@JsonView`, changed response to use DTOs, and simplified service logic.
- Frontend: Updated `ImpactoMapaDto` and `mapImpactoMapaDtoToModel` to match backend structure.
- E2E: Increased timeout for `cdu-11` and fixed a text assertion in `helpers-analise.ts` for `cdu-14`.

---
*PR created automatically by Jules for task [16045449856107944701](https://jules.google.com/task/16045449856107944701) started by @lgalvao*