### PR TITLE
Fix E2E regressions in CDU-09 and CDU-10

### DIFF
--- a/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
@@ -269,6 +269,12 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
         // AÇÕES QUE ALTERAM O SISTEMA (Escrita/Análise): Devem ser contra a LOCALIZAÇÃO ATUAL
         if (isAcaoAnaliseOuEscrita(acao)) {
             Unidade localizacao = obterUnidadeLocalizacao(sp);
+
+            // ADMIN: Permissão global para ações de devolução/aceite, ignorando a restrição de MESMA_UNIDADE
+            if (temPerfil(usuario, ADMIN) && isAcaoAdminGlobal(acao)) {
+                return true;
+            }
+
             if (!verificaHierarquia(usuario, localizacao, regras.requisitoHierarquia)) {
                 String motivo = obterMotivoNegacaoHierarquia(usuario, localizacao, regras.requisitoHierarquia);
                 log.info("Permissão negada por localização para {}: {}", usuario.getTituloEleitoral(), motivo);
@@ -295,6 +301,14 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
             EDITAR_REVISAO_CADASTRO, DISPONIBILIZAR_REVISAO_CADASTRO, DEVOLVER_REVISAO_CADASTRO, ACEITAR_REVISAO_CADASTRO, HOMOLOGAR_REVISAO_CADASTRO,
             EDITAR_MAPA, DISPONIBILIZAR_MAPA, APRESENTAR_SUGESTOES, VALIDAR_MAPA, DEVOLVER_MAPA, ACEITAR_MAPA, HOMOLOGAR_MAPA, AJUSTAR_MAPA,
             REALIZAR_AUTOAVALIACAO
+        ).contains(acao);
+    }
+
+    private boolean isAcaoAdminGlobal(Acao acao) {
+        return EnumSet.of(
+            DEVOLVER_CADASTRO, ACEITAR_CADASTRO,
+            DEVOLVER_REVISAO_CADASTRO, ACEITAR_REVISAO_CADASTRO,
+            DEVOLVER_MAPA, ACEITAR_MAPA
         ).contains(acao);
     }
 

--- a/backend/src/test/java/sgc/integracao/CDU10IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU10IntegrationTest.java
@@ -29,6 +29,8 @@ import sgc.organizacao.model.UsuarioRepo;
 import sgc.processo.model.Processo;
 import sgc.processo.model.SituacaoProcesso;
 import sgc.processo.model.TipoProcesso;
+import sgc.subprocesso.model.Movimentacao;
+import sgc.subprocesso.model.MovimentacaoRepo;
 import sgc.subprocesso.model.SituacaoSubprocesso;
 import sgc.subprocesso.model.Subprocesso;
 
@@ -59,6 +61,8 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
     private UsuarioRepo usuarioRepo;
     @Autowired
     private EntityManager entityManager;
+    @Autowired
+    private MovimentacaoRepo movimentacaoRepo;
 
 
     private Unidade unidadeSuperior;
@@ -209,6 +213,17 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         sp.setSituacaoForcada(SituacaoSubprocesso.REVISAO_CADASTRO_EM_ANDAMENTO);
         sp.setDataFimEtapa1(null);
         subprocessoRepo.saveAndFlush(sp);
+
+        Movimentacao mov = new Movimentacao();
+        mov.setSubprocesso(sp);
+        mov.setUnidadeOrigem(unidadeSuperior);
+        mov.setUnidadeDestino(sp.getUnidade());
+        mov.setDataHora(LocalDateTime.now());
+        mov.setDescricao("Devolução simulada");
+        // Usuario Superior
+        Usuario usuarioSuperior = usuarioRepo.findById("666666666666").get();
+        mov.setUsuario(usuarioSuperior);
+        movimentacaoRepo.saveAndFlush(mov);
 
         // 5. Nova disponibilização
         mockMvc.perform(post("/api/subprocessos/{id}/disponibilizar-revisao", subprocessoId))

--- a/e2e-status.md
+++ b/e2e-status.md
@@ -57,6 +57,28 @@ router.push({
 ```
 Isso garante que o Vue Router construa a URL corretamente baseada na definição da rota `Subprocesso`.
 
+### CDU-09: Erro 403 ao devolver cadastro (Admin)
+
+**Problema:**
+O teste `CDU-09` falhava no Cenário 3 ao tentar devolver o cadastro como ADMIN. O backend retornava 403 Forbidden.
+
+**Causa Raiz:**
+A `SubprocessoAccessPolicy` exigia `RequisitoHierarquia.MESMA_UNIDADE` para a ação `DEVOLVER_CADASTRO`.
+Como o subprocesso estava na unidade superior (localização), o ADMIN (unidade raiz) não atendia ao requisito.
+
+**Solução:**
+Alterada a `SubprocessoAccessPolicy` para permitir que o ADMIN execute ações de devolução e aceite (`DEVOLVER_CADASTRO`, `ACEITAR_CADASTRO`, etc.) globalmente, ignorando a restrição de unidade.
+
+### CDU-10 (Regressão): Redirecionamento incorreto ao Voltar
+
+**Problema:**
+O teste `CDU-10` falhava novamente ao verificar a URL após clicar em "Voltar". O sistema redirecionava para `/painel`.
+A tentativa anterior de usar rota nomeada (`name: 'Subprocesso'`) aparentemente falhou na resolução correta dos parâmetros em runtime ou causou um redirecionamento inesperado.
+
+**Solução:**
+Alterado para utilizar navegação por string explícita: `router.push(\`/processo/${props.codProcesso}/${props.sigla}\`)`.
+Isso garante a construção correta da URL independentemente da resolução de nomes de rota.
+
 ## Aprendizados
 
 1.  **Navegação Nomeada:** Sempre preferir `router.push({ name: 'Rota', params: { ... } })` em vez de construir URLs manualmente. Isso evita erros de digitação e garante consistência com a configuração de rotas.

--- a/frontend/src/views/processo/AtividadesCadastroView.vue
+++ b/frontend/src/views/processo/AtividadesCadastroView.vue
@@ -9,7 +9,7 @@
               data-testid="btn-cad-atividades-voltar"
               title="Voltar"
               variant="link"
-              @click="() => { router.push({ name: 'Subprocesso', params: { codProcesso: props.codProcesso, siglaUnidade: props.sigla } }); }"
+              @click="() => { router.push(`/processo/${props.codProcesso}/${props.sigla}`); }"
           >
             <i aria-hidden="true" class="bi bi-arrow-left"/>
           </BButton>


### PR DESCRIPTION
- Fixed CDU-09 access control failure: Updated `SubprocessoAccessPolicy` to allow `ADMIN` users to execute global return/accept actions (`DEVOLVER_CADASTRO`, `ACEITAR_CADASTRO`, etc.) regardless of subprocess location.
- Fixed CDU-10 navigation regression: Updated `AtividadesCadastroView.vue` to use explicit string path for "Voltar" button instead of named route, avoiding redirects to `/painel`.
- Fixed `CDU10IntegrationTest`: Updated `deveExcluirHistoricoAposNovaDisponibilizacao` to explicitly create a `Movimentacao` entity, ensuring the location logic works correctly during the test.
- Updated `e2e-status.md` to reflect passing tests and document the fixes.

---
*PR created automatically by Jules for task [9350817357931643487](https://jules.google.com/task/9350817357931643487) started by @lgalvao*