### PR TITLE
Revert global ADMIN bypass in SubprocessoAccessPolicy

### DIFF
--- a/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
@@ -270,11 +270,6 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
         if (isAcaoAnaliseOuEscrita(acao)) {
             Unidade localizacao = obterUnidadeLocalizacao(sp);
 
-            // ADMIN: Permissão global para ações de devolução/aceite, ignorando a restrição de MESMA_UNIDADE
-            if (temPerfil(usuario, ADMIN) && isAcaoAdminGlobal(acao)) {
-                return true;
-            }
-
             if (!verificaHierarquia(usuario, localizacao, regras.requisitoHierarquia)) {
                 String motivo = obterMotivoNegacaoHierarquia(usuario, localizacao, regras.requisitoHierarquia);
                 log.info("Permissão negada por localização para {}: {}", usuario.getTituloEleitoral(), motivo);
@@ -301,14 +296,6 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
             EDITAR_REVISAO_CADASTRO, DISPONIBILIZAR_REVISAO_CADASTRO, DEVOLVER_REVISAO_CADASTRO, ACEITAR_REVISAO_CADASTRO, HOMOLOGAR_REVISAO_CADASTRO,
             EDITAR_MAPA, DISPONIBILIZAR_MAPA, APRESENTAR_SUGESTOES, VALIDAR_MAPA, DEVOLVER_MAPA, ACEITAR_MAPA, HOMOLOGAR_MAPA, AJUSTAR_MAPA,
             REALIZAR_AUTOAVALIACAO
-        ).contains(acao);
-    }
-
-    private boolean isAcaoAdminGlobal(Acao acao) {
-        return EnumSet.of(
-            DEVOLVER_CADASTRO, ACEITAR_CADASTRO,
-            DEVOLVER_REVISAO_CADASTRO, ACEITAR_REVISAO_CADASTRO,
-            DEVOLVER_MAPA, ACEITAR_MAPA
         ).contains(acao);
     }
 

--- a/backend/src/test/java/sgc/mapa/dto/ImpactoMapaResponseTest.java
+++ b/backend/src/test/java/sgc/mapa/dto/ImpactoMapaResponseTest.java
@@ -14,7 +14,7 @@ class ImpactoMapaResponseTest {
     @Test
     @DisplayName("Deve cobrir branches de criação de ImpactoMapaResponse")
     void deveCobrirBranches() {
-        AtividadeImpactadaDto atividade = AtividadeImpactadaDto.builder().build();
+        AtividadeImpactadaDto dto = AtividadeImpactadaDto.builder().build();
         // 1. Com impactos
         ImpactoMapaResponse d1 = ImpactoMapaResponse.builder()
                 .temImpactos(true)

--- a/backend/src/test/java/sgc/seguranca/acesso/SubprocessoAccessPolicyTest.java
+++ b/backend/src/test/java/sgc/seguranca/acesso/SubprocessoAccessPolicyTest.java
@@ -230,6 +230,22 @@ class SubprocessoAccessPolicyTest {
         assertTrue(policy.canExecute(uAdmin, Acao.VERIFICAR_IMPACTOS, spRevHom));
     }
 
+    @Test
+    @DisplayName("canExecute - Admin Devolver Cadastro - Deve Respeitar Hierarquia")
+    void canExecute_AdminDevolverCadastro_DeveRespeitarHierarquia() {
+        Usuario u = criarUsuario(Perfil.ADMIN, 99L); // Admin na unidade 99
+        Subprocesso sp = criarSubprocesso(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO, 1L); // SP na unidade 1
+
+        mockLocalizacao(sp, 1L); // SP está fisicamente na unidade 1
+
+        // Admin (99) tentando Devolver Cadastro (localizado em 1) -> DEVE SER FALSE
+        assertFalse(policy.canExecute(u, Acao.DEVOLVER_CADASTRO, sp));
+
+        // Admin (1) tentando Devolver Cadastro (localizado em 1) -> DEVE SER TRUE
+        Usuario uAdmin1 = criarUsuario(Perfil.ADMIN, 1L);
+        assertTrue(policy.canExecute(uAdmin1, Acao.DEVOLVER_CADASTRO, sp));
+    }
+
     private int contadorUsuarios = 0;
     
     private Usuario criarUsuario(Perfil perfil, Long codUnidade) {


### PR DESCRIPTION
Removes the incorrect logic that allowed ADMIN users to execute state-changing actions (e.g., DEVOLVER_CADASTRO) regardless of the subprocess location. These actions now strictly enforce the MESMA_UNIDADE hierarchy check. Also fixed a compilation error in ImpactoMapaResponseTest.java found during testing.

---
*PR created automatically by Jules for task [5629051045472608492](https://jules.google.com/task/5629051045472608492) started by @lgalvao*