### PR TITLE
Enforce strict hierarchy for ADMIN and fix E2E tests

### DIFF
--- a/backend/src/main/java/sgc/comum/dto/ComumDtos.java
+++ b/backend/src/main/java/sgc/comum/dto/ComumDtos.java
@@ -14,6 +14,10 @@ public final class ComumDtos {
         String texto
     ) {}
 
+    public record TextoOpcionalRequest(
+        String texto
+    ) {}
+
     public record JustificativaRequest(
         @NotBlank(message = "A justificativa é obrigatória")
         String justificativa

--- a/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
@@ -270,6 +270,11 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
         if (isAcaoAnaliseOuEscrita(acao)) {
             Unidade localizacao = obterUnidadeLocalizacao(sp);
 
+            // IMPORTANT: ADMIN DOES NOT have global write access. They must respect the subprocess location.
+            // If the subprocess is in a subordinate unit, it must be accepted/moved up to the ADMIN's unit
+            // before the ADMIN can perform state-changing actions.
+            // DO NOT ADD global access bypass for ADMIN here.
+
             if (!verificaHierarquia(usuario, localizacao, regras.requisitoHierarquia)) {
                 String motivo = obterMotivoNegacaoHierarquia(usuario, localizacao, regras.requisitoHierarquia);
                 log.info("Permissão negada por localização para {}: {}", usuario.getTituloEleitoral(), motivo);

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoCadastroController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoCadastroController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import sgc.analise.AnaliseFacade;
 import sgc.analise.dto.AnaliseHistoricoDto;
 import sgc.comum.dto.ComumDtos.JustificativaRequest;
+import sgc.comum.dto.ComumDtos.TextoOpcionalRequest;
 import sgc.comum.dto.ComumDtos.TextoRequest;
 import sgc.comum.erros.ErroAutenticacao;
 import sgc.comum.erros.ErroValidacao;
@@ -131,10 +132,11 @@ public class SubprocessoCadastroController {
     @Operation(summary = "Aceita o cadastro de atividades")
     public void aceitarCadastro(
             @PathVariable Long codigo,
-            @Valid @RequestBody TextoRequest request,
+            @Valid @RequestBody TextoOpcionalRequest request,
             @AuthenticationPrincipal @Nullable Object principal) {
         Usuario usuario = obterUsuarioAutenticado(principal);
-        String sanitizedObservacoes = Optional.of(UtilSanitizacao.sanitizar(request.texto()))
+        String sanitizedObservacoes = Optional.ofNullable(request.texto())
+                .map(UtilSanitizacao::sanitizar)
                 .orElse("");
 
         subprocessoFacade.aceitarCadastro(codigo, sanitizedObservacoes, usuario);
@@ -145,10 +147,11 @@ public class SubprocessoCadastroController {
     @Operation(summary = "Homologa o cadastro de atividades")
     public void homologarCadastro(
             @PathVariable Long codigo,
-            @Valid @RequestBody TextoRequest request,
+            @Valid @RequestBody TextoOpcionalRequest request,
             @AuthenticationPrincipal @Nullable Object principal) {
         Usuario usuario = obterUsuarioAutenticado(principal);
-        String sanitizedObservacoes = Optional.of(UtilSanitizacao.sanitizar(request.texto()))
+        String sanitizedObservacoes = Optional.ofNullable(request.texto())
+                .map(UtilSanitizacao::sanitizar)
                 .orElse("");
 
         subprocessoFacade.homologarCadastro(codigo, sanitizedObservacoes, usuario);
@@ -173,10 +176,11 @@ public class SubprocessoCadastroController {
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR')")
     public void aceitarRevisaoCadastro(
             @PathVariable Long codigo,
-            @Valid @RequestBody TextoRequest request,
+            @Valid @RequestBody TextoOpcionalRequest request,
             @AuthenticationPrincipal @Nullable Object principal) {
         Usuario usuario = obterUsuarioAutenticado(principal);
-        String sanitizedObservacoes = Optional.of(UtilSanitizacao.sanitizar(request.texto()))
+        String sanitizedObservacoes = Optional.ofNullable(request.texto())
+                .map(UtilSanitizacao::sanitizar)
                 .orElse("");
 
         subprocessoFacade.aceitarRevisaoCadastro(codigo, sanitizedObservacoes, usuario);
@@ -187,10 +191,11 @@ public class SubprocessoCadastroController {
     @PreAuthorize("hasRole('ADMIN')")
     public void homologarRevisaoCadastro(
             @PathVariable Long codigo,
-            @Valid @RequestBody TextoRequest request,
+            @Valid @RequestBody TextoOpcionalRequest request,
             @AuthenticationPrincipal @Nullable Object principal) {
         Usuario usuario = obterUsuarioAutenticado(principal);
-        String sanitizedObservacoes = Optional.of(UtilSanitizacao.sanitizar(request.texto()))
+        String sanitizedObservacoes = Optional.ofNullable(request.texto())
+                .map(UtilSanitizacao::sanitizar)
                 .orElse("");
 
         subprocessoFacade.homologarRevisaoCadastro(codigo, sanitizedObservacoes, usuario);

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoCadastroControllerTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoCadastroControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import sgc.analise.AnaliseFacade;
 import sgc.analise.dto.AnaliseHistoricoDto;
 import sgc.comum.dto.ComumDtos.JustificativaRequest;
+import sgc.comum.dto.ComumDtos.TextoOpcionalRequest;
 import sgc.comum.dto.ComumDtos.TextoRequest;
 import sgc.comum.erros.ErroAutenticacao;
 import sgc.comum.erros.RestExceptionHandler;
@@ -233,7 +234,7 @@ class SubprocessoCadastroControllerTest {
             when(organizacaoFacade.extrairTituloUsuario(any())).thenReturn("123");
             when(organizacaoFacade.buscarPorLogin("123")).thenReturn(usuario);
 
-            TextoRequest request = new TextoRequest("Aprovado");
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Aprovado");
 
             // Act & Assert
             mockMvc.perform(post("/api/subprocessos/1/aceitar-cadastro")
@@ -243,6 +244,27 @@ class SubprocessoCadastroControllerTest {
                     .andExpect(status().isOk());
 
             verify(subprocessoFacade).aceitarCadastro(eq(1L), anyString(), eq(usuario));
+        }
+
+        @Test
+        @DisplayName("deve aceitar cadastro sem observações")
+        @WithMockUser(roles = "GESTOR")
+        void deveAceitarCadastroSemTexto() throws Exception {
+            // Arrange
+            Usuario usuario = new Usuario();
+            when(organizacaoFacade.extrairTituloUsuario(any())).thenReturn("123");
+            when(organizacaoFacade.buscarPorLogin("123")).thenReturn(usuario);
+
+            TextoOpcionalRequest request = new TextoOpcionalRequest(null);
+
+            // Act & Assert
+            mockMvc.perform(post("/api/subprocessos/1/aceitar-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(subprocessoFacade).aceitarCadastro(eq(1L), eq(""), eq(usuario));
         }
     }
 
@@ -258,7 +280,7 @@ class SubprocessoCadastroControllerTest {
             when(organizacaoFacade.extrairTituloUsuario(any())).thenReturn("123");
             when(organizacaoFacade.buscarPorLogin("123")).thenReturn(usuario);
 
-            TextoRequest request = new TextoRequest("Homologado");
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Homologado");
 
             // Act & Assert
             mockMvc.perform(post("/api/subprocessos/1/homologar-cadastro")
@@ -308,7 +330,7 @@ class SubprocessoCadastroControllerTest {
             when(organizacaoFacade.extrairTituloUsuario(any())).thenReturn("123");
             when(organizacaoFacade.buscarPorLogin("123")).thenReturn(usuario);
 
-            TextoRequest request = new TextoRequest("Revisão aceita");
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Revisão aceita");
 
             // Act & Assert
             mockMvc.perform(post("/api/subprocessos/1/aceitar-revisao-cadastro")
@@ -333,7 +355,7 @@ class SubprocessoCadastroControllerTest {
             when(organizacaoFacade.extrairTituloUsuario(any())).thenReturn("123");
             when(organizacaoFacade.buscarPorLogin("123")).thenReturn(usuario);
 
-            TextoRequest request = new TextoRequest("Homologado");
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Homologado");
 
             // Act & Assert
             mockMvc.perform(post("/api/subprocessos/1/homologar-revisao-cadastro")

--- a/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoBulkOperationsPbtTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoBulkOperationsPbtTest.java
@@ -10,6 +10,7 @@ import sgc.organizacao.UsuarioFacade;
 import sgc.organizacao.model.Unidade;
 import sgc.organizacao.model.Usuario;
 import sgc.seguranca.acesso.AccessControlService;
+import sgc.subprocesso.model.MovimentacaoRepo;
 import sgc.subprocesso.model.SituacaoSubprocesso;
 import sgc.subprocesso.model.Subprocesso;
 import sgc.subprocesso.model.SubprocessoRepo;
@@ -29,6 +30,7 @@ class SubprocessoBulkOperationsPbtTest {
                                               @ForAll int indiceFalha) {
         // Mock dependencies
         SubprocessoRepo subprocessoRepo = mock(SubprocessoRepo.class);
+        MovimentacaoRepo movimentacaoRepo = mock(MovimentacaoRepo.class);
         SubprocessoCrudService crudService = mock(SubprocessoCrudService.class);
         AlertaFacade alertaService = mock(AlertaFacade.class);
         UnidadeFacade unidadeService = mock(UnidadeFacade.class);
@@ -40,7 +42,7 @@ class SubprocessoBulkOperationsPbtTest {
         AccessControlService accessControlService = mock(AccessControlService.class);
 
         SubprocessoCadastroWorkflowService service = new SubprocessoCadastroWorkflowService(
-                subprocessoRepo, crudService, alertaService, unidadeService, 
+                subprocessoRepo, movimentacaoRepo, crudService, alertaService, unidadeService,
                 transicaoService, analiseFacade, usuarioServiceFacade, 
                 validacaoService, impactoMapaService, accessControlService
         );

--- a/e2e/cdu-09.spec.ts
+++ b/e2e/cdu-09.spec.ts
@@ -10,8 +10,8 @@ import {
 } from './helpers/helpers-atividades.js';
 import {
     abrirHistoricoAnalise,
-    acessarSubprocessoAdmin,
-    acessarSubprocessoChefeDireto
+    acessarSubprocessoChefeDireto,
+    acessarSubprocessoGestor
 } from './helpers/helpers-analise.js';
 import {fazerLogout, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
 
@@ -109,9 +109,9 @@ test.describe.serial('CDU-09 - Disponibilizar cadastro de atividades e conhecime
         await expect(page.getByTestId('subprocesso-header__txt-situacao')).toHaveText(/Cadastro disponibilizado/i);
     });
 
-    test('Cenario 3: Devolucao e Historico de Analise', async ({page, autenticadoComoAdmin}) => {
-        // 1. Admin devolve o cadastro
-        await acessarSubprocessoAdmin(page, descProcesso, UNIDADE_ALVO);
+    test('Cenario 3: Devolucao e Historico de Analise', async ({page, autenticadoComoGestorCoord22}) => {
+        // 1. Gestor (Coord 22) devolve o cadastro
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
 
         // Entrar no cadastro de atividades (visualização)
         await navegarParaAtividadesVisualizacao(page);

--- a/e2e/cdu-16.spec.ts
+++ b/e2e/cdu-16.spec.ts
@@ -11,8 +11,15 @@ import {
     removerAtividade
 } from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
-import {acessarSubprocessoAdmin, acessarSubprocessoChefeDireto} from './helpers/helpers-analise.js';
+import {
+    aceitarCadastroMapeamento,
+    aceitarRevisao,
+    acessarSubprocessoAdmin,
+    acessarSubprocessoChefeDireto,
+    acessarSubprocessoGestor
+} from './helpers/helpers-analise.js';
 import {verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {loginComPerfil} from './helpers/helpers-auth.js';
 
 async function verificarPaginaSubprocesso(page: Page, unidade: string) {
     await expect(page).toHaveURL(new RegExp(String.raw`/processo/\d+/${unidade}$`));
@@ -86,6 +93,19 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
         await verificarPaginaPainel(page);
     });
 
+    test('Preparacao 3a: Gestor COORD_21 aceita cadastro', async ({page, autenticadoComoGestorCoord21}) => {
+        await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 3b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
     test('Preparacao 3: Admin homologa cadastro', async ({page, autenticadoComoAdmin}) => {
         
 
@@ -126,6 +146,23 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
         // Validação: confirmar redirecionamento para Painel (CDU-19 passo 8)
         await verificarPaginaPainel(page);
         await expect(page.getByText(/Mapa validado/i).first()).toBeVisible();
+    });
+
+    test('Preparacao 6a: Gestor COORD_21 aceita mapa', async ({page, autenticadoComoGestorCoord21}) => {
+        await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
+        await navegarParaMapa(page);
+        await page.getByTestId('btn-mapa-homologar-aceite').click();
+        await page.getByTestId('btn-aceite-mapa-confirmar').click();
+        await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 6b: Gestor SECRETARIA_2 aceita mapa', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
+        await navegarParaMapa(page);
+        await page.getByTestId('btn-mapa-homologar-aceite').click();
+        await page.getByTestId('btn-aceite-mapa-confirmar').click();
+        await verificarPaginaPainel(page);
     });
 
     test('Preparacao 6: Admin homologa mapa e finaliza processo de mapeamento', async ({page, autenticadoComoAdmin}) => {
@@ -202,6 +239,19 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
 
         await expect(page.getByText(/Revisão do cadastro de atividades disponibilizada/i).first()).toBeVisible();
         await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 9a: Gestor COORD_21 aceita revisão', async ({page, autenticadoComoGestorCoord21}) => {
+        await acessarSubprocessoGestor(page, descProcessoRevisao, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarRevisao(page);
+    });
+
+    test('Preparacao 9b: Gestor SECRETARIA_2 aceita revisão', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcessoRevisao, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarRevisao(page);
     });
 
     test('Preparacao 9: Admin homologa revisão do cadastro', async ({page}) => {

--- a/e2e/helpers/helpers-analise.ts
+++ b/e2e/helpers/helpers-analise.ts
@@ -282,14 +282,14 @@ export async function homologarCadastroRevisaoComImpacto(page: Page) {
     await page.getByTestId('inp-aceite-cadastro-obs').fill('Homologado sem ressalvas');
 
     await page.getByTestId('btn-aceite-cadastro-confirmar').click();
-    await expect(page.getByText(/Revisão homologada/i).first()).toBeVisible();
+    await expect(page.getByText(/Revisão d[oe] cadastro homologada/i).first()).toBeVisible();
 
     // Verifica redirecionamento para tela de detalhes do subprocesso
     await expect(page).toHaveURL(/\/processo\/\d+\/\w+$/);
 
     // Verificar situação após homologação
     await expect(page.getByTestId('subprocesso-header__txt-situacao'))
-        .toHaveText(/Revisão homologada/i);
+        .toHaveText(/Revisão d[oe] cadastro homologada/i);
 }
 
 /**

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -53,7 +53,7 @@ export function formatSituacaoSubprocesso(situacao: SituacaoSubprocesso | string
     [SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO]: 'Mapa homologado',
     [SituacaoSubprocesso.REVISAO_CADASTRO_EM_ANDAMENTO]: 'Revisão em andamento',
     [SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA]: 'Revisão do cadastro disponibilizada',
-    [SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA]: 'Revisão homologada',
+    [SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA]: 'Revisão do cadastro homologada',
     [SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO]: 'Mapa ajustado',
     [SituacaoSubprocesso.REVISAO_MAPA_DISPONIBILIZADO]: 'Mapa disponibilizado',
     [SituacaoSubprocesso.REVISAO_MAPA_COM_SUGESTOES]: 'Mapa com sugestões',


### PR DESCRIPTION
Enforced strict hierarchy checks for ADMIN users, preventing them from bypassing location rules for state-changing actions. Updated E2E tests to reflect this requirement by simulating the full approval chain. Also relaxed validation for observation fields in acceptance/homologation actions to allow empty comments.

---
*PR created automatically by Jules for task [7683929037056762495](https://jules.google.com/task/7683929037056762495) started by @lgalvao*