### PR TITLE
Fix Admin-only access for Map Editing and Workflow transitions

### DIFF
--- a/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
@@ -157,7 +157,7 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
                     RequisitoHierarquia.MESMA_OU_SUBORDINADA)),
 
             Map.entry(EDITAR_MAPA, new RegrasAcao(
-                    EnumSet.of(ADMIN, GESTOR, CHEFE),
+                    EnumSet.of(ADMIN),
                     EnumSet.of(NAO_INICIADO, MAPEAMENTO_CADASTRO_EM_ANDAMENTO,
                             MAPEAMENTO_CADASTRO_HOMOLOGADO, MAPEAMENTO_MAPA_CRIADO,
                             MAPEAMENTO_MAPA_COM_SUGESTOES, REVISAO_CADASTRO_EM_ANDAMENTO,
@@ -167,7 +167,7 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
                     RequisitoHierarquia.MESMA_UNIDADE)),
 
             Map.entry(DISPONIBILIZAR_MAPA, new RegrasAcao(
-                    EnumSet.of(ADMIN, GESTOR, CHEFE),
+                    EnumSet.of(ADMIN),
                     EnumSet.of(MAPEAMENTO_CADASTRO_HOMOLOGADO, MAPEAMENTO_MAPA_CRIADO,
                             MAPEAMENTO_MAPA_COM_SUGESTOES, REVISAO_CADASTRO_HOMOLOGADA,
                             REVISAO_MAPA_AJUSTADO, REVISAO_MAPA_COM_SUGESTOES),

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoMapaController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoMapaController.java
@@ -51,7 +51,7 @@ public class SubprocessoMapaController {
     }
 
     @PostMapping("/{codigo}/disponibilizar-mapa")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Disponibiliza o mapa para validação")
     public ResponseEntity<MensagemResponse> disponibilizarMapa(
             @PathVariable Long codigo,

--- a/backend/src/main/java/sgc/subprocesso/service/workflow/SubprocessoCadastroWorkflowService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/workflow/SubprocessoCadastroWorkflowService.java
@@ -253,7 +253,7 @@ public class SubprocessoCadastroWorkflowService {
                 .sp(sp)
                 .tipo(TipoTransicao.CADASTRO_HOMOLOGADO)
                 .origem(admin)
-                .destino(sp.getUnidade())
+                .destino(admin)
                 .usuario(usuario)
                 .observacoes(observacoes)
                 .build());
@@ -326,7 +326,7 @@ public class SubprocessoCadastroWorkflowService {
                     .sp(sp)
                     .tipo(TipoTransicao.REVISAO_CADASTRO_HOMOLOGADA)
                     .origem(admin)
-                    .destino(sp.getUnidade())
+                    .destino(admin)
                     .usuario(usuario)
                     .observacoes(observacoes)
                     .build());

--- a/e2e/cdu-33.spec.ts
+++ b/e2e/cdu-33.spec.ts
@@ -70,15 +70,16 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
         await homologarCadastroMapeamento(page);
         await fazerLogout(page);
 
-        // 6. Chefe cria mapa e disponibiliza
-        await login(page, USUARIOS.CHEFE_SECAO_212.titulo, USUARIOS.CHEFE_SECAO_212.senha);
-        await acessarSubprocessoChefeDireto(page, descMapeamento);
+        // 6. Admin cria mapa e disponibiliza
+        await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
+        await acessarSubprocessoChefeDireto(page, descMapeamento, UNIDADE_ALVO);
         await navegarParaMapa(page);
         await criarCompetencia(page, `Comp Map ${timestamp}`, [`Ativ Map ${timestamp}`]);
         await disponibilizarMapa(page, '2030-12-31');
+        await fazerLogout(page);
 
-        // 7. Chefe valida mapa (já logado)
-        // Re-navegar pois disponibilizar redireciona para painel
+        // 7. Chefe valida mapa
+        await login(page, USUARIOS.CHEFE_SECAO_212.titulo, USUARIOS.CHEFE_SECAO_212.senha);
         await acessarSubprocessoChefeDireto(page, descMapeamento);
         await navegarParaMapa(page);
         await page.getByTestId('btn-mapa-validar').click();


### PR DESCRIPTION
This PR fixes a regression where map editing and availability actions were incorrectly opened to CHEFE and GESTOR profiles and the workflow failed to move the subprocess to the ADMIN unit for the map creation phase.

Changes:
1.  **Workflow**: `HOMOLOGAR_CADASTRO` and `REVISAO_CADASTRO_HOMOLOGADA` now set the destination to `ADMIN`. This allows the Admin user (who resides in the ADMIN unit) to edit the map, satisfying the `MESMA_UNIDADE` access policy.
2.  **Access Policy**: Removed `CHEFE` and `GESTOR` from `EDITAR_MAPA` and `DISPONIBILIZAR_MAPA`. These are strictly Admin responsibilities as per requirements.
3.  **Security**: Reverted `disponibilizarMapa` endpoint security to require `ROLE_ADMIN`.
4.  **Tests**: Updated `cdu-33.spec.ts` to use the Admin user for map creation steps, ensuring the test reflects the correct actor-action mapping.

---
*PR created automatically by Jules for task [6930868242012341552](https://jules.google.com/task/6930868242012341552) started by @lgalvao*