### PR TITLE
Fix CDU-13 timeout by optimizing Subprocesso location check

### DIFF
--- a/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
+++ b/backend/src/main/java/sgc/seguranca/acesso/SubprocessoAccessPolicy.java
@@ -305,12 +305,20 @@ public class SubprocessoAccessPolicy extends AbstractAccessPolicy<Subprocesso> {
     }
 
     private Unidade obterUnidadeLocalizacao(Subprocesso sp) {
+        if (sp.getLocalizacaoAtualCache() != null) {
+            return sp.getLocalizacaoAtualCache();
+        }
+
         if (sp.getCodigo() == null) {
             return sp.getUnidade();
         }
-        return movimentacaoRepo.findFirstBySubprocessoCodigoOrderByDataHoraDesc(sp.getCodigo())
+
+        Unidade localizacao = movimentacaoRepo.findFirstBySubprocessoCodigoOrderByDataHoraDesc(sp.getCodigo())
                 .map(m -> m.getUnidadeDestino() != null ? m.getUnidadeDestino() : sp.getUnidade())
                 .orElse(sp.getUnidade());
+
+        sp.setLocalizacaoAtualCache(localizacao);
+        return localizacao;
     }
 
     /**

--- a/backend/src/main/java/sgc/subprocesso/model/Subprocesso.java
+++ b/backend/src/main/java/sgc/subprocesso/model/Subprocesso.java
@@ -1,5 +1,6 @@
 package sgc.subprocesso.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import jakarta.persistence.*;
@@ -66,6 +67,10 @@ public class Subprocesso extends EntidadeBase {
     @Column(name = "situacao", length = 50, nullable = false)
     @lombok.Builder.Default
     private SituacaoSubprocesso situacao = SituacaoSubprocesso.NAO_INICIADO;
+
+    @Transient
+    @JsonIgnore
+    private Unidade localizacaoAtualCache;
 
     @JsonView({ComumViews.Publica.class, SubprocessoViews.Publica.class, MapaViews.Publica.class})
     public Set<Atividade> getAtividades() {


### PR DESCRIPTION
Optimized `SubprocessoAccessPolicy` to use a transient cache in `Subprocesso` entity, reducing N+1 database queries during permission calculation. This resolved timeouts in E2E test CDU-13.

---
*PR created automatically by Jules for task [7539927478105197600](https://jules.google.com/task/7539927478105197600) started by @lgalvao*