### PR TITLE
Fix E2E tests access control and workflow steps

### DIFF
--- a/e2e/cdu-17.spec.ts
+++ b/e2e/cdu-17.spec.ts
@@ -8,6 +8,8 @@ import {
 } from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
 import {navegarParaSubprocesso, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
+import {loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 
 test.describe.serial('CDU-17 - Disponibilizar mapa de competências', () => {
     const UNIDADE_ALVO = 'SECAO_211';
@@ -69,6 +71,19 @@ test.describe.serial('CDU-17 - Disponibilizar mapa de competências', () => {
 
         await expect(page.getByText(/Cadastro de atividades disponibilizado/i).first()).toBeVisible();
         await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 2a: Gestor COORD_21 aceita cadastro', async ({page, autenticadoComoGestorCoord21}) => {
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
     });
 
     test('Preparacao 3: Admin homologa cadastro', async ({page, autenticadoComoAdmin}) => {

--- a/e2e/cdu-19.spec.ts
+++ b/e2e/cdu-19.spec.ts
@@ -1,8 +1,15 @@
 import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcesso} from './helpers/helpers-processos.js';
-import {adicionarAtividade, adicionarConhecimento, navegarParaAtividades} from './helpers/helpers-atividades.js';
+import {
+    adicionarAtividade,
+    adicionarConhecimento,
+    navegarParaAtividades,
+    navegarParaAtividadesVisualizacao
+} from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
 import {navegarParaSubprocesso, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
+import {loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 
 test.describe.serial('CDU-19 - Validar mapa de competências', () => {
     const UNIDADE_ALVO = 'SECAO_221';
@@ -62,6 +69,19 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
         await verificarPaginaPainel(page);
     });
 
+    test('Preparacao 2a: Gestor COORD_22 aceita cadastro', async ({page, autenticadoComoGestorCoord22}) => {
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
     test('Preparacao 3: Admin homologa cadastro', async ({page, autenticadoComoAdmin}) => {
         
 
@@ -109,7 +129,7 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
             .toHaveText(/Mapa disponibilizado/i);
 
         // Passo 1: Clica no card Mapa de competências
-        await page.getByTestId('card-subprocesso-mapa').click();
+        await navegarParaMapa(page);
 
         // Passo 2: Sistema mostra tela de Visualização de mapa
         await expect(page.getByText('Mapa de competências técnicas')).toBeVisible();
@@ -124,7 +144,7 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
         
 
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
-        await page.getByTestId('card-subprocesso-mapa').click();
+        await navegarParaMapa(page);
 
         // Clicar em Validar
         await page.getByTestId('btn-mapa-validar').click();
@@ -147,7 +167,7 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
         
 
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
-        await page.getByTestId('card-subprocesso-mapa').click();
+        await navegarParaMapa(page);
 
         // Passo 5: Clicar em Validar
         await page.getByTestId('btn-mapa-validar').click();

--- a/e2e/cdu-20.spec.ts
+++ b/e2e/cdu-20.spec.ts
@@ -8,8 +8,9 @@ import {
     navegarParaAtividadesVisualizacao
 } from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
-import {login, USUARIOS} from './helpers/helpers-auth.js';
+import {login, loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 import {
+    aceitarCadastroMapeamento,
     acessarSubprocessoChefeDireto,
     acessarSubprocessoGestor,
     homologarCadastroMapeamento
@@ -71,6 +72,20 @@ test.describe.serial('CDU-20 - Analisar validação de mapa de competências', (
 
         await expect(page.getByText(/Cadastro de atividades disponibilizado/i).first()).toBeVisible();
         await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 2a: Gestor COORD_22 aceita cadastro', async ({page}) => {
+        await login(page, USUARIOS.GESTOR_COORD_22.titulo, USUARIOS.GESTOR_COORD_22.senha);
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
     });
 
     test('Preparacao 3: Admin homologa cadastro', async ({page}) => {
@@ -183,6 +198,20 @@ test.describe.serial('CDU-20 - Analisar validação de mapa de competências', (
 
         // Após aceite do GESTOR, o mapa ainda está validado mas agora no nível do ADMIN
         await expect(page.getByText(/Mapa validado/i).first()).toBeVisible();
+    });
+
+    test('Cenario 4b: Gestor SECRETARIA_2 aceita mapa', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaMapa(page);
+        await page.getByTestId('btn-mapa-homologar-aceite').click();
+
+        const modal = page.getByRole('dialog');
+        await expect(modal).toBeVisible();
+        await page.getByTestId('btn-aceite-mapa-confirmar').click();
+
+        await verificarPaginaPainel(page);
+        await expect(page.getByText(/Aceite registrado/i).first()).toBeVisible();
     });
 
     test('Cenario 5: ADMIN homologa o mapa', async ({page}) => {

--- a/e2e/cdu-21.spec.ts
+++ b/e2e/cdu-21.spec.ts
@@ -1,13 +1,20 @@
 import type {Page} from '@playwright/test';
 import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcesso} from './helpers/helpers-processos.js';
-import {adicionarAtividade, adicionarConhecimento, navegarParaAtividades} from './helpers/helpers-atividades.js';
+import {
+    adicionarAtividade,
+    adicionarConhecimento,
+    navegarParaAtividades,
+    navegarParaAtividadesVisualizacao
+} from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
 import {navegarParaSubprocesso, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
+import {loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 
 async function acessarSubprocessoChefe(page: Page, descProcesso: string) {
     await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
-    await page.getByTestId('card-subprocesso-mapa').click();
+    await navegarParaMapa(page);
 }
 
 test.describe.serial('CDU-21 - Finalizar processo de mapeamento ou de revisão', () => {
@@ -68,6 +75,19 @@ test.describe.serial('CDU-21 - Finalizar processo de mapeamento ou de revisão',
         await verificarPaginaPainel(page);
     });
 
+    test('Preparacao 2a: Gestor COORD_22 aceita cadastro', async ({page, autenticadoComoGestorCoord22}) => {
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
     test('Preparacao 3: Admin homologa cadastro', async ({page, autenticadoComoAdmin}) => {
         
 
@@ -115,7 +135,20 @@ test.describe.serial('CDU-21 - Finalizar processo de mapeamento ou de revisão',
 
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
         await navegarParaSubprocesso(page, 'SECAO_221');
-        await page.getByTestId('card-subprocesso-mapa').click();
+        await navegarParaMapa(page);
+
+        await page.getByTestId('btn-mapa-homologar-aceite').click();
+        const modal = page.getByRole('dialog');
+        await expect(modal).toBeVisible();
+        await page.getByTestId('btn-aceite-mapa-confirmar').click();
+
+        await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 6b: Gestor SECRETARIA_2 aceita mapa', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
+        await navegarParaMapa(page);
 
         await page.getByTestId('btn-mapa-homologar-aceite').click();
         const modal = page.getByRole('dialog');
@@ -130,7 +163,7 @@ test.describe.serial('CDU-21 - Finalizar processo de mapeamento ou de revisão',
 
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
         await navegarParaSubprocesso(page, 'SECAO_221');
-        await page.getByTestId('card-subprocesso-mapa').click();
+        await navegarParaMapa(page);
 
         await page.getByTestId('btn-mapa-homologar-aceite').click();
         const modal = page.getByRole('dialog');

--- a/e2e/cdu-23.spec.ts
+++ b/e2e/cdu-23.spec.ts
@@ -1,7 +1,14 @@
 import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcesso} from './helpers/helpers-processos.js';
-import {adicionarAtividade, adicionarConhecimento, navegarParaAtividades} from './helpers/helpers-atividades.js';
+import {
+    adicionarAtividade,
+    adicionarConhecimento,
+    navegarParaAtividades,
+    navegarParaAtividadesVisualizacao
+} from './helpers/helpers-atividades.js';
 import {verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
+import {login, loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 
 /**
  * CDU-23 - Homologar cadastros em bloco
@@ -70,6 +77,20 @@ test.describe.serial('CDU-23 - Homologar cadastros em bloco', () => {
         await page.getByTestId('btn-confirmar-disponibilizacao').click();
 
         await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 2a: Gestor COORD_22 aceita cadastro', async ({page}) => {
+        await login(page, USUARIOS.GESTOR_COORD_22.titulo, USUARIOS.GESTOR_COORD_22.senha);
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
     });
 
     // ========================================================================

--- a/e2e/cdu-24.spec.ts
+++ b/e2e/cdu-24.spec.ts
@@ -1,8 +1,15 @@
 import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcesso} from './helpers/helpers-processos.js';
-import {adicionarAtividade, adicionarConhecimento, navegarParaAtividades} from './helpers/helpers-atividades.js';
+import {
+    adicionarAtividade,
+    adicionarConhecimento,
+    navegarParaAtividades,
+    navegarParaAtividadesVisualizacao
+} from './helpers/helpers-atividades.js';
 import {criarCompetencia, navegarParaMapa} from './helpers/helpers-mapas.js';
 import {navegarParaSubprocesso, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
+import {login, loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 
 /**
  * CDU-24 - Disponibilizar mapas de competências em bloco
@@ -71,6 +78,20 @@ test.describe.serial('CDU-24 - Disponibilizar mapas em bloco', () => {
         await page.getByTestId('btn-confirmar-disponibilizacao').click();
 
         await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 2a: Gestor COORD_22 aceita cadastro', async ({page}) => {
+        await login(page, USUARIOS.GESTOR_COORD_22.titulo, USUARIOS.GESTOR_COORD_22.senha);
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
     });
 
     test('Preparacao 3: Admin homologa cadastro e cria competências', async ({page, autenticadoComoAdmin}) => {

--- a/e2e/cdu-25.spec.ts
+++ b/e2e/cdu-25.spec.ts
@@ -1,14 +1,20 @@
 import type {Page} from '@playwright/test';
 import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcesso} from './helpers/helpers-processos.js';
-import {adicionarAtividade, adicionarConhecimento, navegarParaAtividades} from './helpers/helpers-atividades.js';
+import {
+    adicionarAtividade,
+    adicionarConhecimento,
+    navegarParaAtividades,
+    navegarParaAtividadesVisualizacao
+} from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
 import {navegarParaSubprocesso, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
-import {login, USUARIOS} from './helpers/helpers-auth.js';
+import {login, loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
 
 async function acessarSubprocessoChefe(page: Page, descProcesso: string) {
     await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
-    await page.getByTestId('card-subprocesso-mapa').click();
+    await navegarParaMapa(page);
 }
 
 /**
@@ -80,6 +86,20 @@ test.describe.serial('CDU-25 - Aceitar validação de mapas em bloco', () => {
         await page.getByTestId('btn-confirmar-disponibilizacao').click();
 
         await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 2a: Gestor COORD_21 aceita cadastro', async ({page}) => {
+        await login(page, USUARIOS.GESTOR_COORD_21.titulo, USUARIOS.GESTOR_COORD_21.senha);
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
     });
 
     test('Preparacao 3: Admin homologa cadastro e cria mapa', async ({page, autenticadoComoAdmin}) => {

--- a/e2e/cdu-26.spec.ts
+++ b/e2e/cdu-26.spec.ts
@@ -1,13 +1,20 @@
 import type {Page} from '@playwright/test';
 import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcesso} from './helpers/helpers-processos.js';
-import {adicionarAtividade, adicionarConhecimento, navegarParaAtividades} from './helpers/helpers-atividades.js';
+import {
+    adicionarAtividade,
+    adicionarConhecimento,
+    navegarParaAtividades,
+    navegarParaAtividadesVisualizacao
+} from './helpers/helpers-atividades.js';
 import {criarCompetencia, disponibilizarMapa, navegarParaMapa} from './helpers/helpers-mapas.js';
 import {navegarParaSubprocesso, verificarPaginaPainel} from './helpers/helpers-navegacao.js';
+import {aceitarCadastroMapeamento, acessarSubprocessoGestor} from './helpers/helpers-analise.js';
+import {login, loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
 
 async function acessarSubprocessoChefe(page: Page, descProcesso: string) {
     await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
-    await page.getByTestId('card-subprocesso-mapa').click();
+    await navegarParaMapa(page);
 }
 
 /**
@@ -79,6 +86,20 @@ test.describe.serial('CDU-26 - Homologar validação de mapas em bloco', () => {
         await verificarPaginaPainel(page);
     });
 
+    test('Preparacao 2a: Gestor COORD_22 aceita cadastro', async ({page}) => {
+        await login(page, USUARIOS.GESTOR_COORD_22.titulo, USUARIOS.GESTOR_COORD_22.senha);
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
+    test('Preparacao 2b: Gestor SECRETARIA_2 aceita cadastro', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaAtividadesVisualizacao(page);
+        await aceitarCadastroMapeamento(page);
+    });
+
     test('Preparacao 3: Admin homologa cadastro e cria mapa', async ({page, autenticadoComoAdmin}) => {
         
 
@@ -104,6 +125,30 @@ test.describe.serial('CDU-26 - Homologar validação de mapas em bloco', () => {
         await page.getByTestId('btn-mapa-validar').click();
         await expect(page.getByRole('dialog')).toBeVisible();
         await page.getByTestId('btn-validar-mapa-confirmar').click();
+
+        await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 4a: Gestor COORD_22 aceita mapa', async ({page}) => {
+        await login(page, USUARIOS.GESTOR_COORD_22.titulo, USUARIOS.GESTOR_COORD_22.senha);
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaMapa(page);
+
+        await page.getByTestId('btn-mapa-homologar-aceite').click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+        await page.getByTestId('btn-aceite-mapa-confirmar').click();
+
+        await verificarPaginaPainel(page);
+    });
+
+    test('Preparacao 4b: Gestor SECRETARIA_2 aceita mapa', async ({page}) => {
+        await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
+        await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
+        await navegarParaMapa(page);
+
+        await page.getByTestId('btn-mapa-homologar-aceite').click();
+        await expect(page.getByRole('dialog')).toBeVisible();
+        await page.getByTestId('btn-aceite-mapa-confirmar').click();
 
         await verificarPaginaPainel(page);
     });


### PR DESCRIPTION
Updated E2E tests (CDU-17, 19, 20, 21, 23, 24, 25, 26) to include intermediate workflow steps (GESTOR acceptance) required for the Admin to homologate subprocesses. This aligns the tests with the strict location-based access control rules enforced by `SubprocessoAccessPolicy`. Also updated `acessarSubprocessoChefe` helper to use `navegarParaMapa` for robust element selection.

---
*PR created automatically by Jules for task [9349139235215376915](https://jules.google.com/task/9349139235215376915) started by @lgalvao*