### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/views/__tests__/VisAtividades.spec.ts
+++ b/frontend/src/views/__tests__/VisAtividades.spec.ts
@@ -162,6 +162,8 @@ describe("VisAtividades.vue", () => {
     const mountComponent = (initialState: any = {}, accessOverrides: Record<string, any> = {}) => {
         vi.spyOn(useAcessoModule, 'useAcesso').mockReturnValue({
             podeHomologarCadastro: ref(true),
+            podeAceitarCadastro: ref(true),
+            podeDevolverCadastro: ref(true),
             podeVisualizarImpacto: ref(true),
             ...accessOverrides
         } as any);


### PR DESCRIPTION
This change fixes 6 failing unit tests in `frontend/src/views/__tests__/VisAtividades.spec.ts` by updating the `useAcesso` hook mock to include all necessary permissions. It also ensures the frontend passes all quality checks (typecheck, lint, and unit tests).

---
*PR created automatically by Jules for task [13207317897089475038](https://jules.google.com/task/13207317897089475038) started by @lgalvao*