### PR TITLE
Cleanup comments and fix build

### DIFF
--- a/backend/src/main/java/sgc/analise/AnaliseController.java
+++ b/backend/src/main/java/sgc/analise/AnaliseController.java
@@ -60,7 +60,6 @@ public class AnaliseController {
         return criarAnalise(codSubprocesso, request, TipoAnalise.VALIDACAO);
     }
 
-    // TODO essa logica deveria estar no facade o service! Inclusive ja tem um quase igual la.
     private AnaliseHistoricoDto criarAnalise(Long codSubprocesso, CriarAnaliseRequest request, TipoAnalise tipo) {
         Subprocesso sp = subprocessoFacade.buscarSubprocesso(codSubprocesso);
         String obs = StringUtils.stripToEmpty(request.observacoes());

--- a/backend/src/main/java/sgc/analise/AnaliseFacade.java
+++ b/backend/src/main/java/sgc/analise/AnaliseFacade.java
@@ -33,7 +33,6 @@ public class AnaliseFacade {
     /**
      * Lista todas as análises de um determinado tipoAnalise para um subprocesso específico.
      *
-     * @param codSubprocesso O código do subprocesso.
      * @param tipoAnalise    O tipo de análise a ser filtrada (e.g., CADASTRO, VALIDACAO).
      * @return Uma lista de {@link Analise} ordenada pela data e hora em ordem decrescente.
      */
@@ -81,7 +80,6 @@ public class AnaliseFacade {
     /**
      * Cria e persiste uma análise com base nos dados fornecidos.
      *
-     * @param subprocesso A entidade do subprocesso.
      * @param command     O comando contendo todas as informações necessárias para criar a análise.
      * @return A entidade {@link Analise} que foi criada e salva no banco de dados.
      */
@@ -110,8 +108,6 @@ public class AnaliseFacade {
      * análises dependentes também sejam removidas.
      *
      * <p>Este método deve ser chamado dentro de uma transação existente.
-     *
-     * @param codSubprocesso O código do subprocesso cujas análises serão removidas.
      */
     @Transactional
     public void removerPorSubprocesso(Long codSubprocesso) {

--- a/backend/src/main/java/sgc/analise/AnaliseService.java
+++ b/backend/src/main/java/sgc/analise/AnaliseService.java
@@ -19,37 +19,19 @@ import java.util.List;
  */
 @Service
 @RequiredArgsConstructor
-// TODO essa classe deveria ser consolidada com a AnaliseFacade. Tem muito pouca coisa aqui!
 public class AnaliseService {
 
     private final AnaliseRepo analiseRepo;
 
-    /**
-     * Lista análises de um subprocesso ordenadas por data/hora descendente.
-     *
-     * @param codSubprocesso código do subprocesso
-     * @return lista de análises ordenadas
-     */
     public List<Analise> listarPorSubprocesso(Long codSubprocesso) {
         return analiseRepo.findBySubprocessoCodigoOrderByDataHoraDesc(codSubprocesso);
     }
 
-    /**
-     * Salva uma análise.
-     *
-     * @param analise análise a salvar
-     * @return análise salva
-     */
     @Transactional
     public Analise salvar(Analise analise) {
         return analiseRepo.save(analise);
     }
 
-    /**
-     * Remove todas as análises de um subprocesso.
-     *
-     * @param codSubprocesso código do subprocesso
-     */
     @Transactional
     public void removerPorSubprocesso(Long codSubprocesso) {
         List<Analise> analises = analiseRepo.findBySubprocessoCodigo(codSubprocesso);

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoCrudController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoCrudController.java
@@ -61,7 +61,7 @@ public class SubprocessoCrudController {
     @JsonView(SubprocessoViews.Publica.class)
     public ResponseEntity<Subprocesso> buscarPorProcessoEUnidade(
             @RequestParam Long codProcesso, @RequestParam String siglaUnidade) {
-        UnidadeDto unidade = organizacaoFacade.buscarUnidadePorSigla(siglaUnidade);
+        UnidadeDto unidade = organizacaoFacade.buscarPorSigla(siglaUnidade);
         Subprocesso sp = subprocessoFacade.obterEntidadePorProcessoEUnidade(codProcesso, unidade.getCodigo());
         return ResponseEntity.ok(sp);
     }

--- a/backend/src/main/java/sgc/subprocesso/model/Subprocesso.java
+++ b/backend/src/main/java/sgc/subprocesso/model/Subprocesso.java
@@ -114,7 +114,6 @@ public class Subprocesso extends EntidadeBase {
         return !situacoesFinalizadas.contains(this.situacao) && !SituacaoSubprocesso.NAO_INICIADO.equals(this.situacao);
     }
 
-    // TODO nao existe etapa nula.
     public Integer getEtapaAtual() {
         final List<SituacaoSubprocesso> situacoesFinalizadas =
                 Arrays.asList(MAPEAMENTO_MAPA_HOMOLOGADO, REVISAO_MAPA_HOMOLOGADO, DIAGNOSTICO_CONCLUIDO);

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoContextoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoContextoService.java
@@ -50,7 +50,6 @@ class SubprocessoContextoService {
 
         Usuario responsavel = usuarioService.buscarResponsavelAtual(sp.getUnidade().getSigla());
 
-        // TODO aqui já começou errado. O titular nunca pode ser nulo!
         Usuario titular = null;
         try {
             titular = usuarioService.buscarPorLogin(sp.getUnidade().getTituloTitular());
@@ -91,7 +90,6 @@ class SubprocessoContextoService {
         Unidade unidade = subprocesso.getUnidade();
         List<AtividadeDto> atividades = atividadeService.listarAtividadesSubprocesso(codSubprocesso);
 
-        // TODO deveria usar builder
         return new ContextoEdicaoResponse(
                 unidade,
                 subprocesso,

--- a/frontend/src/stores/__tests__/atividades.spec.ts
+++ b/frontend/src/stores/__tests__/atividades.spec.ts
@@ -44,7 +44,8 @@ describe("useAtividadesStore", () => {
                     codigo: 1,
                     situacao: "CADASTRO_EM_ANDAMENTO" as any,
                 },
-                atividadesAtualizadas: [novaAtividade]
+                atividadesAtualizadas: [novaAtividade],
+                permissoes: {} as any
             });
 
             await context.store.adicionarAtividade(1, 999, {descricao: "Nova Atividade"});
@@ -75,7 +76,8 @@ describe("useAtividadesStore", () => {
                     codigo: 1,
                     situacao: "CADASTRO_EM_ANDAMENTO" as any,
                 },
-                atividadesAtualizadas: []
+                atividadesAtualizadas: [],
+                permissoes: {} as any
             });
 
             await context.store.removerAtividade(1, 1);
@@ -109,7 +111,8 @@ describe("useAtividadesStore", () => {
                     codigo: 1,
                     situacao: "CADASTRO_EM_ANDAMENTO" as any,
                 },
-                atividadesAtualizadas: [atividadeComConhecimento]
+                atividadesAtualizadas: [atividadeComConhecimento],
+                permissoes: {} as any
             });
 
             await context.store.adicionarConhecimento(1, 1, {
@@ -154,7 +157,8 @@ describe("useAtividadesStore", () => {
                     codigo: 1,
                     situacao: "CADASTRO_EM_ANDAMENTO" as any,
                 },
-                atividadesAtualizadas: [atividadeSemConhecimento]
+                atividadesAtualizadas: [atividadeSemConhecimento],
+                permissoes: {} as any
             });
 
             await context.store.removerConhecimento(1, 1, 1);
@@ -211,7 +215,8 @@ describe("useAtividadesStore", () => {
                     codigo: 1,
                     situacao: "CADASTRO_EM_ANDAMENTO" as any,
                 },
-                atividadesAtualizadas: [atividadeAtualizada]
+                atividadesAtualizadas: [atividadeAtualizada],
+                permissoes: {} as any
             });
 
             await context.store.atualizarAtividade(1, 1, atividadeAtualizada);
@@ -264,7 +269,8 @@ describe("useAtividadesStore", () => {
                     codigo: 1,
                     situacao: "CADASTRO_EM_ANDAMENTO" as any,
                 },
-                atividadesAtualizadas: [atividadeComConhecimentoAtualizado]
+                atividadesAtualizadas: [atividadeComConhecimentoAtualizado],
+                permissoes: {} as any
             });
 
             await context.store.atualizarConhecimento(1, 1, 1, conhecimentoAtualizado);

--- a/frontend/src/views/ConfiguracoesView.vue
+++ b/frontend/src/views/ConfiguracoesView.vue
@@ -2,10 +2,8 @@
   <div class="container-fluid mt-4">
     <PageHeader title="Configurações" />
 
-    <!-- Seção de Administradores -->
     <AdministradoresSection v-if="podeGerenciarAdministradores" />
 
-    <!-- Seção de Configurações de Parâmetros -->
     <ParametrosSection />
   </div>
 </template>

--- a/frontend/src/views/PainelView.vue
+++ b/frontend/src/views/PainelView.vue
@@ -1,6 +1,5 @@
 <template>
   <LayoutPadrao>
-    <!-- Tabela de Processos -->
     <div class="mb-5">
       <PageHeader title="Processos" title-test-id="txt-painel-titulo-processos">
         <template #actions>


### PR DESCRIPTION
Cleaned up the codebase by removing conversational comments (TODOs) and redundant documentation (obvious Javadocs) as per the user request. Additionally, fixed a backend compilation error in `SubprocessoCrudController` and resolved frontend TypeScript errors in `atividades.spec.ts` to ensure a clean build and passing tests.

---
*PR created automatically by Jules for task [10615737023746520306](https://jules.google.com/task/10615737023746520306) started by @lgalvao*