### PR TITLE
Fix empty administrator list and harden E2E tests

### DIFF
--- a/e2e-status.md
+++ b/e2e-status.md
@@ -1,0 +1,43 @@
+# Status dos Testes E2E
+
+| Teste | Status | Detalhes |
+|---|---|---|
+| CDU-01 | Passou | Login e estrutura das telas |
+| CDU-02 | Passou | Visualizar Painel |
+| CDU-03 | Passou | Manter Processo |
+| CDU-04 | Passou | Iniciar processo de mapeamento |
+| CDU-05 | Passou | Iniciar processo de revisao |
+| CDU-06 | Passou | Detalhar processo |
+| CDU-07 | Passou | Detalhar subprocesso |
+| CDU-08 | Passou | Manter cadastro de atividades e conhecimentos |
+| CDU-09 | Passou | Disponibilizar cadastro de atividades e conhecimentos |
+| CDU-10 | Passou | Disponibilizar revisão do cadastro de atividades e conhecimentos |
+| CDU-11 | Passou | Visualizar cadastro de atividades e conhecimentos |
+| CDU-12 | Passou | Verificar impactos no mapa de competências |
+| CDU-13 | Passou | Analisar cadastro de atividades e conhecimentos |
+| CDU-14 | Passou | Analisar revisão de cadastro de atividades e conhecimentos |
+| CDU-15 | Passou | Manter mapa de competências |
+| CDU-16 | Passou | Ajustar mapa de competências |
+| CDU-17 | Passou | Disponibilizar mapa de competências |
+| CDU-18 | Passou | Visualizar mapa de competências |
+| CDU-19 | Passou | Validar mapa de competências |
+| CDU-20 | Passou | Analisar validação de mapa de competências |
+| CDU-21 | Passou | Finalizar processo de mapeamento ou de revisão |
+| CDU-22 | Passou | Aceitar cadastros em bloco |
+| CDU-23 | Passou | Homologar cadastros em bloco |
+| CDU-24 | Passou | Disponibilizar mapas em bloco |
+| CDU-25 | Passou | Aceitar validação de mapas em bloco |
+| CDU-26 | Passou | Homologar validação de mapas em bloco |
+| CDU-27 | Passou | Alterar data limite de subprocesso |
+| CDU-28 | Passou | Manter atribuição temporária |
+| CDU-29 | Passou | Consultar histórico de processos |
+| CDU-30 | Passou | Manter Administradores (Bug corrigido: seed.sql incompleto) |
+| CDU-31 | Passou | Configurar sistema |
+| CDU-32 | Passou | Reabrir cadastro |
+| CDU-33 | Passou | Reabrir revisão de cadastro |
+| CDU-34 | Passou | Enviar lembrete de prazo |
+| CDU-35 | Passou | Gerar relatório de andamento |
+| CDU-36 | Passou | Gerar relatório de mapas |
+| Regressão | Passou | |
+| UI Consistency | Passou | |
+| Micro Painel | Passou | |

--- a/e2e/cdu-11.spec.ts
+++ b/e2e/cdu-11.spec.ts
@@ -197,18 +197,14 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
         await fazerLogout(page);
         await login(page, USUARIO_ADMIN, SENHA_ADMIN);
         await page.getByTestId('tbl-processos').getByText(descProcessoMapeamento).first().click();
-        if (!await page.getByTestId('card-subprocesso-atividades-vis').isVisible().catch(() => false)) {
-            await navegarParaSubprocesso(page, UNIDADE_ALVO);
-        }
+        await navegarParaSubprocesso(page, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await page.getByTestId('btn-acao-analisar-principal').click();
         await page.getByTestId('inp-aceite-cadastro-obs').fill('Homologado para finalização do cenário');
         await page.getByTestId('btn-aceite-cadastro-confirmar').click();
         await page.goto('/painel');
         await page.getByTestId('tbl-processos').getByText(descProcessoMapeamento).first().click();
-        if (!await page.getByTestId('card-subprocesso-mapa').isVisible().catch(() => false)) {
-            await navegarParaSubprocesso(page, UNIDADE_ALVO);
-        }
+        await navegarParaSubprocesso(page, UNIDADE_ALVO);
 
         // Adicionar competências e disponibilizar mapa
         await navegarParaMapa(page);

--- a/e2e/cdu-13.spec.ts
+++ b/e2e/cdu-13.spec.ts
@@ -147,9 +147,7 @@ test.describe.serial('CDU-13 - Analisar cadastro de atividades e conhecimentos',
 
     test('Cenario 8: ADMIN visualiza histórico com múltiplas análises', async ({page, autenticadoComoAdmin}) => {
         await acessarSubprocessoAdmin(page, descProcesso, UNIDADE_ALVO);
-        if (!await page.getByTestId('card-subprocesso-atividades-vis').isVisible().catch(() => false)) {
-            await navegarParaSubprocesso(page, UNIDADE_ALVO);
-        }
+        await navegarParaSubprocesso(page, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
 
         // Abrir histórico

--- a/e2e/cdu-14.spec.ts
+++ b/e2e/cdu-14.spec.ts
@@ -84,18 +84,14 @@ test.describe.serial('CDU-14 - Analisar revisão de cadastro de atividades e con
 
     test('Preparacao 0.4: ADMIN homologa cadastro', async ({page, autenticadoComoAdmin}) => {
         await acessarSubprocessoAdmin(page, descMapeamento, UNIDADE_ALVO);
-        if (!await page.getByTestId('card-subprocesso-atividades-vis').or(page.getByTestId('card-subprocesso-atividades')).isVisible().catch(() => false)) {
-            await navegarParaSubprocesso(page, UNIDADE_ALVO);
-        }
+        await navegarParaSubprocesso(page, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await homologarCadastroMapeamento(page);
     });
 
     test('Preparacao 0.5: ADMIN cria competências e disponibiliza mapa', async ({page, autenticadoComoAdmin}) => {
         await acessarSubprocessoAdmin(page, descMapeamento, UNIDADE_ALVO);
-        if (!await page.getByTestId('card-subprocesso-mapa-edicao').or(page.getByTestId('card-subprocesso-mapa-visualizacao')).isVisible().catch(() => false)) {
-            await navegarParaSubprocesso(page, UNIDADE_ALVO);
-        }
+        await navegarParaSubprocesso(page, UNIDADE_ALVO);
         await navegarParaMapa(page);
         await criarCompetencia(page, `Competência Map ${timestamp}`, [`Atividade Map 1 ${timestamp}`]);
         await disponibilizarMapa(page, '2030-12-31');

--- a/e2e/cdu-30.spec.ts
+++ b/e2e/cdu-30.spec.ts
@@ -1,5 +1,4 @@
 import {expect, test} from './fixtures/complete-fixtures.js';
-import logger from '../frontend/src/utils/logger.js';
 
 /**
  * CDU-30 - Manter Administradores
@@ -22,8 +21,6 @@ test.describe.serial('CDU-30 - Manter Administradores', () => {
     // ========================================================================
 
     test('Cenario 1: ADMIN acessa página de configurações', async ({page, autenticadoComoAdmin}) => {
-        
-
         // Acessar configurações
         await page.getByTestId('btn-configuracoes').click();
         await expect(page).toHaveURL(/\/configuracoes/);
@@ -34,27 +31,11 @@ test.describe.serial('CDU-30 - Manter Administradores', () => {
     // ========================================================================
 
     test('Cenario 2: Página de configurações contém seção de administradores', async ({page, autenticadoComoAdmin}) => {
-        
-
         await page.getByTestId('btn-configuracoes').click();
         await expect(page).toHaveURL(/\/configuracoes/);
 
         // Verificar se existe seção ou link para administradores
-        // Pode ser uma aba, card ou link dentro da página de configurações
-        const secaoAdmins = page.getByText(/Administradores/i);
-        if (await secaoAdmins.isVisible().catch(() => false)) {
-            await expect(secaoAdmins).toBeVisible();
-        } else {
-            // Verificar se existe tab ou link para gerenciar admins
-            const tabAdmins = page.getByRole('tab', {name: /Administradores/i});
-            const linkAdmins = page.getByRole('link', {name: /Administradores/i});
-            
-            const temTab = await tabAdmins.isVisible().catch(() => false);
-            const temLink = await linkAdmins.isVisible().catch(() => false);
-            
-            // Log para debug - teste passa se qualquer opção existe
-            logger.info(`Seção Administradores encontrada: ${temTab || temLink}`);
-        }
+        await expect(page.getByRole('heading', {name: /Administradores/i})).toBeVisible();
     });
 
     // ========================================================================
@@ -62,25 +43,20 @@ test.describe.serial('CDU-30 - Manter Administradores', () => {
     // ========================================================================
 
     test('Cenario 3: Lista de administradores é exibida', async ({page, autenticadoComoAdmin}) => {
-        
-
         await page.getByTestId('btn-configuracoes').click();
+        await expect(page).toHaveURL(/\/configuracoes/);
 
         // Procurar por tabela ou lista de administradores
-        const tabela = page.locator('table');
-        if (await tabela.count() > 0) {
-            // Verificar que tabela tem dados
-            const linhas = tabela.locator('tbody tr');
-            const numLinhas = await linhas.count();
-            expect(numLinhas).toBeGreaterThanOrEqual(0);
-        }
+        const tabela = page.locator('main table');
+        await expect(tabela).toBeVisible();
+
+        // Verificar que tabela tem dados (pelo menos o proprio admin)
+        const linhas = tabela.locator('tbody tr');
+        await expect(linhas).not.toHaveCount(0);
 
         // Verificar botão de adicionar administrador
         const btnAdicionar = page.getByRole('button', {name: /Adicionar|Novo/i});
-        const btnVisivel = await btnAdicionar.isVisible().catch(() => false);
-        
-        if (btnVisivel) {
-            await expect(btnAdicionar).toBeEnabled();
-        }
+        await expect(btnAdicionar).toBeVisible();
+        await expect(btnAdicionar).toBeEnabled();
     });
 });

--- a/e2e/setup/seed.sql
+++ b/e2e/setup/seed.sql
@@ -183,6 +183,10 @@ VALUES ('303030', '00303030', 'Alice Cooper', 'alice.cooper@tre-pe.jus.br', '203
 INSERT INTO sgc.vw_usuario_perfil_unidade (usuario_titulo, perfil, unidade_codigo)
 VALUES ('303030', 'CHEFE', 8);
 
+-- Administradores do Sistema (necessário para listar em configurações)
+INSERT INTO sgc.administrador (usuario_titulo) VALUES ('191919');
+INSERT INTO sgc.administrador (usuario_titulo) VALUES ('111111');
+
 -- Inserir Mapa vigente para Assessoria 12 (Unit 4) para testes de Revisão
 -- Processo 99
 INSERT INTO sgc.processo (codigo, data_criacao, data_finalizacao, data_limite, descricao, situacao, tipo)


### PR DESCRIPTION
Found and fixed a bug where the Administrators list in Settings was empty because the seed data was missing entries in the `sgc.administrador` table (despite users having ADMIN role). 

Also refactored several E2E tests (`cdu-11`, `cdu-13`, `cdu-14`, `cdu-30`) to remove defensive programming patterns that could mask bugs, and improved locator specificity to fix strict mode violations.


---
*PR created automatically by Jules for task [14434867911361443750](https://jules.google.com/task/14434867911361443750) started by @lgalvao*