### PR TITLE
Clean up unnecessary comments in backend and frontend

### DIFF
--- a/backend/src/main/java/sgc/subprocesso/model/Subprocesso.java
+++ b/backend/src/main/java/sgc/subprocesso/model/Subprocesso.java
@@ -114,7 +114,6 @@ public class Subprocesso extends EntidadeBase {
         return !situacoesFinalizadas.contains(this.situacao) && !SituacaoSubprocesso.NAO_INICIADO.equals(this.situacao);
     }
 
-    // TODO nao existe etapa nula.
     public Integer getEtapaAtual() {
         final List<SituacaoSubprocesso> situacoesFinalizadas =
                 Arrays.asList(MAPEAMENTO_MAPA_HOMOLOGADO, REVISAO_MAPA_HOMOLOGADO, DIAGNOSTICO_CONCLUIDO);

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoAjusteMapaService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoAjusteMapaService.java
@@ -26,9 +26,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/**
- * Service responsável por operações relacionadas a ajustes de mapa em subprocessos.
- */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -41,11 +38,6 @@ class SubprocessoAjusteMapaService {
     private final AnaliseFacade analiseFacade;
     private final MapaAjusteMapper mapaAjusteMapper;
 
-    /**
-     * Salva ajustes feitos no mapa de um subprocesso.
-     * 
-     * @throws sgc.subprocesso.erros.ErroMapaEmSituacaoInvalida se situação não permite ajuste
-     */
     @Transactional
     public void salvarAjustesMapa(Long codSubprocesso, List<CompetenciaAjusteDto> competencias) {
         Subprocesso sp = repo.buscar(Subprocesso.class, codSubprocesso);
@@ -58,9 +50,6 @@ class SubprocessoAjusteMapaService {
         subprocessoRepo.save(sp);
     }
 
-    /**
-     * Obtém mapa preparado para ajuste.
-     */
     @Transactional(readOnly = true)
     public MapaAjusteDto obterMapaParaAjuste(Long codSubprocesso) {
         Subprocesso sp = crudService.buscarSubprocessoComMapa(codSubprocesso);
@@ -79,11 +68,6 @@ class SubprocessoAjusteMapaService {
         return mapaAjusteMapper.toDto(sp, analise, competencias, atividades, conhecimentos, associacoes);
     }
 
-    /**
-     * Valida se a situação do subprocesso permite ajuste de mapa.
-     * 
-     * @throws sgc.subprocesso.erros.ErroMapaEmSituacaoInvalida se situação inválida
-     */
     private void validarSituacaoParaAjuste(Subprocesso sp) {
         if (sp.getSituacao() != SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA
                 && sp.getSituacao() != SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO) {
@@ -93,9 +77,6 @@ class SubprocessoAjusteMapaService {
         }
     }
 
-    /**
-     * Atualiza descrições de atividades em lote.
-     */
     private void atualizarDescricoesAtividades(List<CompetenciaAjusteDto> competencias) {
         Map<Long, String> atividadeDescricoes = new HashMap<>();
         for (CompetenciaAjusteDto compDto : competencias) {
@@ -108,9 +89,6 @@ class SubprocessoAjusteMapaService {
         }
     }
 
-    /**
-     * Atualiza competências e suas associações com atividades.
-     */
     private void atualizarCompetenciasEAssociacoes(List<CompetenciaAjusteDto> competencias) {
         // Carregar todas as competências envolvidas
         List<Long> competenciaIds = competencias.stream()

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoAtividadeService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoAtividadeService.java
@@ -23,14 +23,6 @@ import static sgc.subprocesso.model.SituacaoSubprocesso.*;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Service responsável por operações relacionadas a atividades de subprocessos. Responsabilidades:
- * <ul>
- *   <li>Importar atividades entre subprocessos (via eventos)</li>
- *   <li>Listar atividades de um subprocesso para visualização</li>
- *   <li>Transformar atividades em DTOs para visualização</li>
- * </ul>
- */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -45,9 +37,6 @@ class SubprocessoAtividadeService {
     private final SgcPermissionEvaluator permissionEvaluator;
     private final SubprocessoValidacaoService validacaoService;
 
-    /**
-     * Importa atividades de um subprocesso de origem para um subprocesso de destino.
-     */
     @Transactional
     public void importarAtividades(Long codSubprocessoDestino, Long codSubprocessoOrigem) {
         final Subprocesso spDestino = repo.buscar(Subprocesso.class, codSubprocessoDestino);
@@ -100,9 +89,6 @@ class SubprocessoAtividadeService {
                 codSubprocessoOrigem, codSubprocessoDestino);
     }
 
-    /**
-     * Lista todas as atividades de um subprocesso para visualização.
-     */
     @Transactional(readOnly = true)
     public List<AtividadeDto> listarAtividadesSubprocesso(Long codSubprocesso) {
         Subprocesso subprocesso = crudService.buscarSubprocessoComMapa(codSubprocesso);
@@ -111,9 +97,6 @@ class SubprocessoAtividadeService {
         return todasAtividades.stream().map(this::mapAtividadeToDto).toList();
     }
 
-    /**
-     * Transforma uma atividade em DTO para visualização.
-     */
     private AtividadeDto mapAtividadeToDto(Atividade atividade) {
         return AtividadeDto.builder()
                 .codigo(atividade.getCodigo())

--- a/backend/src/main/java/sgc/subprocesso/service/crud/SubprocessoCrudService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/crud/SubprocessoCrudService.java
@@ -22,18 +22,9 @@ import java.util.Optional;
  * Serviço especializado para operações CRUD básicas de Subprocesso.
  *
  * <p>
- * Responsável pelas operações de criação, leitura, atualização e exclusão
- * de subprocessos. Parte da decomposição arquitetural do módulo subprocesso.
- *
- * <p>
  * <b>Visibilidade:</b> Package-private - uso interno ao módulo subprocesso.
  * Acesso externo deve ser feito via
  * {@link sgc.subprocesso.service.SubprocessoFacade}.
- *
- * <p><b>Refatoração v3.0:</b> Removido uso de @Lazy e dependência em MapaFacade.
- * A criação do mapa agora é responsabilidade de SubprocessoFactory.</p>
- *
- * @since 3.0.0 - Removido @Lazy e MapaFacade
  */
 @Service
 @Transactional
@@ -48,9 +39,6 @@ public class SubprocessoCrudService {
                 .orElseThrow(() -> new ErroEntidadeNaoEncontrada("Subprocesso", codigo));
     }
 
-    /**
-     * Busca subprocesso e seu mapa associado.
-     */
     public Subprocesso buscarSubprocessoComMapa(Long codigo) {
         return buscarSubprocesso(codigo);
     }

--- a/backend/src/main/java/sgc/subprocesso/service/crud/SubprocessoValidacaoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/crud/SubprocessoValidacaoService.java
@@ -121,12 +121,6 @@ public class SubprocessoValidacaoService {
                 .build();
     }
 
-    /**
-     * Valida se a situação atual do subprocesso está entre as situações permitidas.
-     *
-     * @throws ErroValidacao se a situação atual não está entre as permitidas
-     * @throws IllegalArgumentException se situação do subprocesso for null
-     */
     public void validarSituacaoPermitida(Subprocesso subprocesso, Set<SituacaoSubprocesso> permitidas) {
         if (subprocesso.getSituacao() == null) {
             throw new IllegalArgumentException("Situação do subprocesso não pode ser nula");
@@ -145,12 +139,6 @@ public class SubprocessoValidacaoService {
         }
     }
 
-    /**
-     * Valida se a situação atual do subprocesso está entre as situações permitidas (variadic).
-     *
-     * @throws ErroValidacao se a situação atual não está entre as permitidas
-     * @throws IllegalArgumentException se subprocesso for null, situação for null, ou nenhuma situação permitida for fornecida
-     */
     public void validarSituacaoPermitida(Subprocesso subprocesso, SituacaoSubprocesso... permitidas) {
         if (permitidas.length == 0) {
             throw new IllegalArgumentException("Pelo menos uma situação permitida deve ser fornecida");
@@ -158,12 +146,6 @@ public class SubprocessoValidacaoService {
         validarSituacaoPermitida(subprocesso, Set.of(permitidas));
     }
 
-    /**
-     * Valida se a situação atual do subprocesso está entre as situações permitidas com mensagem customizada.
-     *
-     * @throws ErroValidacao se a situação atual não está entre as permitidas
-     * @throws IllegalArgumentException se a situação do subprocesso for null, ou nenhuma situação permitida for fornecida
-     */
     public void validarSituacaoPermitida(Subprocesso subprocesso, String mensagem, SituacaoSubprocesso... permitidas) {
         if (subprocesso.getSituacao() == null) {
             throw new IllegalArgumentException("Situação do subprocesso não pode ser nula");
@@ -178,12 +160,6 @@ public class SubprocessoValidacaoService {
         }
     }
 
-    /**
-     * Valida se a situação atual do subprocesso é maior ou igual à situação mínima.
-     *
-     * @throws ErroValidacao se a situação atual é inferior à mínima
-     * @throws IllegalArgumentException se a situação do subprocesso for null
-     */
     public void validarSituacaoMinima(Subprocesso subprocesso, SituacaoSubprocesso minima) {
         if (subprocesso.getSituacao() == null) {
             throw new IllegalArgumentException("Situação do subprocesso não pode ser nula");
@@ -196,12 +172,6 @@ public class SubprocessoValidacaoService {
         }
     }
 
-    /**
-     * Valida se a situação atual do subprocesso é maior ou igual à situação mínima com mensagem customizada.
-     *
-     * @throws ErroValidacao se a situação atual é inferior à mínima
-     * @throws IllegalArgumentException se a situação do subprocesso for null
-     */
     public void validarSituacaoMinima(Subprocesso subprocesso, SituacaoSubprocesso minima, String mensagem) {
         if (subprocesso.getSituacao() == null) {
             throw new IllegalArgumentException("Situação do subprocesso não pode ser nula");

--- a/backend/src/main/java/sgc/subprocesso/service/factory/SubprocessoFactory.java
+++ b/backend/src/main/java/sgc/subprocesso/service/factory/SubprocessoFactory.java
@@ -116,9 +116,6 @@ public class SubprocessoFactory {
         movimentacaoRepo.saveAll(movimentacoes);
     }
 
-    /**
-     * Cria subprocesso para processo de revisão e copia o mapa vigente da unidade.
-     */
     public void criarParaRevisao(Processo processo, Unidade unidade, UnidadeMapa unidadeMapa, Unidade unidadeOrigem, Usuario usuario) {
 
         Long codMapaVigente = unidadeMapa.getMapaVigente().getCodigo();
@@ -149,10 +146,6 @@ public class SubprocessoFactory {
         log.info("Subprocesso para revisão criado para unidade {}", unidade.getSigla());
     }
 
-    /**
-     * Cria subprocesso para processo de diagnóstico.
-     * Copia o mapa vigente e inicia com autoavaliação em andamento.
-     */
     public void criarParaDiagnostico(Processo processo, Unidade unidade, UnidadeMapa unidadeMapa, Unidade unidadeOrigem, Usuario usuario) {
 
         Long codMapaVigente = unidadeMapa.getMapaVigente().getCodigo();

--- a/backend/src/main/java/sgc/subprocesso/service/query/ConsultasSubprocessoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/query/ConsultasSubprocessoService.java
@@ -21,10 +21,6 @@ import static sgc.subprocesso.model.SituacaoSubprocesso.*;
 public class ConsultasSubprocessoService {
     private final SubprocessoRepo subprocessoRepo;
 
-    /**
-     * Verifica se todas as unidades especificadas participam do processo através de subprocessos.
-     *
-     */
     public boolean verificarAcessoUnidadeAoProcesso(Long processoId, List<Long> unidadeCodigos) {
         if (unidadeCodigos.isEmpty()) {
             return false;
@@ -32,11 +28,6 @@ public class ConsultasSubprocessoService {
         return subprocessoRepo.existsByProcessoCodigoAndUnidadeCodigoIn(processoId, unidadeCodigos);
     }
 
-    /**
-     * Valida se todos os subprocessos de um processo estão homologados.
-     *
-     * @return resultado da validação com detalhes
-     */
     public ValidationResult validarSubprocessosParaFinalizacao(Long processoId) {
         long total = subprocessoRepo.countByProcessoCodigo(processoId);
 
@@ -61,25 +52,14 @@ public class ConsultasSubprocessoService {
         return ValidationResult.ofValido();
     }
 
-    /**
-     * Lista subprocessos por processo e múltiplas situações.
-     */
     public List<Subprocesso> listarPorProcessoESituacoes(Long processoId, List<SituacaoSubprocesso> situacoes) {
         return subprocessoRepo.findByProcessoCodigoAndSituacaoInWithUnidade(processoId, situacoes);
     }
 
-    /**
-     * Lista todos os subprocessos de um processo.
-     *
-     * @return lista de subprocessos com unidade e mapa carregados
-     */
     public List<Subprocesso> listarEntidadesPorProcesso(Long processoId) {
         return subprocessoRepo.findByProcessoCodigoWithUnidade(processoId);
     }
 
-    /**
-     * Lista subprocessos por processo, unidade e situações.
-     */
     public List<Subprocesso> listarPorProcessoUnidadeESituacoes(
             Long processoId, Long unidadeId, List<SituacaoSubprocesso> situacoes) {
         return subprocessoRepo.findByProcessoCodigoAndUnidadeCodigoAndSituacaoInWithUnidade(

--- a/frontend/src/stores/perfil.ts
+++ b/frontend/src/stores/perfil.ts
@@ -37,17 +37,14 @@ export const usePerfilStore = defineStore("perfil", () => {
 
     function definirUsuarioCodigo(novoId: string) {
         usuarioCodigo.value = novoId;
-        // localStorage.setItem removido - sincronização automática
     }
 
     function definirPerfilUnidade(perfil: Perfil, unidadeCodigo: number, unidadeSigla: string, nome?: string) {
         perfilSelecionado.value = perfil;
         unidadeSelecionada.value = unidadeCodigo;
         unidadeSelecionadaSigla.value = unidadeSigla;
-        // localStorage.setItem removido - sincronização automática
         if (nome) {
             usuarioNome.value = nome;
-            // localStorage.setItem removido - sincronização automática
         }
     }
 
@@ -57,7 +54,6 @@ export const usePerfilStore = defineStore("perfil", () => {
 
     function definirPerfis(novosPerfis: Perfil[]) {
         perfis.value = novosPerfis;
-        // localStorage.setItem removido - sincronização automática
     }
 
     async function loginCompleto(tituloEleitoral: string, senha: string) {
@@ -128,7 +124,6 @@ export const usePerfilStore = defineStore("perfil", () => {
     }
 
     function logout() {
-        // Limpa estados - remoção do localStorage é automática
         usuarioCodigo.value = null;
         perfilSelecionado.value = null;
         unidadeSelecionada.value = null;
@@ -136,8 +131,7 @@ export const usePerfilStore = defineStore("perfil", () => {
         usuarioNome.value = null;
         perfisUnidades.value = [];
         perfis.value = [];
-        
-        // Apenas jwtToken precisa de remoção manual (não é gerenciado pelo composable)
+
         localStorage.removeItem("jwtToken");
     }
 


### PR DESCRIPTION
Cleaned up unnecessary comments in the codebase.
- Removed conversational comments (e.g., in `frontend/src/stores/perfil.ts`).
- Removed redundant Javadoc in backend services and models (e.g., `Subprocesso.java`, `SubprocessoCrudService.java`, `SubprocessoAtividadeService.java`).
- Removed historical context comments in Javadoc.

---
*PR created automatically by Jules for task [3134662688365800244](https://jules.google.com/task/3134662688365800244) started by @lgalvao*