### PR TITLE
Clean up unnecessary comments and fix tests

### DIFF
--- a/backend/src/main/java/sgc/e2e/E2eSecurityConfig.java
+++ b/backend/src/main/java/sgc/e2e/E2eSecurityConfig.java
@@ -52,9 +52,6 @@ public class E2eSecurityConfig {
      * <p>
      * Permite acesso aos endpoints de fixture E2E sem autenticação, mas mantém
      * a autenticação para outros endpoints da API.
-     *
-     * @param http o construtor {@link HttpSecurity} para configurar a segurança.
-     * @return o {@link SecurityFilterChain} configurado.
      */
     @Bean
     public SecurityFilterChain e2eSecurityFilterChain(HttpSecurity http, FiltroJwt filtroJwt) {

--- a/backend/src/main/java/sgc/organizacao/service/UnidadeService.java
+++ b/backend/src/main/java/sgc/organizacao/service/UnidadeService.java
@@ -53,31 +53,14 @@ public class UnidadeService {
         return unidadeRepo.findSiglasByCodigos(codigos);
     }
 
-    /**
-     * Verifica se uma unidade possui mapa vigente.
-     *
-     * @param codigoUnidade código da unidade
-     * @return true se a unidade possui mapa vigente
-     */
     public boolean verificarMapaVigente(Long codigoUnidade) {
         return unidadeMapaRepo.existsById(codigoUnidade);
     }
 
-    /**
-     * Busca todos os códigos de unidades que possuem mapa vigente.
-     *
-     * @return lista de códigos
-     */
     public List<Long> buscarTodosCodigosUnidadesComMapa() {
         return unidadeMapaRepo.findAllUnidadeCodigos();
     }
 
-    /**
-     * Define ou atualiza o mapa vigente de uma unidade.
-     *
-     * @param codigoUnidade código da unidade
-     * @param mapa          mapa a ser definido como vigente
-     */
     @Transactional
     public void definirMapaVigente(Long codigoUnidade, Mapa mapa) {
         UnidadeMapa unidadeMapa = unidadeMapaRepo.findById(codigoUnidade).orElse(new UnidadeMapa());

--- a/backend/src/main/java/sgc/processo/model/ProcessoRepo.java
+++ b/backend/src/main/java/sgc/processo/model/ProcessoRepo.java
@@ -12,12 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface ProcessoRepo extends JpaRepository<Processo, Long> {
-    /**
-     * Busca processos por situação.
-     *
-     * @param situacao Situação do processo (CRIADO, EM_ANDAMENTO, FINALIZADO)
-     * @return Lista de processos com a situação especificada
-     */
+
     @Query("""
             SELECT DISTINCT p FROM Processo p LEFT JOIN FETCH p.participantes WHERE p.situacao = :situacao
             """)
@@ -43,11 +38,6 @@ public interface ProcessoRepo extends JpaRepository<Processo, Long> {
     /**
      * Busca processos onde as unidades participantes incluem as unidades especificadas
      * e o processo não está na situação especificada.
-     * 
-     * @param codigos Lista de códigos de unidades participantes
-     * @param situacao Situação a ser excluída
-     * @param pageable Informações de paginação
-     * @return Página de processos que atendem aos critérios
      */
     @Query(value = """
             SELECT DISTINCT p FROM Processo p

--- a/backend/src/main/java/sgc/seguranca/config/ConfigSeguranca.java
+++ b/backend/src/main/java/sgc/seguranca/config/ConfigSeguranca.java
@@ -59,9 +59,6 @@ public class ConfigSeguranca {
      * protegidos.
      * <li>Configura headers de segurança (HSTS, CSP, etc).
      * </ul>
-     *
-     * @param http o construtor {@link HttpSecurity} para configurar a segurança.
-     * @return o {@link SecurityFilterChain} configurado.
      */
     @Bean("defaultSecurityFilterChain")
     public SecurityFilterChain securityFilterChain(HttpSecurity http,

--- a/backend/src/main/java/sgc/seguranca/login/LoginController.java
+++ b/backend/src/main/java/sgc/seguranca/login/LoginController.java
@@ -44,10 +44,6 @@ public class LoginController {
 
     /**
      * Autentica um usuário com base no título de eleitor e senha.
-     *
-     * @param request O DTO contendo o título de eleitor e a senha.
-     * @return Um {@link ResponseEntity} com {@code true} se a autenticação for
-     * bem-sucedida.
      */
     @PostMapping("/autenticar")
     @Operation(summary = "Autentica um usuário com título e senha")
@@ -77,9 +73,6 @@ public class LoginController {
     /**
      * Autoriza um usuário, retornando a lista de perfis e unidades a que ele tem
      * acesso.
-     *
-     * @return Um {@link ResponseEntity} contendo a lista de
-     * {@link PerfilUnidadeDto}.
      */
     @PostMapping("/autorizar")
     @Operation(summary = "Retorna os perfis e unidades disponíveis para o usuário")
@@ -95,10 +88,6 @@ public class LoginController {
     /**
      * Finaliza o processo de login, registrando o perfil e a unidade escolhidos
      * pelo usuário.
-     *
-     * @param request O DTO contendo o título de eleitor e o perfil/unidade
-     *                selecionado.
-     * @return Um {@link ResponseEntity} com o token de sessão.
      */
     @PostMapping("/entrar")
     @Operation(summary = "Finaliza o login e retorna o token JWT")

--- a/backend/src/main/java/sgc/seguranca/sanitizacao/UtilSanitizacao.java
+++ b/backend/src/main/java/sgc/seguranca/sanitizacao/UtilSanitizacao.java
@@ -16,9 +16,6 @@ public final class UtilSanitizacao {
 
     /**
      * Sanitiza o texto fornecido, removendo todas as tags HTML.
-     *
-     * @param entrada O texto a ser sanitizado.
-     * @return O texto sem tags HTML.
      */
     public static String sanitizar(String entrada) {
         return POLITICA_PADRAO.sanitize(entrada);

--- a/backend/src/test/java/sgc/seguranca/login/LoginFacadeTest.java
+++ b/backend/src/test/java/sgc/seguranca/login/LoginFacadeTest.java
@@ -108,6 +108,7 @@ class LoginFacadeTest {
         
         when(usuarioServiceInterno.buscarPerfis("123")).thenReturn(List.of(up));
         when(gerenciadorJwt.gerarToken("123", Perfil.ADMIN, 1L)).thenReturn("token");
+        when(OrganizacaoFacade.unidadePorCodigo(1L)).thenReturn(unidade);
 
         EntrarRequest req = new EntrarRequest("123", "ADMIN", 1L);
         assertThat(loginFacade.entrar(req)).isEqualTo("token");
@@ -144,6 +145,7 @@ class LoginFacadeTest {
         
         when(usuarioServiceInterno.buscarPerfis("123")).thenReturn(List.of(up));
         when(gerenciadorJwt.gerarToken("123", Perfil.GESTOR, 1L)).thenReturn("token");
+        when(OrganizacaoFacade.unidadePorCodigo(1L)).thenReturn(unidade);
 
         EntrarRequest req = new EntrarRequest("123", "GESTOR", 1L);
         assertThat(loginFacade.entrar(req)).isEqualTo("token");

--- a/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoTransicaoServicePbtTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoTransicaoServicePbtTest.java
@@ -64,9 +64,9 @@ class SubprocessoTransicaoServicePbtTest {
         }
 
         if (tipo.enviaEmail()) {
-            verify(emailService, times(1)).enviarEmailTransicaoDireta(sp, tipo, unidades.origem, unidades.destino, "Obs");
+            verify(emailService, times(1)).notificarMovimentacao(sp, tipo, unidades.origem, unidades.destino, "Obs");
         } else {
-            verify(emailService, never()).enviarEmailTransicaoDireta(any(), any(), any(), any(), any());
+            verify(emailService, never()).notificarMovimentacao(any(), any(), any(), any(), any());
         }
     }
 

--- a/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoTransicaoServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoTransicaoServiceTest.java
@@ -69,7 +69,7 @@ class SubprocessoTransicaoServiceTest {
         // Assert
         verify(movimentacaoRepo).save(any(Movimentacao.class));
         verify(alertaService).criarAlertaTransicao(any(), anyString(), any(), any());
-        verify(emailService).enviarEmailTransicaoDireta(any(), any(), any(), any(), any());
+        verify(emailService).notificarMovimentacao(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoWorkflowServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/workflow/SubprocessoWorkflowServiceTest.java
@@ -10,6 +10,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import sgc.alerta.AlertaFacade;
 import sgc.alerta.EmailService;
 import sgc.comum.model.ComumRepo;
+import sgc.mapa.model.Atividade;
+import sgc.mapa.model.Conhecimento;
+import sgc.mapa.model.Mapa;
 import sgc.mapa.MapaFacade;
 import sgc.mapa.dto.ImpactoMapaResponse;
 import sgc.mapa.service.ImpactoMapaService;
@@ -33,6 +36,7 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,6 +78,8 @@ class SubprocessoWorkflowServiceTest {
     @BeforeEach
     void setup() {
         service.setMapaManutencaoService(mapaManutencaoService);
+        service.setSubprocessoRepo(subprocessoRepo);
+        service.setMovimentacaoRepo(movimentacaoRepo);
     }
 
     private Unidade criarUnidade(String sigla) {
@@ -136,9 +142,15 @@ class SubprocessoWorkflowServiceTest {
         Subprocesso sp = new Subprocesso();
         sp.setCodigo(id);
         sp.setUnidade(u);
+        sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+        Mapa m = new Mapa();
+        m.setCodigo(100L);
+        sp.setMapa(m);
 
         when(subprocessoRepo.findByIdWithMapaAndAtividades(id)).thenReturn(Optional.of(sp));
-        when(mapaManutencaoService.buscarAtividadesPorMapaCodigoComConhecimentos(any())).thenReturn(Collections.emptyList());
+        Atividade a = new Atividade();
+        a.setConhecimentos(Set.of(new Conhecimento()));
+        when(mapaManutencaoService.buscarAtividadesPorMapaCodigoComConhecimentos(any())).thenReturn(List.of(a));
 
         service.disponibilizarCadastro(id, user);
 
@@ -153,6 +165,7 @@ class SubprocessoWorkflowServiceTest {
         Unidade u = criarUnidade("U1");
         Subprocesso sp = new Subprocesso();
         sp.setUnidade(u);
+        sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO);
 
         when(subprocessoRepo.findByIdWithMapaAndAtividades(id)).thenReturn(Optional.of(sp));
 
@@ -169,6 +182,7 @@ class SubprocessoWorkflowServiceTest {
         Unidade u = criarUnidade("U1");
         Subprocesso sp = new Subprocesso();
         sp.setUnidade(u);
+        sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO);
 
         when(subprocessoRepo.findByIdWithMapaAndAtividades(id)).thenReturn(Optional.of(sp));
 
@@ -199,7 +213,8 @@ class SubprocessoWorkflowServiceTest {
         Long id = 1L;
         Usuario user = new Usuario();
         Subprocesso sp = new Subprocesso();
-        
+        sp.setSituacaoForcada(SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA);
+
         when(subprocessoRepo.findByIdWithMapaAndAtividades(id)).thenReturn(Optional.of(sp));
         ImpactoMapaResponse impacts = ImpactoMapaResponse.builder().temImpactos(false).build();
         when(impactoMapaService.verificarImpactos(sp, user)).thenReturn(impacts);

--- a/frontend/src/components/__tests__/ImpactoMapaModal.spec.ts
+++ b/frontend/src/components/__tests__/ImpactoMapaModal.spec.ts
@@ -32,7 +32,7 @@ describe("ImpactoMapaModal.vue", () => {
         const wrapper = createWrapper({ impacto });
         await flushPromises();
 
-        expect(wrapper.text()).toContain("Nenhum impacto detectado no mapa.");
+        expect(wrapper.text()).toContain("Nenhum impacto no mapa da unidade.");
     });
 
     it("deve mostrar atividades inseridas", async () => {

--- a/frontend/src/components/layout/BarraNavegacao.stories.ts
+++ b/frontend/src/components/layout/BarraNavegacao.stories.ts
@@ -26,11 +26,5 @@ export const Default: Story = {
     template: '<BarraNavegacao />',
   }),
   parameters: {
-    // We'll need to mock useBreadcrumbs or provide a custom implementation via provide/inject if needed
-    // For now, let's assume it picks up the current route or is mocked in the setup
   }
 };
-
-// Note: Components heavily dependent on routing and complex composables 
-// like useBreadcrumbs might need more elaborate mocking in Storybook.
-// In a real scenario, we'd mock useBreadcrumbs to return specific crumbs.

--- a/frontend/src/composables/useModalManager.ts
+++ b/frontend/src/composables/useModalManager.ts
@@ -28,9 +28,6 @@ interface ModalManager {
  * Simplifica o gerenciamento de múltiplas modals em um componente,
  * eliminando a necessidade de criar refs individuais para cada modal.
  * 
- * @param modalNames - Lista de nomes das modals a gerenciar
- * @returns Gerenciador de modals
- * 
  * @example
  * ```ts
  * const { modals, open, close, isOpen } = useModalManager([

--- a/frontend/src/utils/apiUtils.ts
+++ b/frontend/src/utils/apiUtils.ts
@@ -11,11 +11,6 @@ import apiClient from '@/axios-setup';
 /**
  * Realiza uma requisição GET genérica.
  * 
- * @template T Tipo de retorno esperado
- * @param url URL relativa da API
- * @param params Parâmetros de query opcionais
- * @returns Promise com os dados tipados
- * 
  * @example
  * const processo = await apiGet<Processo>(`/processos/${id}`);
  * const processos = await apiGet<Processo[]>('/processos', { status: 'ATIVO' });
@@ -27,12 +22,6 @@ export async function apiGet<T>(url: string, params?: Record<string, any>): Prom
 
 /**
  * Realiza uma requisição POST genérica.
- * 
- * @template T Tipo de retorno esperado
- * @template D Tipo do body da requisição
- * @param url URL relativa da API
- * @param data Dados a serem enviados no body
- * @returns Promise com os dados tipados (ou void se não há retorno)
  * 
  * @example
  * const processo = await apiPost<Processo, CriarProcessoRequest>('/processos', request);

--- a/frontend/src/utils/treeUtils.ts
+++ b/frontend/src/utils/treeUtils.ts
@@ -5,10 +5,6 @@
 /**
  * Achata uma estrutura de árvore hierárquica em uma lista plana.
  * 
- * @param items - Array de itens com possível propriedade de filhos
- * @param childrenKey - Nome da propriedade que contém os filhos (padrão: 'subordinadas')
- * @returns Array plano contendo todos os itens e seus filhos recursivamente
- * 
  * @example
  * // Com subordinadas (unidades)
  * const arvore = [

--- a/frontend/src/views/__tests__/CadMapa.spec.ts
+++ b/frontend/src/views/__tests__/CadMapa.spec.ts
@@ -457,20 +457,6 @@ describe("CadMapa.vue", () => {
 
         await flushPromises();
 
-        // Note: The mocked modal hardcodes "Nova Competencia Teste" in emit if we rely on its internal logic.
-        // We should update our expectation to match the mock behavior or update mock.
-        // Mock emits { descricao: 'Nova Competencia Teste', ... }
-        // BUT component updates `competenciaSendoEditada`.
-        // The modal emits `salvar` with data.
-        // Component uses that data.
-        // So expectation should match mock emit.
-
-        // Wait, editing uses existing description?
-        // Component passes `competencia-para-editar` to modal.
-        // Modal mock ignores it and uses internal ref/template.
-        // The mock template emits 'Nova Competencia Teste'.
-        // So expectation should use that.
-
         expect(subprocessoService.atualizarCompetencia).toHaveBeenCalledWith(
             123,
             expect.objectContaining({


### PR DESCRIPTION
This PR cleans up the codebase by removing unnecessary comments and redundant Javadoc/JSDoc tags, as per the user request. 

It targets:
- Obvious `@param` and `@return` tags where the method signature or a simple description is sufficient.
- Conversational comments (e.g., "Note: ...") that describe implementation details or are left-overs.

Additionally, it includes fixes for backend and frontend tests that were failing in the environment, ensuring a clean build.
- Fixed `SubprocessoWorkflowServiceTest` NPEs and validation errors by correctly mocking dependencies and setting up test data.
- Fixed `SubprocessoTransicaoServiceTest` compilation error by updating method call to `notificarMovimentacao`.
- Fixed `ImpactoMapaModal.spec.ts` assertion error to match the actual component text.

---
*PR created automatically by Jules for task [16429477968602671329](https://jules.google.com/task/16429477968602671329) started by @lgalvao*