### PR TITLE
Fix race condition in cdu-11 e2e test

### DIFF
--- a/e2e/cdu-11.spec.ts
+++ b/e2e/cdu-11.spec.ts
@@ -202,6 +202,7 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
         await page.getByTestId('btn-acao-analisar-principal').click();
         await page.getByTestId('inp-aceite-cadastro-obs').fill('Homologado para finalização do cenário');
         await page.getByTestId('btn-aceite-cadastro-confirmar').click();
+        await expect(page.getByText(/Cadastro homologado/i).first()).toBeVisible();
         await page.goto('/painel');
         await page.getByTestId('tbl-processos').getByText(descProcessoMapeamento).first().click();
         await navegarParaSubprocesso(page, UNIDADE_ALVO);


### PR DESCRIPTION
The `cdu-11.spec.ts` test was failing intermittently due to a race condition. The test clicked the "Confirmar" button to homologate a registration and immediately navigated to the dashboard (`/painel`). This sometimes caused the browser to cancel the pending backend request before it could be processed, leading to a state mismatch in subsequent steps (where the test expected the registration to be homologated but it wasn't).

This fix adds an explicit `await expect(page.getByText(/Cadastro homologado/i).first()).toBeVisible();` after clicking the confirmation button. This ensures the frontend has received a success response from the backend and updated the UI before the test proceeds to navigate away.

Verified by running `e2e/cdu-11.spec.ts` multiple times. All other E2E tests were also verified to pass.

---
*PR created automatically by Jules for task [12491326545992982730](https://jules.google.com/task/12491326545992982730) started by @lgalvao*