### PR TITLE
Improve backend test coverage with targeted unit tests

### DIFF
--- a/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageTest.java
@@ -1,0 +1,146 @@
+package sgc.processo.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+import sgc.alerta.*;
+import sgc.organizacao.*;
+import sgc.organizacao.dto.*;
+import sgc.organizacao.model.*;
+import sgc.processo.model.*;
+import sgc.subprocesso.service.*;
+import sgc.subprocesso.model.Subprocesso;
+
+import java.time.*;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProcessoNotificacaoService - Cobertura")
+class ProcessoNotificacaoServiceCoverageTest {
+
+    @Mock private AlertaFacade alertaService;
+    @Mock private EmailService emailService;
+    @Mock private EmailModelosService emailModelosService;
+    @Mock private OrganizacaoFacade organizacaoFacade;
+    @Mock private ProcessoRepo processoRepo;
+    @Mock private SubprocessoService subprocessoService;
+    @Mock private UsuarioFacade usuarioService;
+
+    @InjectMocks private ProcessoNotificacaoService service;
+
+    @Test
+    @DisplayName("processarFinalizacaoProcesso - deve ignorar se sem participantes")
+    void processarFinalizacaoProcesso_SemParticipantes() {
+        Long codProcesso = 1L;
+        Processo p = new Processo();
+        p.setCodigo(codProcesso);
+        // p.participantes is initialized as empty list by default
+
+        when(processoRepo.findByIdComParticipantes(codProcesso)).thenReturn(Optional.of(p));
+
+        service.emailFinalizacaoProcesso(codProcesso);
+
+        verifyNoInteractions(organizacaoFacade);
+        verifyNoInteractions(emailService);
+    }
+
+    @Test
+    @DisplayName("enviarEmailFinalizacao - deve enviar para unidade INTERMEDIARIA com subordinadas")
+    void enviarEmailFinalizacao_Intermediaria() {
+        Long codProcesso = 1L;
+        Processo p = new Processo();
+        p.setCodigo(codProcesso);
+        p.setDescricao("P1");
+
+        Unidade inter = new Unidade();
+        inter.setCodigo(10L);
+        inter.setSigla("INTER");
+        inter.setTipo(TipoUnidade.INTERMEDIARIA);
+        inter.setSituacao(SituacaoUnidade.ATIVA);
+
+        Unidade sub = new Unidade();
+        sub.setCodigo(20L);
+        sub.setSigla("SUB");
+        sub.setTipo(TipoUnidade.OPERACIONAL);
+        sub.setSituacao(SituacaoUnidade.ATIVA);
+        sub.setUnidadeSuperior(inter);
+
+        // Setup para processarFinalizacaoProcesso
+        p.adicionarParticipantes(Set.of(inter, sub));
+
+        when(processoRepo.findByIdComParticipantes(codProcesso)).thenReturn(Optional.of(p));
+        when(organizacaoFacade.unidadesPorCodigos(any())).thenReturn(List.of(inter, sub));
+        when(organizacaoFacade.buscarResponsaveisUnidades(any())).thenReturn(Collections.emptyMap());
+        when(usuarioService.buscarUsuariosPorTitulos(any())).thenReturn(Collections.emptyMap());
+
+        when(emailModelosService.criarEmailProcessoFinalizadoUnidadesSubordinadas(eq("INTER"), eq("P1"), anyList()))
+            .thenReturn("HTML");
+
+        service.emailFinalizacaoProcesso(codProcesso);
+
+        verify(emailService).enviarEmailHtml(eq("inter@tre-pe.jus.br"), contains("Finalização"), eq("HTML"));
+    }
+
+    @Test
+    @DisplayName("enviarEmailFinalizacao - deve ignorar unidade INTERMEDIARIA sem subordinadas participantes")
+    void enviarEmailFinalizacao_IntermediariaSemSubordinadas() {
+        Long codProcesso = 1L;
+        Processo p = new Processo();
+        p.setCodigo(codProcesso);
+        p.setDescricao("P1");
+
+        Unidade inter = new Unidade();
+        inter.setCodigo(10L);
+        inter.setSigla("INTER");
+        inter.setTipo(TipoUnidade.INTERMEDIARIA);
+        inter.setSituacao(SituacaoUnidade.ATIVA);
+
+        // Setup para processarFinalizacaoProcesso
+        p.adicionarParticipantes(Set.of(inter));
+
+        when(processoRepo.findByIdComParticipantes(codProcesso)).thenReturn(Optional.of(p));
+        when(organizacaoFacade.unidadesPorCodigos(any())).thenReturn(List.of(inter));
+        when(organizacaoFacade.buscarResponsaveisUnidades(any())).thenReturn(Collections.emptyMap());
+
+        service.emailFinalizacaoProcesso(codProcesso);
+
+        verify(emailService, never()).enviarEmailHtml(eq("inter@tre-pe.jus.br"), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("emailInicioProcesso - deve tratar exceção ao enviar email")
+    void emailInicioProcesso_ExcecaoEmail() {
+        Long codProcesso = 1L;
+        Processo p = new Processo();
+        p.setCodigo(codProcesso);
+
+        Unidade u = new Unidade();
+        u.setCodigo(10L);
+        u.setSigla("U1");
+        u.setTipo(TipoUnidade.OPERACIONAL);
+
+        Subprocesso sp = new Subprocesso();
+        sp.setUnidade(u);
+        sp.setProcesso(p);
+
+        // Mocking subprocessoService to return a subprocesso
+        when(subprocessoService.listarEntidadesPorProcesso(codProcesso)).thenReturn(List.of(sp));
+
+        when(processoRepo.findByIdComParticipantes(codProcesso)).thenReturn(Optional.of(p));
+        when(organizacaoFacade.buscarResponsaveisUnidades(any())).thenReturn(Collections.emptyMap());
+        when(organizacaoFacade.unidadePorCodigo(10L)).thenReturn(u);
+
+        when(emailModelosService.criarEmailInicioProcessoConsolidado(any(), any(), any(), anyBoolean(), anyList()))
+            .thenReturn("HTML");
+
+        doThrow(new RuntimeException("SMTP Error")).when(emailService).enviarEmailHtml(any(), any(), any());
+
+        // Should not throw exception
+        service.emailInicioProcesso(codProcesso);
+
+        verify(alertaService).criarAlertasProcessoIniciado(any(), anyList());
+    }
+}

--- a/backend/src/test/java/sgc/seguranca/SgcPermissionEvaluatorCoverageTest.java
+++ b/backend/src/test/java/sgc/seguranca/SgcPermissionEvaluatorCoverageTest.java
@@ -1,0 +1,198 @@
+package sgc.seguranca;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+import sgc.organizacao.model.*;
+import sgc.organizacao.service.*;
+import sgc.processo.model.*;
+import sgc.subprocesso.model.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SgcPermissionEvaluator - Cobertura")
+class SgcPermissionEvaluatorCoverageTest {
+
+    @Mock private SubprocessoRepo subprocessoRepo;
+    @Mock private MovimentacaoRepo movimentacaoRepo;
+    @Mock private HierarquiaService hierarquiaService;
+    @Mock private ProcessoRepo processoRepo;
+
+    @InjectMocks private SgcPermissionEvaluator evaluator;
+
+    private Usuario usuario(Perfil perfil, Long codUnidade) {
+        Usuario u = new Usuario();
+        u.setPerfilAtivo(perfil);
+        u.setUnidadeAtivaCodigo(codUnidade);
+        u.setTituloEleitoral("123");
+        return u;
+    }
+
+    private Subprocesso criarSubprocesso(Long codigo, Long codUnidade) {
+        Subprocesso sp = new Subprocesso();
+        sp.setCodigo(codigo);
+        sp.setUnidade(Unidade.builder().codigo(codUnidade).sigla("U"+codUnidade).build());
+        return sp;
+    }
+
+    @Test
+    @DisplayName("checkSubprocesso - Processo FINALIZADO bloqueia escrita")
+    void checkSubprocesso_Finalizado_BloqueiaEscrita() {
+        Subprocesso sp = criarSubprocesso(1L, 10L);
+        Processo p = new Processo();
+        p.setSituacao(SituacaoProcesso.FINALIZADO);
+        sp.setProcesso(p);
+
+        Usuario user = usuario(Perfil.ADMIN, 10L);
+
+        boolean result = evaluator.checkPermission(user, sp, "EDITAR_CADASTRO");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("checkSubprocesso - Processo FINALIZADO permite leitura")
+    void checkSubprocesso_Finalizado_PermiteLeitura() {
+        Subprocesso sp = criarSubprocesso(1L, 10L);
+        Processo p = new Processo();
+        p.setSituacao(SituacaoProcesso.FINALIZADO);
+        sp.setProcesso(p);
+
+        Usuario user = usuario(Perfil.ADMIN, 10L); // Admin ve tudo
+
+        boolean result = evaluator.checkPermission(user, sp, "VISUALIZAR");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("checkSubprocesso - CONSULTAR_PARA_IMPORTACAO permite acesso fora da hierarquia para CHEFE")
+    void checkSubprocesso_Importacao_Chefe() {
+        Subprocesso sp = criarSubprocesso(1L, 20L); // Unidade diferente
+        sp.setProcesso(new Processo()); // Nao finalizado
+
+        Usuario user = usuario(Perfil.CHEFE, 10L);
+
+        boolean result = evaluator.checkPermission(user, sp, "CONSULTAR_PARA_IMPORTACAO");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("checkSubprocesso - VERIFICAR_IMPACTOS permite visualizacao para GESTOR")
+    void checkSubprocesso_Impactos_Gestor() {
+        Subprocesso sp = criarSubprocesso(1L, 20L);
+        sp.setProcesso(new Processo());
+
+        Usuario user = usuario(Perfil.GESTOR, 10L);
+
+        boolean result = evaluator.checkPermission(user, sp, "VERIFICAR_IMPACTOS");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("checkSubprocesso - Escrita falha se localizacao diferente da unidade usuario")
+    void checkSubprocesso_Escrita_LocalizacaoDiferente() {
+        Subprocesso sp = criarSubprocesso(1L, 10L);
+        sp.setProcesso(new Processo());
+        sp.setLocalizacaoAtual(Unidade.builder().codigo(20L).build()); // Localizacao difere da unidade origem e do usuario
+
+        Usuario user = usuario(Perfil.CHEFE, 10L); // Chefe na unidade 10
+
+        // Acao de escrita
+        boolean result = evaluator.checkPermission(user, sp, "EDITAR_CADASTRO");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("checkSubprocesso - Escrita sucesso se localizacao igual unidade usuario")
+    void checkSubprocesso_Escrita_LocalizacaoIgual() {
+        Subprocesso sp = criarSubprocesso(1L, 10L);
+        sp.setProcesso(new Processo());
+        sp.setLocalizacaoAtual(Unidade.builder().codigo(10L).build());
+
+        Usuario user = usuario(Perfil.CHEFE, 10L); // Chefe deve editar cadastro
+
+        boolean result = evaluator.checkPermission(user, sp, "EDITAR_CADASTRO");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("checkProcesso - FINALIZADO bloqueia escrita")
+    void checkProcesso_Finalizado_BloqueiaEscrita() {
+        Processo p = new Processo();
+        p.setSituacao(SituacaoProcesso.FINALIZADO);
+
+        Usuario user = usuario(Perfil.ADMIN, 10L);
+
+        boolean result = evaluator.checkPermission(user, p, "HOMOLOGAR_CADASTRO_EM_BLOCO");
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("checkProcesso - Permite acoes em bloco para GESTOR")
+    void checkProcesso_Gestor_Bloco() {
+        Processo p = new Processo();
+        p.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
+
+        Usuario user = usuario(Perfil.GESTOR, 10L);
+
+        boolean result = evaluator.checkPermission(user, p, "HOMOLOGAR_CADASTRO_EM_BLOCO");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("obterUnidadeLocalizacao - fallback para unidade subprocesso se sem movimentos")
+    void obterUnidadeLocalizacao_Fallback() {
+        Subprocesso sp = criarSubprocesso(1L, 10L);
+        sp.setProcesso(new Processo());
+        // sp.localizacaoAtual is null
+
+        when(movimentacaoRepo.findFirstBySubprocessoCodigoOrderByDataHoraDesc(1L)).thenReturn(Optional.empty());
+
+        Usuario user = usuario(Perfil.CHEFE, 10L);
+        // Deve usar unidade do sp (10L) que é igual a do usuario -> allow
+        boolean result = evaluator.checkPermission(user, sp, "EDITAR_CADASTRO");
+
+        assertThat(result).isTrue();
+        assertThat(sp.getLocalizacaoAtual().getCodigo()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("checkHierarquia - GESTOR usa hierarquia service")
+    void checkHierarquia_Gestor() {
+        Subprocesso sp = criarSubprocesso(1L, 20L);
+        sp.setProcesso(new Processo());
+
+        Usuario user = usuario(Perfil.GESTOR, 10L);
+
+        when(hierarquiaService.isMesmaOuSubordinada(any(), any())).thenReturn(true);
+
+        boolean result = evaluator.checkPermission(user, sp, "VISUALIZAR");
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasPermission - Collection")
+    void hasPermission_Collection() {
+        Subprocesso sp1 = criarSubprocesso(1L, 10L);
+        sp1.setProcesso(new Processo());
+        sp1.setLocalizacaoAtual(Unidade.builder().codigo(10L).build());
+
+        Subprocesso sp2 = criarSubprocesso(2L, 10L);
+        sp2.setProcesso(new Processo());
+        sp2.setLocalizacaoAtual(Unidade.builder().codigo(10L).build());
+
+        Usuario user = usuario(Perfil.CHEFE, 10L);
+
+        // Using the interface method directly
+        org.springframework.security.core.Authentication auth = mock(org.springframework.security.core.Authentication.class);
+        when(auth.getPrincipal()).thenReturn(user);
+
+        boolean result = evaluator.hasPermission(auth, List.of(sp1, sp2), "EDITAR_CADASTRO");
+        assertThat(result).isTrue();
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoServiceCoverageTest.java
@@ -1,0 +1,256 @@
+package sgc.subprocesso.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
+import sgc.alerta.*;
+import sgc.comum.erros.*;
+import sgc.mapa.dto.*;
+import sgc.mapa.model.*;
+import sgc.mapa.service.*;
+import sgc.organizacao.*;
+import sgc.organizacao.model.*;
+import sgc.processo.model.*;
+import sgc.subprocesso.dto.*;
+import sgc.subprocesso.model.*;
+import sgc.testutils.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SubprocessoService - Cobertura")
+class SubprocessoServiceCoverageTest {
+
+    @Mock private SubprocessoRepo subprocessoRepo;
+    @Mock private MovimentacaoRepo movimentacaoRepo;
+    @Mock private AnaliseRepo analiseRepo;
+    @Mock private AlertaFacade alertaService;
+    @Mock private OrganizacaoFacade organizacaoFacade;
+    @Mock private UsuarioFacade usuarioFacade;
+    @Mock private ImpactoMapaService impactoMapaService;
+    @Mock private EmailService emailService;
+    @Mock private MapaManutencaoService mapaManutencaoService;
+    @Mock private MapaSalvamentoService mapaSalvamentoService;
+
+    @InjectMocks private SubprocessoService service;
+
+    @BeforeEach
+    void setup() {
+        service.setMapaManutencaoService(mapaManutencaoService);
+        service.setSubprocessoRepo(subprocessoRepo);
+        service.setMovimentacaoRepo(movimentacaoRepo);
+    }
+
+    private Subprocesso criarSubprocesso(Long id, SituacaoSubprocesso situacao) {
+        Subprocesso sp = new Subprocesso();
+        sp.setCodigo(id);
+        sp.setSituacaoForcada(situacao);
+        sp.setUnidade(new Unidade());
+        sp.getUnidade().setSigla("U1");
+        sp.setProcesso(new Processo());
+        sp.getProcesso().setDescricao("Processo 1");
+        sp.getProcesso().setTipo(TipoProcesso.MAPEAMENTO);
+        sp.setMapa(new Mapa());
+        sp.getMapa().setCodigo(100L);
+        return sp;
+    }
+
+    @Test
+    @DisplayName("validarExistenciaAtividades - deve lançar erro se mapa sem atividades")
+    void validarExistenciaAtividades_SemAtividades() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        when(mapaManutencaoService.buscarAtividadesPorMapaCodigoComConhecimentos(100L)).thenReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> service.validarExistenciaAtividades(codigo))
+                .isInstanceOf(ErroValidacao.class)
+                .hasMessage("O mapa de competências deve ter ao menos uma atividade cadastrada.");
+    }
+
+    @Test
+    @DisplayName("validarExistenciaAtividades - deve lançar erro se atividades sem conhecimento")
+    void validarExistenciaAtividades_SemConhecimento() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+        Atividade a = new Atividade();
+        a.setConhecimentos(Collections.emptySet());
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        when(mapaManutencaoService.buscarAtividadesPorMapaCodigoComConhecimentos(100L)).thenReturn(List.of(a));
+
+        assertThatThrownBy(() -> service.validarExistenciaAtividades(codigo))
+                .isInstanceOf(ErroValidacao.class)
+                .hasMessage("Todas as atividades devem possuir conhecimentos vinculados. Verifique as atividades pendentes.");
+    }
+
+    @Test
+    @DisplayName("validarSituacaoPermitida - deve lançar erro com mensagem correta")
+    void validarSituacaoPermitida_Erro() {
+        Subprocesso sp = new Subprocesso();
+        sp.setSituacaoForcada(SituacaoSubprocesso.NAO_INICIADO);
+
+        assertThatThrownBy(() -> service.validarSituacaoPermitida(sp, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO))
+                .isInstanceOf(ErroValidacao.class)
+                .hasMessageContaining("Situação do subprocesso não permite esta operação");
+    }
+
+    @Test
+    @DisplayName("validarSituacaoPermitida - deve lançar erro se situacao nula")
+    void validarSituacaoPermitida_SituacaoNula() {
+        Subprocesso sp = new Subprocesso();
+        sp.setSituacaoForcada(null);
+        assertThatThrownBy(() -> service.validarSituacaoPermitida(sp, SituacaoSubprocesso.NAO_INICIADO))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("validarSituacaoPermitida - deve lançar erro se permitidas vazio")
+    void validarSituacaoPermitida_PermitidasVazio() {
+        Subprocesso sp = new Subprocesso();
+        sp.setSituacaoForcada(SituacaoSubprocesso.NAO_INICIADO);
+        assertThatThrownBy(() -> service.validarSituacaoPermitida(sp))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("alterarDataLimite - deve alterar data etapa 2 se situacao for MAPA")
+    void alterarDataLimite_Etapa2() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO);
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+
+        LocalDate novaData = LocalDate.of(2025, 1, 1);
+        service.alterarDataLimite(codigo, novaData);
+
+        assertThat(sp.getDataLimiteEtapa2()).isEqualTo(novaData.atStartOfDay());
+        verify(subprocessoRepo).save(sp);
+    }
+
+    @Test
+    @DisplayName("removerCompetencia - deve voltar para CADASTRO_HOMOLOGADO se mapa ficar vazio (Mapeamento)")
+    void removerCompetencia_MapaFicaVazio_Mapeamento() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO);
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        when(mapaManutencaoService.buscarCompetenciasPorCodMapa(100L)).thenReturn(Collections.emptyList());
+
+        service.removerCompetencia(codigo, 10L);
+
+        assertThat(sp.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+        verify(subprocessoRepo).save(sp);
+    }
+
+    @Test
+    @DisplayName("removerCompetencia - deve voltar para REVISAO_CADASTRO_HOMOLOGADA se mapa ficar vazio (Revisao)")
+    void removerCompetencia_MapaFicaVazio_Revisao() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO);
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        when(mapaManutencaoService.buscarCompetenciasPorCodMapa(100L)).thenReturn(Collections.emptyList());
+
+        service.removerCompetencia(codigo, 10L);
+
+        assertThat(sp.getSituacao()).isEqualTo(SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA);
+        verify(subprocessoRepo).save(sp);
+    }
+
+    @Test
+    @DisplayName("salvarMapaSubprocesso - deve avancar situacao se mapa era vazio")
+    void salvarMapaSubprocesso_EraVazio() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        when(mapaManutencaoService.buscarCompetenciasPorCodMapa(100L)).thenReturn(Collections.emptyList());
+
+        SalvarMapaRequest req = new SalvarMapaRequest("Obs", List.of(new SalvarMapaRequest.CompetenciaRequest(null, "C1", List.of())));
+        service.salvarMapaSubprocesso(codigo, req);
+
+        assertThat(sp.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO);
+        verify(subprocessoRepo).save(sp);
+    }
+
+    @Test
+    @DisplayName("executarAceiteValidacao - deve homologar se nao houver unidade superior")
+    void executarAceiteValidacao_SemSuperior() {
+        Long codigo = 1L;
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO);
+        // Unidade sem superior
+        sp.getUnidade().setUnidadeSuperior(null);
+
+        Usuario user = new Usuario();
+        user.setTituloEleitoral("123");
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        when(organizacaoFacade.buscarPorSigla(any())).thenReturn(new sgc.organizacao.dto.UnidadeDto());
+
+        service.aceitarValidacao(codigo, user);
+
+        assertThat(sp.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO);
+        verify(subprocessoRepo).save(sp);
+        verify(analiseRepo).save(any(Analise.class)); // Cria analise final
+    }
+
+    @Test
+    @DisplayName("disponibilizar - deve usar unidade origem como destino se superior for nulo")
+    void disponibilizar_SemSuperior() {
+        Long codigo = 1L;
+        Usuario user = new Usuario();
+
+        Subprocesso sp = criarSubprocesso(codigo, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+        sp.getUnidade().setUnidadeSuperior(null);
+
+        when(subprocessoRepo.findByIdWithMapaAndAtividades(codigo)).thenReturn(Optional.of(sp));
+        // Mock validacoes
+        Atividade a = new Atividade();
+        a.setConhecimentos(Set.of(new Conhecimento()));
+        when(mapaManutencaoService.buscarAtividadesPorMapaCodigoComConhecimentos(100L)).thenReturn(List.of(a));
+
+        service.disponibilizarCadastro(codigo, user);
+
+        verify(movimentacaoRepo).save(argThat(m -> m.getUnidadeDestino().equals(sp.getUnidade())));
+    }
+
+    @Test
+    @DisplayName("validarAssociacoesMapa - deve lançar erro se competencias sem atividades")
+    void validarAssociacoesMapa_CompetenciaSemAtividade() {
+        Long mapaId = 100L;
+        Competencia c = new Competencia();
+        c.setDescricao("Comp 1");
+        c.setAtividades(Collections.emptySet());
+
+        when(mapaManutencaoService.buscarCompetenciasPorCodMapa(mapaId)).thenReturn(List.of(c));
+
+        assertThatThrownBy(() -> service.validarAssociacoesMapa(mapaId))
+            .isInstanceOf(ErroValidacao.class)
+            .hasMessageContaining("Existem competências que não foram associadas a nenhuma atividade");
+    }
+
+    @Test
+    @DisplayName("validarAssociacoesMapa - deve lançar erro se atividades sem competencia")
+    void validarAssociacoesMapa_AtividadeSemCompetencia() {
+        Long mapaId = 100L;
+        Competencia c = new Competencia();
+        c.setAtividades(Set.of(new Atividade())); // ok
+
+        Atividade a = new Atividade();
+        a.setDescricao("Ativ 1");
+        a.setCompetencias(Collections.emptySet());
+
+        when(mapaManutencaoService.buscarCompetenciasPorCodMapa(mapaId)).thenReturn(List.of(c));
+        when(mapaManutencaoService.buscarAtividadesPorMapaCodigo(mapaId)).thenReturn(List.of(a));
+
+        assertThatThrownBy(() -> service.validarAssociacoesMapa(mapaId))
+            .isInstanceOf(ErroValidacao.class)
+            .hasMessageContaining("Existem atividades que não foram associadas a nenhuma competência");
+    }
+}


### PR DESCRIPTION
Added `SubprocessoServiceCoverageTest.java`, `ProcessoNotificacaoServiceCoverageTest.java`, and `SgcPermissionEvaluatorCoverageTest.java` to improve backend test coverage based on the gaps identified in `cobertura_lacunas.json`. These tests cover edge cases, validations, notification logic, and security permission evaluation.

---
*PR created automatically by Jules for task [12990634859768498973](https://jules.google.com/task/12990634859768498973) started by @lgalvao*