### PR TITLE
Fix ImpactoMapa response mapping in frontend

### DIFF
--- a/frontend/src/services/subprocessoService.ts
+++ b/frontend/src/services/subprocessoService.ts
@@ -99,8 +99,21 @@ export async function obterMapaVisualizacao(
 }
 
 export async function verificarImpactosMapa(codSubprocesso: number): Promise<ImpactoMapa> {
-    const response = await apiClient.get(`/subprocessos/${codSubprocesso}/impactos-mapa`);
-    return response.data as ImpactoMapa;
+    const response = await apiClient.get<any>(`/subprocessos/${codSubprocesso}/impactos-mapa`);
+    const data = response.data;
+
+    // Mapeamento manual para garantir compatibilidade com a interface do frontend
+    return {
+        temImpactos: data.temImpactos,
+        atividadesInseridas: data.inseridas || [],
+        atividadesRemovidas: data.removidas || [],
+        atividadesAlteradas: data.alteradas || [],
+        competenciasImpactadas: data.competenciasImpactadas || [],
+        totalAtividadesInseridas: data.totalInseridas || 0,
+        totalAtividadesRemovidas: data.totalRemovidas || 0,
+        totalAtividadesAlteradas: data.totalAlteradas || 0,
+        totalCompetenciasImpactadas: data.totalCompetenciasImpactadas || 0
+    };
 }
 
 export async function obterMapaCompleto(codSubprocesso: number): Promise<MapaCompleto> {


### PR DESCRIPTION
Resolved a data mismatch between the backend `ImpactoMapaResponse` DTO and the frontend `ImpactoMapa` interface. The backend returns fields like `inseridas`, `removidas`, and `alteradas`, while the frontend expects `atividadesInseridas`, `atividadesRemovidas`, and `atividadesAlteradas`.

Added a manual mapping step in `subprocessoService.ts` within the `verificarImpactosMapa` function to translate the response fields. This ensures the "Impacto no Mapa" modal correctly displays the differences (inserted, removed, altered activities) during the review process.

Verified the fix by running the `cdu-12.spec.ts` E2E test, which previously failed to find the inserted activity text in the modal and now passes successfully.

---
*PR created automatically by Jules for task [6844727295850544062](https://jules.google.com/task/6844727295850544062) started by @lgalvao*