### PR TITLE
Fix nested property search in ComumRepo for CDU-08

### DIFF
--- a/backend/src/main/java/sgc/comum/model/ComumRepo.java
+++ b/backend/src/main/java/sgc/comum/model/ComumRepo.java
@@ -53,7 +53,7 @@ public class ComumRepo {
         var root = cq.from(classe);
 
         var predicates = filtros.entrySet().stream()
-                .map(f -> cb.equal(root.get(f.getKey()), f.getValue()))
+                .map(f -> cb.equal(getPath(root, f.getKey()), f.getValue()))
                 .toArray(Predicate[]::new);
 
         cq.where(predicates);
@@ -63,6 +63,14 @@ public class ComumRepo {
         } catch (NoResultException e) {
             throw new ErroEntidadeNaoEncontrada(classe.getSimpleName(), filtros.values().toString());
         }
+    }
+
+    private Path<?> getPath(Root<?> root, String attributeName) {
+        Path<?> path = root;
+        for (String part : attributeName.split("\\.")) {
+            path = path.get(part);
+        }
+        return path;
     }
 
     /**

--- a/e2e-status.md
+++ b/e2e-status.md
@@ -1,0 +1,13 @@
+# Status dos Testes E2E
+
+| CDU | Status | Observações |
+|---|---|---|
+| CDU-01 | ✅ Passou | Login e estrutura básica funcionais. |
+| CDU-02 | ✅ Passou | Painel principal, criação e visualização de processos ok. |
+| CDU-03 | ✅ Passou | Manter Processo (CRUD, validações, regras de negócio) ok. |
+| CDU-04 | ✅ Passou | Iniciar Processo (subprocessos, notificações) ok. |
+| CDU-05 | ✅ Passou | Processo de Revisão (fluxo completo) ok. |
+| CDU-06 | ✅ Passou | Detalhar Processo (visão Admin e Gestor) ok. |
+| CDU-07 | ✅ Passou | Detalhar Subprocesso (todas as visões) ok. |
+| CDU-08 | ✅ Passou | Manter Cadastro de Atividades. **FIX**: Corrigido erro de `IllegalArgumentException` no backend ao acessar propriedades aninhadas (`atividade.codigo`) em critérios de busca. |
+| Smoke | ✅ Passou | Teste de fumaça cobrindo principais fluxos do sistema. |


### PR DESCRIPTION
Fixes a critical backend bug where searching for entities using nested properties (e.g., `atividade.codigo`) in `ComumRepo` caused an `IllegalArgumentException`. This issue was blocking the CDU-08 E2E test ("Manter Cadastro de Atividades"). The fix involves enhancing the `ComumRepo` to correctly traverse object graphs using JPA Criteria API when constructing search predicates. Verified with CDU-08 and Smoke tests.

---
*PR created automatically by Jules for task [9606598323702109860](https://jules.google.com/task/9606598323702109860) started by @lgalvao*