### PR TITLE
Clean up unnecessary comments across codebase

### DIFF
--- a/backend/src/main/java/sgc/comum/erros/ErroInterno.java
+++ b/backend/src/main/java/sgc/comum/erros/ErroInterno.java
@@ -3,7 +3,6 @@ package sgc.comum.erros;
 /**
  * Exceção base para erros internos que indicam bugs, configuração incorreta ou violação de
  * invariantes do sistema.
- *
  */
 public abstract class ErroInterno extends RuntimeException {
     /**

--- a/backend/src/main/java/sgc/mapa/AtividadeController.java
+++ b/backend/src/main/java/sgc/mapa/AtividadeController.java
@@ -26,11 +26,6 @@ public class AtividadeController {
 
     /**
      * Busca e retorna uma atividade específica pelo seu código.
-     *
-     * @param codAtividade O código da atividade a ser buscada.
-     * @return Um {@link ResponseEntity} contendo a {@link Atividade}
-     * correspondente ou um status
-     * 404 Not Found se a atividade não for encontrada.
      */
     @GetMapping("/{codAtividade}")
     @PreAuthorize("isAuthenticated()")
@@ -76,10 +71,6 @@ public class AtividadeController {
 
     /**
      * Lista todos os conhecimentos associados a uma atividade específica.
-     *
-     * @param codAtividade O código da atividade pai.
-     * @return Um {@link ResponseEntity} com status 200 OK e a lista de
-     * {@link Conhecimento}.
      */
     @GetMapping("/{codAtividade}/conhecimentos")
     @PreAuthorize("isAuthenticated()")

--- a/backend/src/main/java/sgc/mapa/MapaController.java
+++ b/backend/src/main/java/sgc/mapa/MapaController.java
@@ -27,8 +27,6 @@ public class MapaController {
 
     /**
      * Retorna uma lista com todos os mapas de competências.
-     *
-     * @return Uma {@link List} de {@link Mapa}.
      */
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR', 'CHEFE')")
@@ -40,9 +38,6 @@ public class MapaController {
 
     /**
      * Busca e retorna um mapa de competências específico pelo seu código.
-     *
-     * @param codigo O código do mapa a ser buscado.
-     * @return Um {@link ResponseEntity} contendo o {@link Mapa} correspondente.
      */
     @GetMapping("/{codigo}")
     @PreAuthorize("hasAnyRole('ADMIN', 'GESTOR', 'CHEFE')")

--- a/backend/src/main/java/sgc/mapa/model/CompetenciaRepo.java
+++ b/backend/src/main/java/sgc/mapa/model/CompetenciaRepo.java
@@ -18,7 +18,6 @@ import java.util.*;
  * <li>{@link #findCompetenciaAndAtividadeIdsByMapaCodigo(Long)} - Projeção SQL otimizada</li>
  * <li> - Sem relacionamentos (mais leve)</li>
  * </ul>
- *
  */
 @Repository
 public interface CompetenciaRepo extends JpaRepository<Competencia, Long> {
@@ -29,8 +28,6 @@ public interface CompetenciaRepo extends JpaRepository<Competencia, Long> {
      *
      * <p><b>Performance:</b> EntityGraph evita N+1 queries mas pode duplicar dados em memória
      * se múltiplas competências compartilham atividades.
-     *
-     * @param mapaCodigo Código do mapa
      */
     @EntityGraph(attributePaths = {"atividades"})
     List<Competencia> findByMapa_Codigo(@Param("mapaCodigo") Long mapaCodigo);
@@ -46,8 +43,6 @@ public interface CompetenciaRepo extends JpaRepository<Competencia, Long> {
      *
      * <p><b>Trade-off:</b> Requer parsing manual de Object[] no código cliente.
      *
-     * @param mapaCodigo Código do mapa
-     * @return Lista de arrays de objetos [Long competenciaId, String descricao, Long atividadeId]
      * @see sgc.mapa.service.MapaVisualizacaoService#obterMapaParaVisualizacao(sgc.subprocesso.model.Subprocesso)
      */
     @Query("""
@@ -69,8 +64,6 @@ public interface CompetenciaRepo extends JpaRepository<Competencia, Long> {
      * <p><b>Atenção:</b> Acessar {@code competencia.getAtividades()} causará lazy loading
      * (N+1 queries) se fora de transação.
      *
-     * @param mapaCodigo Código do mapa
-     * @return Lista de competências sem relacionamentos carregados
      * @see sgc.mapa.service.MapaManutencaoService#buscarCompetenciasPorCodMapaSemRelacionamentos(Long)
      */
     @Query("SELECT c FROM Competencia c WHERE c.mapa.codigo = :mapaCodigo")
@@ -78,8 +71,6 @@ public interface CompetenciaRepo extends JpaRepository<Competencia, Long> {
 
     /**
      * Remove todas as competências de um mapa.
-     *
-     * @param mapaCodigo Código do mapa
      */
     void deleteByMapa_Codigo(Long mapaCodigo);
 }

--- a/backend/src/main/java/sgc/organizacao/service/ResponsavelUnidadeService.java
+++ b/backend/src/main/java/sgc/organizacao/service/ResponsavelUnidadeService.java
@@ -23,7 +23,6 @@ import static java.util.stream.Collectors.*;
  *   <li>Carregamento de perfis e atribuições de usuários</li>
  *   <li>Consultas em lote de responsáveis</li>
  * </ul>
- *
  */
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/sgc/processo/ProcessoFacade.java
+++ b/backend/src/main/java/sgc/processo/ProcessoFacade.java
@@ -145,7 +145,6 @@ public class ProcessoFacade {
         Processo processo = buscarEntidadePorId(codProcesso);
         Unidade unidade = organizacaoFacade.unidadePorCodigo(unidadeCodigo);
 
-        // Verifica se unidade participa do processo
         if (processo.getParticipantes().stream().noneMatch(u -> u.getUnidadeCodigo().equals(unidadeCodigo))) {
             throw new ErroProcesso("Unidade não participa deste processo.");
         }

--- a/backend/src/main/java/sgc/processo/service/ProcessoValidador.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoValidador.java
@@ -72,8 +72,6 @@ class ProcessoValidador {
 
     /**
      * Valida se as unidades participantes são elegíveis (não são INTERMEDIARIA).
-     *
-     * @return Optional com mensagem de erro se houver unidade inválida
      */
     public Optional<String> validarTiposUnidades(List<Unidade> unidades) {
         if (unidades.isEmpty()) {

--- a/backend/src/main/java/sgc/subprocesso/model/SituacaoSubprocesso.java
+++ b/backend/src/main/java/sgc/subprocesso/model/SituacaoSubprocesso.java
@@ -8,7 +8,6 @@ import sgc.processo.model.*;
 public enum SituacaoSubprocesso {
     NAO_INICIADO("Não iniciado"),
 
-    // Mapeamento
     MAPEAMENTO_CADASTRO_EM_ANDAMENTO("Cadastro em andamento"),
     MAPEAMENTO_CADASTRO_DISPONIBILIZADO("Cadastro disponibilizado"),
     MAPEAMENTO_CADASTRO_HOMOLOGADO("Cadastro homologado"),
@@ -18,7 +17,6 @@ public enum SituacaoSubprocesso {
     MAPEAMENTO_MAPA_VALIDADO("Mapa validado"),
     MAPEAMENTO_MAPA_HOMOLOGADO("Mapa homologado"),
 
-    // Revisão
     REVISAO_CADASTRO_EM_ANDAMENTO("Revisão de cadastro em andamento"),
     REVISAO_CADASTRO_DISPONIBILIZADA("Revisão de cadastro disponibilizada"),
     REVISAO_CADASTRO_HOMOLOGADA("Revisão de cadastro homologada"),
@@ -28,7 +26,6 @@ public enum SituacaoSubprocesso {
     REVISAO_MAPA_VALIDADO("Mapa validado"),
     REVISAO_MAPA_HOMOLOGADO("Mapa homologado"),
 
-    // Diagnóstico
     DIAGNOSTICO_AUTOAVALIACAO_EM_ANDAMENTO("Autoavaliação em andamento"),
     DIAGNOSTICO_MONITORAMENTO("Monitoramento"),
     DIAGNOSTICO_CONCLUIDO("Concluído");

--- a/clean_comments.py
+++ b/clean_comments.py
@@ -1,0 +1,109 @@
+import os
+import re
+
+def process_file(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    original_content = content
+
+    # 1. Remove visual separator lines like // ======== or // --------
+    content = re.sub(r'^[ \t]*//[-=]{3,}[ \t]*\n', '', content, flags=re.MULTILINE)
+    content = re.sub(r'^[ \t]*/\*[-=]{3,}\*/[ \t]*\n', '', content, flags=re.MULTILINE)
+
+    # 2. Obvious @param and @return
+    # This regex deletes `@param` and `@return` lines and ANY subsequent continuation lines
+    # (lines starting with `* ` but not `* @` and not `*/`)
+    # We use a pattern to match the `@param`/`@return` line AND optionally any following lines
+    # that just contain `* ` and text (but not another tag or the end of comment).
+    # A continuation line typically looks like `[ \t]*\*[ \t]+[^@\n/].*?\n`
+    chunk_pattern = r'^[ \t]*\*[ \t]*@(param|return(s)?)[ \t]+.*?\n(?:[ \t]*\*[ \t]+(?:[^@ \n].*?)?\n)*'
+    content = re.sub(chunk_pattern, '', content, flags=re.MULTILINE)
+
+    # We remove empty lines at the end of javadoc blocks before */
+    content = re.sub(r'(\n[ \t]*\*[ \t]*)+\n([ \t]*)\*/', r'\n\2*/', content)
+    # We remove empty lines at the start of javadoc blocks after /**
+    content = re.sub(r'/\*\*[ \t]*\n([ \t]*\*[ \t]*\n)+', '/**\n', content)
+    # Remove empty JSDoc/Javadoc blocks
+    content = re.sub(r'^[ \t]*/\*\*[ \t]*\n([ \t]*\*[ \t]*\n)*[ \t]*\*/[ \t]*\n', '', content, flags=re.MULTILINE)
+
+    # 3. Conversational and obvious single line comments
+    phrases = [
+        "This function", "This class", "This method", "Here we",
+        "We need to", "The purpose of", "As requested", "This component",
+        "Essa função", "Essa classe", "Esse método", "Aqui nós", "Nós precisamos",
+        "O objetivo desse", "Como solicitado", "Esse componente"
+    ]
+
+    obvious_starts = [
+        "cria um", "retorna um", "retorna a", "retorna o", "atualiza o", "atualiza a",
+        "busca um", "busca o", "busca a", "deleta o", "deleta a", "salva o", "salva a",
+        "verifica se", "checa se", "valida o", "valida a", "valida se",
+        "função para", "método para", "classe que", "componente que",
+        "import", "imports", "define", "definição de", "declaração de",
+        "inicializa", "inicia o", "inicia a", "configura o", "configura a",
+        "renderiza o", "renderiza a", "estado de", "variável que",
+        "adiciona o", "adiciona a", "remove o", "remove a",
+        "lida com", "trata o", "trata a", "trata erro",
+        "exporta", "export default", "export", "interface", "tipo",
+        "chama o", "chama a", "executa o", "executa a",
+        "define a props", "define as props", "define as propriedades", "propriedades",
+        "importa", "importa os", "importa as"
+    ]
+
+    lines = content.split('\n')
+    new_lines = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith('//'):
+            comment_text = stripped[2:].strip()
+
+            # Skip jacoco ignores and eslint/ts/ide directives
+            ct_lower = comment_text.lower()
+            if ct_lower.startswith("jacoco") or ct_lower.startswith("eslint") or ct_lower.startswith("@ts") or ct_lower.startswith("noinspection"):
+                new_lines.append(line)
+                continue
+
+            if len(comment_text.split()) <= 2:
+                continue
+
+            is_bad = False
+            for phrase in phrases:
+                if ct_lower.startswith(phrase.lower()):
+                    is_bad = True
+                    break
+
+            if is_bad:
+                continue
+
+            for phrase in obvious_starts:
+                if ct_lower.startswith(phrase):
+                    is_bad = True
+                    break
+
+            if is_bad:
+                continue
+
+        new_lines.append(line)
+
+    content = '\n'.join(new_lines)
+
+    if content != original_content:
+        with open(filepath, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return True
+    return False
+
+modified_files = []
+
+for root, dirs, files in os.walk('.'):
+    if 'node_modules' in root or '.git' in root or 'build' in root or 'dist' in root or 'test' in root or '__tests__' in root or 'stories' in root:
+        continue
+    for file in files:
+        if file.endswith(('.ts', '.js', '.vue', '.java')):
+            if process_file(os.path.join(root, file)):
+                modified_files.append(os.path.join(root, file))
+
+print(f"Modified {len(modified_files)} files.")

--- a/e2e/captura-telas.spec.ts
+++ b/e2e/captura-telas.spec.ts
@@ -115,7 +115,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await expect(page).toHaveURL(/\/processo\/cadastro/);
             await capturarTela(page, '02-painel', '02-criar-processo-form-vazio');
 
-            // Preenchendo formulário
             await page.getByTestId('inp-processo-descricao').fill(descricaoProcesso);
             await page.getByTestId('sel-processo-tipo').selectOption('MAPEAMENTO');
             const dataLimite = new Date();
@@ -140,7 +139,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await page.getByTestId('chk-arvore-unidade-SECAO_111').click();
             await capturarTela(page, '02-painel', '05-arvore-unidades-selecionada');
 
-            // Salvar processo
             await page.getByTestId('btn-processo-salvar').click();
             await expect(page).toHaveURL(/\/painel/);
             await expect(page.getByTestId('tbl-processos')).toBeVisible();
@@ -308,7 +306,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await page.getByTestId('btn-logout').click();
             await login(page, USUARIOS.CHEFE_SECAO_211.titulo, USUARIOS.CHEFE_SECAO_211.senha);
 
-            // Acessar subprocesso
             await page.getByTestId('tbl-processos').getByText(descricao).first().click();
             await navegarParaSubprocesso(page, UNIDADE_ALVO);
             await capturarTela(page, '04-subprocesso', '01-dashboard-subprocesso', {fullPage: true});
@@ -317,7 +314,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await navegarParaAtividades(page);
             await capturarTela(page, '04-subprocesso', '02-cadastro-atividades-vazio', {fullPage: true});
 
-            // Adicionar atividade
             const atividadeDesc = `Atividade Teste ${Date.now()}`;
             await page.getByTestId('inp-nova-atividade').fill(atividadeDesc);
             await capturarTela(page, '04-subprocesso', '03-cadastro-atividades-preenchendo');
@@ -325,7 +321,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await expect(page.getByText(atividadeDesc, {exact: true})).toBeVisible();
             await capturarTela(page, '04-subprocesso', '04-cadastro-atividades-com-uma', {fullPage: true});
 
-            // Adicionar conhecimentos
             const card = page.locator('.atividade-card', {has: page.getByText(atividadeDesc)});
             await card.getByTestId('inp-novo-conhecimento').fill('Java');
             await capturarTela(page, '04-subprocesso', '05-cadastro-conhecimento-preenchendo');
@@ -491,7 +486,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await acessarSubprocessoChefeDireto(page, descricao, 'SECAO_121');
             await navegarParaAtividades(page);
 
-            // Adicionar atividades
             await adicionarAtividade(page, 'Desenvolvimento Web');
             await adicionarConhecimento(page, 'Desenvolvimento Web', 'Vue.js');
             await adicionarConhecimento(page, 'Desenvolvimento Web', 'TypeScript');
@@ -538,7 +532,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             // Entrar no cadastro de atividades (visualização)
             await navegarParaAtividadesVisualizacao(page);
 
-            // Homologar cadastro
             await page.getByTestId('btn-acao-analisar-principal').click();
             await page.getByTestId('btn-aceite-cadastro-confirmar').click();
             await page.waitForTimeout(100);
@@ -548,7 +541,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await navegarParaMapa(page);
             await capturarTela(page, '05-mapa', '01-mapa-vazio', {fullPage: true});
 
-            // Criar competência
             await abrirModalCriarCompetencia(page);
             await page.waitForTimeout(100);
             await capturarTela(page, '05-mapa', '02-modal-criar-competencia');
@@ -557,7 +549,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await page.getByTestId('inp-criar-competencia-descricao').fill(competenciaDesc);
             await capturarTela(page, '05-mapa', '03-modal-criar-competencia-preenchida');
 
-            // Selecionar atividades
             const modal = page.getByTestId('mdl-criar-competencia');
             await modal.locator('label').filter({hasText: 'Desenvolvimento Web'}).click();
             await modal.locator('label').filter({hasText: 'Desenvolvimento Backend'}).click();
@@ -574,7 +565,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await page.waitForTimeout(100);
             await capturarTela(page, '05-mapa', '06-mapa-competencia-hover');
 
-            // Disponibilizar mapa
             await page.getByTestId('btn-cad-mapa-disponibilizar').click();
             await page.waitForTimeout(100);
             await capturarTela(page, '05-mapa', '07-modal-disponibilizar-mapa');
@@ -596,7 +586,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         test('Captura elementos de navegação', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Menu principal
             await capturarTela(page, '06-navegacao', '01-menu-principal');
 
             // Configurações (se admin)
@@ -610,18 +599,15 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await page.waitForTimeout(100);
             await capturarTela(page, '06-navegacao', '03-unidades', {fullPage: true});
 
-            // Seção Relatórios
             await page.getByText('Relatórios').click();
             await page.waitForTimeout(100);
             await capturarTela(page, '06-navegacao', '04-relatorios', {fullPage: true});
 
-            // Seção Histórico
             await page.getByText('Histórico').click();
             await page.waitForTimeout(100);
             await capturarTela(page, '06-navegacao', '05-historico', {fullPage: true});
             await capturarComponente(page.getByRole('navigation').first(), '06-navegacao', '05a-barra-lateral');
 
-            // Rodapé
             await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
             await page.waitForTimeout(100);
             await capturarTela(page, '06-navegacao', '06-rodape');
@@ -632,7 +618,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         test('Captura diferentes estados de processo', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Processo CRIADO
             const processosCriado = `Proc CRIADO ${Date.now()}`;
             await criarProcesso(page, {
                 descricao: processosCriado,
@@ -650,7 +635,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
 
             await capturarTela(page, '07-estados', '01-processo-criado');
 
-            // Processo EM_ANDAMENTO
             const processosAndamento = `Proc ANDAMENTO ${Date.now()}`;
             await criarProcesso(page, {
                 descricao: processosAndamento,
@@ -679,19 +663,15 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await page.setViewportSize({width: 1366, height: 768});
             await capturarTela(page, '08-responsividade', '02-desktop-1366x768', {fullPage: true});
 
-            // Tablet (768x1024)
             await page.setViewportSize({width: 768, height: 1024});
             await capturarTela(page, '08-responsividade', '03-tablet-768x1024', {fullPage: true});
 
-            // Mobile (375x667)
             await page.setViewportSize({width: 375, height: 667});
             await capturarTela(page, '08-responsividade', '04-mobile-375x667', {fullPage: true});
         });
     });
 
-    // ========================================================================
     // SEÇÃO 09 - OPERAÇÕES EM BLOCO (CDUs 22-26)
-    // ========================================================================
     test.describe('09 - Operações em Bloco', () => {
         test('Captura fluxo de aceitar cadastros em bloco', async ({page}) => {
             // Prepara cenário: criar processo com unidades subordinadas e disponibilizar cadastros
@@ -789,9 +769,7 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 10 - GESTÃO DE SUBPROCESSOS (CDUs 27, 32-34)
-    // ========================================================================
     test.describe('10 - Gestão de Subprocessos', () => {
         test('Captura modais de gestão de subprocesso', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -814,7 +792,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             const processoId = await extrairProcessoId(page);
             if (processoId > 0) cleanup.registrar(processoId);
 
-            // Acessar subprocesso
             await page.getByRole('row', {name: /SECAO_121/i}).click();
             await expect(page).toHaveURL(/\/processo\/\d+\/SECAO_121/);
             await capturarTela(page, '10-gestao-subprocessos', '01-detalhes-subprocesso-admin', {fullPage: true});
@@ -846,9 +823,7 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 11 - GESTÃO DE UNIDADES E ATRIBUIÇÕES (CDU-28)
-    // ========================================================================
     test.describe('11 - Gestão de Unidades', () => {
         test('Captura página de unidades e atribuição temporária', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -888,9 +863,7 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 12 - HISTÓRICO DE PROCESSOS (CDU-29)
-    // ========================================================================
     test.describe('12 - Histórico', () => {
         test('Captura seção de histórico', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -912,14 +885,11 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 13 - CONFIGURAÇÕES E ADMINISTRADORES (CDUs 30-31)
-    // ========================================================================
     test.describe('13 - Configurações', () => {
         test('Captura página de configurações e administradores', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Acessar configurações
             await page.getByTestId('btn-configuracoes').click();
             await page.waitForTimeout(500);
             await capturarTela(page, '13-configuracoes', '01-pagina-configuracoes', {fullPage: true});
@@ -949,14 +919,11 @@ test.describe('Captura de Telas - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 14 - RELATÓRIOS (CDUs 35-36)
-    // ========================================================================
     test.describe('14 - Relatórios', () => {
         test('Captura página e modais de relatórios', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Acessar relatórios
             const linkRelatorios = page.getByRole('link', {name: /Relatórios/i});
             if (await linkRelatorios.isVisible().catch(() => false)) {
                 await linkRelatorios.click();
@@ -974,7 +941,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
                         await capturarComponente(modalRelatorio, '14-relatorios', '02a-modal-relatorio-andamento-detalhe');
                     }
 
-                    // Verificar filtros
                     const filtroTipo = page.getByTestId('sel-filtro-tipo');
                     if (await filtroTipo.isVisible().catch(() => false)) {
                         await capturarTela(page, '14-relatorios', '03-filtros-relatorio');

--- a/e2e/cdu-02.spec.ts
+++ b/e2e/cdu-02.spec.ts
@@ -152,7 +152,6 @@ test.describe('CDU-02 - Visualizar Painel', () => {
             await expect(page.getByTestId('chk-arvore-unidade-SECAO_112')).toBeChecked();
             await expect(page.getByTestId('chk-arvore-unidade-SECAO_113')).toBeChecked();
 
-            // Salva o processo
             await page.getByTestId('btn-processo-salvar').click();
 
             await expect(page).toHaveURL(/\/painel/);

--- a/e2e/cdu-03.spec.ts
+++ b/e2e/cdu-03.spec.ts
@@ -43,7 +43,6 @@ test.describe('CDU-03 - Manter Processo', () => {
         cleanupAutomatico: ReturnType<typeof useProcessoCleanup>
     }) => {
         const descricaoOriginal = `Processo para Edição - ${Date.now()}`;
-        // Cria um processo inicial
         await criarProcesso(page, {
             descricao: descricaoOriginal,
             tipo: 'MAPEAMENTO',
@@ -158,7 +157,6 @@ test.describe('CDU-03 - Manter Processo', () => {
 
         // 5. Teste Unidade Interoperacional (Raiz independente)
         // Requisito: "Se a raiz for interoperacional, ela poderá ser selecionada ainda que subordinadas não o sejam".
-        // Limpar filhos
         await page.getByTestId('chk-arvore-unidade-SECAO_111').click();
         await page.getByTestId('chk-arvore-unidade-SECAO_112').click();
         await page.getByTestId('chk-arvore-unidade-SECAO_113').click();
@@ -186,7 +184,6 @@ test.describe('CDU-03 - Manter Processo', () => {
             iniciar: true
         });
 
-        // Pegar cleanup
         await page.getByTestId('tbl-processos').getByText(descricaoProcessoBase).first().click();
         await page.waitForURL(/\/processo\/\d+/);
         const idProcesso = await extrairProcessoId(page);

--- a/e2e/cdu-05.spec.ts
+++ b/e2e/cdu-05.spec.ts
@@ -30,9 +30,7 @@ test.describe.serial('CDU-05 - Iniciar processo de revisao', () => {
     const descProcMapeamento = `Mapeamento Setup ${timestamp}`;
     const descProcRevisao = `Revisão Teste ${timestamp}`;
 
-    // ========================================================================
     // PASSOS DE PREPARAÇÃO - PROCESSO DE MAPEAMENTO
-    // ========================================================================
 
     async function passo1_AdminCriaEIniciaProcessoMapeamento(page: Page, descricao: string): Promise<void> {
         await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -57,7 +55,6 @@ test.describe.serial('CDU-05 - Iniciar processo de revisao', () => {
         await expect(page).toHaveURL(/\/processo\/cadastro/);
         await expect(page.getByTestId('inp-processo-descricao')).toHaveValue(descricao);
 
-        // Iniciar processo
         await page.getByTestId('btn-processo-iniciar').click();
         await page.getByTestId('btn-iniciar-processo-confirmar').click();
 
@@ -71,9 +68,6 @@ test.describe.serial('CDU-05 - Iniciar processo de revisao', () => {
     }
 
 
-    // ========================================================================
-    // TESTE PRINCIPAL
-    // ========================================================================
 
     test('Fase 1.1: ADMIN cria e inicia processo de Mapeamento', async ({
                                                                             page,

--- a/e2e/cdu-11.spec.ts
+++ b/e2e/cdu-11.spec.ts
@@ -31,9 +31,7 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
 
     let processoMapeamentoId: number;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar processo de mapeamento com atividades disponibilizadas
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de mapeamento', async ({
                                                                                 page,
@@ -61,7 +59,6 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
         // Não registrar cleanup aqui pois os testes seguintes dependem deste processo (serial)
         // O registro será feito no último cenário.
 
-        // Iniciar processo
         await page.getByTestId('btn-processo-iniciar').click();
         await page.getByTestId('btn-iniciar-processo-confirmar').click();
 
@@ -89,7 +86,6 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
         await adicionarAtividade(page, atividadeB);
         await adicionarConhecimento(page, atividadeB, conhecimento3);
 
-        // Disponibilizar cadastro
         await page.getByTestId('btn-cad-atividades-disponibilizar').click();
         await page.getByTestId('btn-confirmar-disponibilizacao').click();
 
@@ -97,9 +93,7 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
         await verificarPaginaPainel(page);
     });
 
-    // ========================================================================
     // TESTES PRINCIPAIS - CDU-11
-    // ========================================================================
 
     test('Cenario 1: ADMIN visualiza cadastro clicando na unidade subordinada', async ({
                                                                                            page,
@@ -178,7 +172,6 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
 
 
         await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
-        // Aceitar cadastro
         await navegarParaAtividadesVisualizacao(page);
         await page.getByTestId('btn-acao-analisar-principal').click();
         await page.getByTestId('inp-aceite-cadastro-obs').fill('Aceite para finalização do cenário');
@@ -311,7 +304,6 @@ test.describe.serial('CDU-11 - Visualizar cadastro de atividades e conhecimentos
         // Verificar que foi diretamente para subprocesso (perfil CHEFE)
         await verificarPaginaSubprocesso(page, UNIDADE_ALVO);
 
-        // Visualizar atividades
         await navegarParaAtividadesVisualizacao(page);
 
         await expect(page.getByRole('heading', {name: 'Atividades e conhecimentos'})).toBeVisible();

--- a/e2e/cdu-12.spec.ts
+++ b/e2e/cdu-12.spec.ts
@@ -37,9 +37,7 @@ test.describe.serial('CDU-12 - Verificar impactos no mapa de competências', () 
     let codProcessoMapeamento: number;
     let processoRevisaoId: number;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar Mapa Vigente e Iniciar Revisão
-    // ========================================================================
 
     test('Preparacao: Setup Mapeamento e Início da Revisão', async ({page, cleanupAutomatico}) => {
         test.slow();
@@ -145,7 +143,6 @@ test.describe.serial('CDU-12 - Verificar impactos no mapa de competências', () 
         await page.getByTestId('btn-mapa-homologar-aceite').click();
         await page.getByTestId('btn-aceite-mapa-confirmar').click();
 
-        // Finalizar Processo
         await page.goto('/painel');
         await page.getByTestId('tbl-processos').locator('tr', {has: page.getByText(descProcessoMapeamento)}).click();
         await page.getByTestId('btn-processo-finalizar').click();
@@ -169,9 +166,7 @@ test.describe.serial('CDU-12 - Verificar impactos no mapa de competências', () 
         await expect(page.getByText(/Processo iniciado/i).first()).toBeVisible();
     });
 
-    // ========================================================================
     // FLUXO DE VERIFICAÇÃO DE IMPACTOS (Tramitação)
-    // ========================================================================
 
     test('Fluxo CHEFE: Realizar alterações e verificar impactos', async ({page}) => {
         // Debbie Harry possui apenas 1 perfil
@@ -200,7 +195,6 @@ test.describe.serial('CDU-12 - Verificar impactos no mapa de competências', () 
         await expect(page.locator('.modal-content').getByText(`Competência 1 ${timestamp}`)).toBeVisible();
         await fecharModalImpacto(page);
 
-        // 4. Remoção
         await removerAtividade(page, `Atividade Base 3 ${timestamp}`);
         await abrirModalImpacto(page);
         await expect(page.locator('.modal-content').getByText(`Competência 3 ${timestamp}`)).toBeVisible();

--- a/e2e/cdu-13.spec.ts
+++ b/e2e/cdu-13.spec.ts
@@ -107,7 +107,6 @@ test.describe.serial('CDU-13 - Analisar cadastro de atividades e conhecimentos',
         });
 
         await test.step('7. ACEITE FINAL -> ADMIN homologa', async () => {
-            // Coordenação aceita
             await login(page, USUARIOS.GESTOR_COORD_21.titulo, USUARIOS.GESTOR_COORD_21.senha);
             await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
             await navegarParaAtividadesVisualizacao(page);

--- a/e2e/cdu-14.spec.ts
+++ b/e2e/cdu-14.spec.ts
@@ -45,7 +45,6 @@ test.describe.serial('CDU-14 - Analisar revisão de cadastro de atividades e con
             });
             await fazerLogout(page);
 
-            // Chefe disponibiliza
             await login(page, USUARIOS.CHEFE_SECAO_211.titulo, USUARIOS.CHEFE_SECAO_211.senha);
             await acessarSubprocessoChefeDireto(page, descMapeamento, UNIDADE_ALVO);
             await navegarParaAtividades(page);
@@ -113,7 +112,6 @@ test.describe.serial('CDU-14 - Analisar revisão de cadastro de atividades e con
             await page.getByTestId('btn-mapa-homologar-aceite').click();
             await page.getByTestId('btn-aceite-mapa-confirmar').click();
 
-            // Finalizar processo
             await page.goto('/painel');
             await page.getByTestId('tbl-processos').locator('tr').filter({has: page.getByText(descMapeamento)}).click();
             await page.getByTestId('btn-processo-finalizar').click();

--- a/e2e/cdu-16.spec.ts
+++ b/e2e/cdu-16.spec.ts
@@ -37,9 +37,7 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
     const competencia3 = `Competência 3 ${timestamp}`;
     const atividadeNovaRevisao = `Atividade Nova Revisão ${timestamp}`;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar mapa vigente (processo de mapeamento completo)
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de mapeamento', async ({
                                                                                 page,
@@ -91,12 +89,10 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
 
     test('Preparacao 3: Gestores aceitam cadastro', async ({page, autenticadoComoGestorCoord21}) => {
         console.log('-> Gestores (COORD e SEC) aceitando cadastro...');
-        // Gestor COORD_21
         await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarCadastroMapeamento(page);
 
-        // Gestor SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
@@ -137,14 +133,12 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
     });
 
     test('Preparacao 6: Gestores aceitam mapa', async ({page, autenticadoComoGestorCoord21}) => {
-        // Gestor COORD_21
         await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
         await navegarParaMapa(page);
         await page.getByTestId('btn-mapa-homologar-aceite').click();
         await page.getByTestId('btn-aceite-mapa-confirmar').click();
         await verificarPaginaPainel(page);
 
-        // Gestor SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descProcessoMapeamento, UNIDADE_ALVO);
         await navegarParaMapa(page);
@@ -213,18 +207,15 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
     });
 
     test('Preparacao 9: Gestores e Admin aceitam revisão', async ({page, autenticadoComoGestorCoord21}) => {
-        // Gestor COORD_21
         await acessarSubprocessoGestor(page, descProcessoRevisao, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarRevisao(page);
 
-        // Gestor SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descProcessoRevisao, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarRevisao(page);
 
-        // Admin homologa
         await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
         await acessarSubprocessoAdmin(page, descProcessoRevisao, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
@@ -235,9 +226,7 @@ test.describe.serial('CDU-16 - Ajustar mapa de competências', () => {
             .toHaveText(/Revis[aã]o d[oe] cadastro homologada/i);
     });
 
-    // ========================================================================
     // TESTES PRINCIPAIS - CDU-16
-    // ========================================================================
 
     test('Cenários CDU-16: ADMIN ajusta mapa e visualiza impactos', async ({page, autenticadoComoAdmin}) => {
         // Cenario 1: Navegação para tela de edição do mapa

--- a/e2e/cdu-17.spec.ts
+++ b/e2e/cdu-17.spec.ts
@@ -25,9 +25,7 @@ test.describe.serial('CDU-17 - Disponibilizar mapa de competências', () => {
     const competencia1 = `Competência 1 ${timestamp}`;
     const competencia2 = `Competência 2 ${timestamp}`;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar mapa pronto para disponibilização
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de mapeamento', async ({
                                                                                 page,
@@ -78,12 +76,10 @@ test.describe.serial('CDU-17 - Disponibilizar mapa de competências', () => {
     });
 
     test('Preparacao 3: Gestores aceitam cadastro', async ({page, autenticadoComoGestorCoord21}) => {
-        // Gestor COORD_21
         await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarCadastroMapeamento(page);
 
-        // Gestor SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
@@ -108,9 +104,7 @@ test.describe.serial('CDU-17 - Disponibilizar mapa de competências', () => {
         await expect(page.getByTestId('btn-cad-mapa-disponibilizar')).toBeVisible();
     });
 
-    // ========================================================================
     // TESTES PRINCIPAIS - CDU-17
-    // ========================================================================
 
     test('Cenários CDU-17: Fluxo completo de disponibilização do mapa pelo ADMIN', async ({
                                                                                               page,

--- a/e2e/cdu-19.spec.ts
+++ b/e2e/cdu-19.spec.ts
@@ -24,9 +24,7 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
     const competencia1 = `Competência 1 ${timestamp}`;
     const competencia2 = `Competência 2 ${timestamp}`;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar mapa disponibilizado para CHEFE validar
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de mapeamento', async ({
                                                                                 page,
@@ -74,12 +72,10 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
     });
 
     test('Preparacao 3: Gestores aceitam cadastro', async ({page, autenticadoComoGestorCoord22}) => {
-        // Gestor COORD_22
         await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarCadastroMapeamento(page);
 
-        // Gestor SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descProcesso, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
@@ -105,9 +101,7 @@ test.describe.serial('CDU-19 - Validar mapa de competências', () => {
         await expect(page.getByText(/Mapa disponibilizado/i)).toBeVisible();
     });
 
-    // ========================================================================
     // TESTES PRINCIPAIS - CDU-19
-    // ========================================================================
 
     test('Cenários CDU-19: Fluxo completo de validação do mapa pelo CHEFE', async ({
                                                                                        page,

--- a/e2e/cdu-20.spec.ts
+++ b/e2e/cdu-20.spec.ts
@@ -113,7 +113,6 @@ test.describe.serial('CDU-20 - Analisar validação de mapa de competências', (
             await page.getByTestId('btn-mapa-devolver').click();
             await page.getByTestId('btn-devolucao-mapa-cancelar').click();
 
-            // Aceita
             await page.getByTestId('btn-mapa-homologar-aceite').click();
             await page.getByTestId('btn-aceite-mapa-confirmar').click();
             await expect(page).toHaveURL(/\/painel/);

--- a/e2e/cdu-21.spec.ts
+++ b/e2e/cdu-21.spec.ts
@@ -30,9 +30,7 @@ test.describe.serial('CDU-21 - Finalizar processo de mapeamento ou de revisão',
     const competencia1 = `Competência 1 ${timestamp}`;
     const competencia2 = `Competência 2 ${timestamp}`;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar mapa homologado para ADMIN finalizar processo
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de mapeamento', async ({
                                                                                 page,
@@ -186,9 +184,7 @@ test.describe.serial('CDU-21 - Finalizar processo de mapeamento ou de revisão',
             .toHaveText(/Mapa homologado/i);
     });
 
-    // ========================================================================
     // TESTES PRINCIPAIS - CDU-21
-    // ========================================================================
 
     test('Cenario 1: ADMIN navega para detalhes do processo', async ({page, autenticadoComoAdmin}) => {
         // CDU-21: Passos 1-2

--- a/e2e/cdu-22.spec.ts
+++ b/e2e/cdu-22.spec.ts
@@ -29,9 +29,6 @@ test.describe.serial('CDU-22 - Aceitar cadastros em bloco', () => {
 
     const atividade1 = `Atividade Bloco ${timestamp}`;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de mapeamento', async ({
                                                                                 page,
@@ -78,9 +75,6 @@ test.describe.serial('CDU-22 - Aceitar cadastros em bloco', () => {
         await verificarPaginaPainel(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenario 1: GESTOR abre modal e cancela aceite em bloco', async ({page, autenticadoComoGestorCoord22}) => {
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();

--- a/e2e/cdu-23.spec.ts
+++ b/e2e/cdu-23.spec.ts
@@ -37,9 +37,6 @@ test.describe.serial('CDU-23 - Homologar cadastros em bloco', () => {
 
     const atividade1 = `Atividade Homol ${timestamp}`;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
 
@@ -93,9 +90,6 @@ test.describe.serial('CDU-23 - Homologar cadastros em bloco', () => {
         await aceitarCadastroMapeamento(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenario 1: ADMIN abre modal e cancela homologação em bloco', async ({page, autenticadoComoAdmin}) => {
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();

--- a/e2e/cdu-24.spec.ts
+++ b/e2e/cdu-24.spec.ts
@@ -38,9 +38,7 @@ test.describe.serial('CDU-24 - Disponibilizar mapas em bloco', () => {
     const atividade1 = `Atividade Mapa ${timestamp}`;
     const competencia1 = `Competência Mapa ${timestamp}`;
 
-    // ========================================================================
     // PREPARAÇÃO - Criar processo com mapa criado
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
 
@@ -105,7 +103,6 @@ test.describe.serial('CDU-24 - Disponibilizar mapas em bloco', () => {
 
         await expect(page).toHaveURL(/\/processo\/\d+\/\w+$/);
 
-        // Criar competências
         await navegarParaMapa(page);
         await criarCompetencia(page, competencia1, [atividade1]);
 
@@ -117,9 +114,7 @@ test.describe.serial('CDU-24 - Disponibilizar mapas em bloco', () => {
             .toHaveText(/Mapa criado/i);
     });
 
-    // ========================================================================
     // TESTES PRINCIPAIS - CDU-24
-    // ========================================================================
 
     test('Cenario 1: ADMIN visualiza botão Disponibilizar Mapas em Bloco', async ({page, autenticadoComoAdmin}) => {
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();

--- a/e2e/cdu-25.spec.ts
+++ b/e2e/cdu-25.spec.ts
@@ -45,9 +45,6 @@ test.describe.serial('CDU-25 - Aceitar validação de mapas em bloco', () => {
     const atividade1 = `Atividade Val ${timestamp}`;
     const competencia1 = `Competência Val ${timestamp}`;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
 
@@ -132,9 +129,6 @@ test.describe.serial('CDU-25 - Aceitar validação de mapas em bloco', () => {
         await verificarPaginaPainel(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenario 1: GESTOR acessa processo com mapa validado', async ({page}) => {
         await login(page, USUARIOS.GESTOR_COORD_21.titulo, USUARIOS.GESTOR_COORD_21.senha);

--- a/e2e/cdu-26.spec.ts
+++ b/e2e/cdu-26.spec.ts
@@ -44,9 +44,6 @@ test.describe.serial('CDU-26 - Homologar validação de mapas em bloco', () => {
     const atividade1 = `Atividade Homol ${timestamp}`;
     const competencia1 = `Competência Homol ${timestamp}`;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
 
@@ -153,9 +150,6 @@ test.describe.serial('CDU-26 - Homologar validação de mapas em bloco', () => {
         await verificarPaginaPainel(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenario 1: ADMIN visualiza botão Homologar Mapa em Bloco', async ({page, autenticadoComoAdmin}) => {
 

--- a/e2e/cdu-27.spec.ts
+++ b/e2e/cdu-27.spec.ts
@@ -24,9 +24,6 @@ test.describe.serial('CDU-27 - Alterar data limite de subprocesso', () => {
     const descProcesso = `Mapeamento CDU-27 ${timestamp}`;
     let processoId: number;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
 
@@ -51,9 +48,6 @@ test.describe.serial('CDU-27 - Alterar data limite de subprocesso', () => {
         await verificarPaginaPainel(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenario 1: ADMIN navega para detalhes do subprocesso', async ({page, autenticadoComoAdmin}) => {
         // CDU-27: Passos 1-2

--- a/e2e/cdu-29.spec.ts
+++ b/e2e/cdu-29.spec.ts
@@ -13,9 +13,7 @@ import {expect, test} from './fixtures/complete-fixtures.js';
  */
 test.describe.serial('CDU-29 - Consultar histórico de processos', () => {
 
-    // ========================================================================
     // CENÁRIO 1: Navegação para página de histórico
-    // ========================================================================
 
     test('Cenario 1: ADMIN navega para página de histórico', async ({page, autenticadoComoAdmin}) => {
         // CDU-29: Passos 1-2
@@ -47,9 +45,7 @@ test.describe.serial('CDU-29 - Consultar histórico de processos', () => {
         await expect(page.getByRole('heading', {name: /Histórico/i})).toBeVisible();
     });
 
-    // ========================================================================
     // CENÁRIO 4: Verificar estrutura da tabela de processos finalizados
-    // ========================================================================
 
     test('Cenario 4: Tabela apresenta colunas corretas', async ({page, autenticadoComoAdmin}) => {
 

--- a/e2e/cdu-32.spec.ts
+++ b/e2e/cdu-32.spec.ts
@@ -31,9 +31,6 @@ test.describe.serial('CDU-32 - Reabrir cadastro', () => {
 
     const atividade1 = `Atividade Reabrir ${timestamp}`;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
         await criarProcesso(page, {
@@ -73,18 +70,15 @@ test.describe.serial('CDU-32 - Reabrir cadastro', () => {
                                                                                    page,
                                                                                    autenticadoComoGestorCoord22
                                                                                }) => {
-        // Aceite COORD_22
         await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarCadastroMapeamento(page, 'Aceite intermediário COORD_22');
 
-        // Aceite SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descProcesso, UNIDADE_1);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarCadastroMapeamento(page, 'Aceite intermediário SECRETARIA_2');
 
-        // ADMIN homologa
         await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
         await page.getByTestId('tbl-processos').getByText(descProcesso).first().click();
         await navegarParaSubprocesso(page, UNIDADE_1);
@@ -92,9 +86,6 @@ test.describe.serial('CDU-32 - Reabrir cadastro', () => {
         await homologarCadastroMapeamento(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenários CDU-32: ADMIN reabre cadastro', async ({page, autenticadoComoAdmin}) => {
         // Cenario 1 & 2: Navegação e visualização do botão

--- a/e2e/cdu-33.spec.ts
+++ b/e2e/cdu-33.spec.ts
@@ -32,9 +32,7 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
     const descMapeamento = `Mapeamento Pre-CDU-33 ${timestamp}`;
     const descRevisao = `Revisão CDU-33 ${timestamp}`;
 
-    // ========================================================================
     // PREPARAÇÃO 0 - CRIAR MAPA VIGENTE
-    // ========================================================================
 
     test('Preparacao 0: Criar e finalizar Mapeamento', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
         test.setTimeout(90000);
@@ -117,9 +115,6 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
         await page.getByTestId('btn-finalizar-processo-confirmar').click();
     });
 
-    // ========================================================================
-    // PREPARAÇÃO REVISÃO
-    // ========================================================================
 
     test('Preparacao 1: Admin cria e inicia processo de REVISAO', async ({
                                                                              page,
@@ -160,18 +155,15 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
     });
 
     test('Preparacao 3: Gestores e ADMIN aceitam revisão', async ({page, autenticadoComoGestorCoord21}) => {
-        // Gestor COORD_21
         await acessarSubprocessoGestor(page, descRevisao, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarRevisao(page);
 
-        // Gestor SECRETARIA_2
         await loginComPerfil(page, USUARIOS.CHEFE_SECRETARIA_2.titulo, USUARIOS.CHEFE_SECRETARIA_2.senha, 'GESTOR - SECRETARIA_2');
         await acessarSubprocessoGestor(page, descRevisao, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
         await aceitarRevisao(page);
 
-        // ADMIN homologa
         await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
         await acessarSubprocessoChefeDireto(page, descRevisao, UNIDADE_ALVO);
         await navegarParaAtividadesVisualizacao(page);
@@ -181,9 +173,6 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
             .toHaveText(/Revisão do cadastro homologada/i);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenários CDU-33: ADMIN reabre revisão de cadastro', async ({page, autenticadoComoAdmin}) => {
         // Cenario 1 & 2: Navegação e visualização do botão

--- a/e2e/cdu-34.spec.ts
+++ b/e2e/cdu-34.spec.ts
@@ -23,9 +23,6 @@ test.describe.serial('CDU-34 - Enviar lembrete de prazo', () => {
     const descProcesso = `Mapeamento CDU-34 ${timestamp}`;
     let processoId: number;
 
-    // ========================================================================
-    // PREPARAÇÃO
-    // ========================================================================
 
     test('Preparacao: Admin cria e inicia processo', async ({page, autenticadoComoAdmin, cleanupAutomatico}) => {
         await criarProcesso(page, {
@@ -47,9 +44,6 @@ test.describe.serial('CDU-34 - Enviar lembrete de prazo', () => {
         await verificarPaginaPainel(page);
     });
 
-    // ========================================================================
-    // TESTES PRINCIPAIS
-    // ========================================================================
 
     test('Cenario principal: ADMIN envia lembrete e sistema registra histórico/alerta', async ({
                                                                                                    page,

--- a/e2e/fixtures/complete-fixtures.ts
+++ b/e2e/fixtures/complete-fixtures.ts
@@ -43,7 +43,6 @@ const test = base.extend<{
     cleanupAutomatico: async ({request}, use) => {
         const cleanup = useProcessoCleanup();
 
-        // Use
         await use(cleanup);
 
         // Limpar após o teste

--- a/e2e/fixtures/fixtures-processos.ts
+++ b/e2e/fixtures/fixtures-processos.ts
@@ -33,9 +33,6 @@ export interface ProcessoFixtureOptions {
  * esteja implementado no backend. Se o endpoint não existir, use a criação
  * via UI com `criarProcesso()` do helpers-processos.ts.
  *
- * @param request - Contexto de requisição do Playwright
- * @param options - Opções de configuração do processo
- * @returns Dados do processo criado
  *
  * @example
  * ```typescript

--- a/e2e/fixtures/processo-fixtures.ts
+++ b/e2e/fixtures/processo-fixtures.ts
@@ -63,7 +63,6 @@ export const test = base.extend<ProcessoContext>({
 
         await page.goto('/painel');
 
-        // Use fixture
         await use({codigo, descricao});
 
         // Cleanup automático via endpoint E2E
@@ -87,11 +86,6 @@ export {expect} from './auth-fixtures.js';
 
 /**
  * Helper para criar múltiplos processos em um teste
- *
- * @param page - Página do Playwright
- * @param count - Número de processos a criar
- * @param options - Opções para criação (tipo, unidade, etc.)
- * @returns Array com códigos e descrições dos processos criados
  */
 export async function criarMultiplosProcessos(
     page: Page,

--- a/e2e/helpers/helpers-analise.ts
+++ b/e2e/helpers/helpers-analise.ts
@@ -8,9 +8,7 @@ import {verificarPaginaPainel} from './helpers-navegacao.js';
  * Helpers para análise de cadastro de atividades (CDU-13 e CDU-14)
  */
 
-// ============================================================================
 // Funções de Navegação
-// ============================================================================
 
 /**
  * Acessa subprocesso como GESTOR (via lista de unidades)
@@ -126,9 +124,7 @@ export async function acessarSubprocessoAdmin(page: Page, descricaoProcesso: str
     }
 }
 
-// ============================================================================
 // Funções de Histórico de Análise
-// ============================================================================
 
 /**
  * Abre modal de histórico de análise (tela de edição - CadAtividades)
@@ -164,9 +160,7 @@ export async function fecharHistoricoAnalise(page: Page) {
     await expect(page.locator('.modal-content').filter({hasText: 'Histórico de Análise'})).toBeHidden();
 }
 
-// ============================================================================
 // Funções de Devolução
-// ============================================================================
 
 /**
  * Função genérica para devolução de cadastro/revisão
@@ -214,9 +208,7 @@ export async function cancelarDevolucao(page: Page) {
     await expect(page.getByRole('dialog')).toBeHidden();
 }
 
-// ============================================================================
 // Funções de Aceite (GESTOR)
-// ============================================================================
 
 /**
  * Função genérica para aceite de cadastro/revisão (GESTOR)
@@ -248,9 +240,7 @@ export async function aceitarRevisao(page: Page, observacao: string = '') {
     await realizarAceite(page, /Revisão aceita/i, observacao);
 }
 
-// ============================================================================
 // Funções de Homologação (ADMIN)
-// ============================================================================
 
 /**
  * Homologa cadastro (ADMIN) - Mapeamento

--- a/e2e/helpers/helpers-mapas.ts
+++ b/e2e/helpers/helpers-mapas.ts
@@ -67,7 +67,6 @@ export async function criarCompetencia(page: Page, descricao: string, atividades
     await page.getByTestId('btn-criar-competencia-salvar').click();
     await expect(modal).toBeHidden();
 
-    // Verify creation
     await verificarCompetenciaNoMapa(page, descricao, atividades);
 }
 

--- a/e2e/helpers/helpers-navegacao.ts
+++ b/e2e/helpers/helpers-navegacao.ts
@@ -7,9 +7,7 @@ import {expect, type Page} from '@playwright/test';
  * em múltiplos arquivos de teste.
  */
 
-// ============================================================================
 // Funções de Logout
-// ============================================================================
 
 /**
  * Limpa notificações (toasts e alertas) da tela.
@@ -54,9 +52,7 @@ export async function fazerLogout(page: Page): Promise<void> {
     await expect(page).toHaveURL(/\/login/);
 }
 
-// ============================================================================
 // Funções de Verificação de Página
-// ============================================================================
 
 /**
  * Verifica que está na página do painel principal.
@@ -65,16 +61,11 @@ export async function verificarPaginaPainel(page: Page): Promise<void> {
     await expect(page).toHaveURL(/\/painel/);
 }
 
-// ============================================================================
 // Funções de Navegação
-// ============================================================================
 
 /**
  * Navega para um subprocesso clicando na célula da unidade na tabela TreeTable.
  * Se já estiver na página do subprocesso (redirecionamento direto), apenas valida.
- *
- * @param page - Instância da página do Playwright
- * @param siglaUnidade - Sigla da unidade a clicar (ex: 'SECAO_221')
  */
 export async function navegarParaSubprocesso(
     page: Page,

--- a/e2e/lifecycle.js
+++ b/e2e/lifecycle.js
@@ -75,7 +75,6 @@ const LOG_FILTERS = [
     // Warnings do Lombok
     /WARNING:/,
 
-    // Gradle
     /^> Task :/,
     /logStarted/,
     /UP-TO-DATE/,
@@ -107,7 +106,6 @@ const LOG_FILTERS = [
     /NotificacaoEmailServiceMock.*ATIVADO/,
     /E-mails serão mockados/,
 
-    // Linhas vazias
     /^\s*$/
 ];
 
@@ -287,6 +285,5 @@ try {
     process.exit(1);
 }
 
-// Keep alive
 setInterval(() => {
 }, 1000);

--- a/e2e/setup/fixtures.ts
+++ b/e2e/setup/fixtures.ts
@@ -1,5 +1,4 @@
 import {test as base} from '@playwright/test';
-// Import the project's logger so E2E logs go through the same formatting
 // Note: import uses .js extension because tests run with Node's ESM resolution (nodenext)
 import logger from '../../frontend/src/utils/logger.js';
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -73,7 +73,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await page.getByTestId('btn-painel-criar-processo').click();
             await expect(page).toHaveURL(/\/processo\/cadastro/);
 
-            // Preenchendo formulário
             await page.getByTestId('inp-processo-descricao').fill(descricaoProcesso);
             await page.getByTestId('sel-processo-tipo').selectOption('MAPEAMENTO');
             const dataLimite = new Date();
@@ -95,7 +94,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await page.getByTestId('chk-arvore-unidade-ASSESSORIA_12').click();
             await page.getByTestId('chk-arvore-unidade-SECAO_111').click();
 
-            // Salvar processo
             await page.getByTestId('btn-processo-salvar').click();
             await expect(page).toHaveURL(/\/painel/);
             await expect(page.getByTestId('tbl-processos')).toBeVisible();
@@ -249,20 +247,17 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await page.getByTestId('btn-logout').click();
             await login(page, USUARIOS.CHEFE_SECAO_211.titulo, USUARIOS.CHEFE_SECAO_211.senha);
 
-            // Acessar subprocesso
             await page.getByTestId('tbl-processos').getByText(descricao).first().click();
             await navegarParaSubprocesso(page, UNIDADE_ALVO);
 
             // Entrar em atividades
             await navegarParaAtividades(page);
 
-            // Adicionar atividade
             const atividadeDesc = `Atividade Teste ${Date.now()}`;
             await page.getByTestId('inp-nova-atividade').fill(atividadeDesc);
             await page.getByTestId('btn-adicionar-atividade').click();
             await expect(page.getByText(atividadeDesc, {exact: true})).toBeVisible();
 
-            // Adicionar conhecimentos
             const card = page.locator('.atividade-card', {has: page.getByText(atividadeDesc)});
             await card.getByTestId('inp-novo-conhecimento').fill('Java');
             await adicionarConhecimento(page, atividadeDesc, 'Java');
@@ -411,7 +406,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await acessarSubprocessoChefeDireto(page, descricao, 'SECAO_121');
             await navegarParaAtividades(page);
 
-            // Adicionar atividades
             await adicionarAtividade(page, 'Desenvolvimento Web');
             await adicionarConhecimento(page, 'Desenvolvimento Web', 'Vue.js');
             await adicionarConhecimento(page, 'Desenvolvimento Web', 'TypeScript');
@@ -456,7 +450,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             // Entrar no cadastro de atividades (visualização)
             await navegarParaAtividadesVisualizacao(page);
 
-            // Homologar cadastro
             await page.getByTestId('btn-acao-analisar-principal').click();
             await page.getByTestId('btn-aceite-cadastro-confirmar').click();
             await page.waitForTimeout(100);
@@ -465,14 +458,12 @@ test.describe('Smoke Test - Sistema SGC', () => {
             // Navegar para mapa
             await navegarParaMapa(page);
 
-            // Criar competência
             await abrirModalCriarCompetencia(page);
             await page.waitForTimeout(100);
 
             const competenciaDesc = 'Desenvolvimento de Software';
             await page.getByTestId('inp-criar-competencia-descricao').fill(competenciaDesc);
 
-            // Selecionar atividades
             const modal = page.getByTestId('mdl-criar-competencia');
             await modal.locator('label').filter({hasText: 'Desenvolvimento Web'}).click();
             await modal.locator('label').filter({hasText: 'Desenvolvimento Backend'}).click();
@@ -486,7 +477,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await card.hover();
             await page.waitForTimeout(100);
 
-            // Disponibilizar mapa
             await page.getByTestId('btn-cad-mapa-disponibilizar').click();
             await page.waitForTimeout(100);
 
@@ -505,7 +495,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
         test('Captura elementos de navegação', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Menu principal
 
             // Configurações (se admin)
             await page.getByTestId('btn-configuracoes').click();
@@ -516,15 +505,12 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await page.getByText('Unidades').first().click();
             await page.waitForTimeout(100);
 
-            // Seção Relatórios
             await page.getByText('Relatórios').click();
             await page.waitForTimeout(100);
 
-            // Seção Histórico
             await page.getByText('Histórico').click();
             await page.waitForTimeout(100);
 
-            // Rodapé
             await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
             await page.waitForTimeout(100);
         });
@@ -534,7 +520,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
         test('Captura diferentes estados de processo', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Processo CRIADO
             const processosCriado = `Proc CRIADO ${Date.now()}`;
             await criarProcesso(page, {
                 descricao: processosCriado,
@@ -550,7 +535,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             if (processoId1 > 0) cleanup.registrar(processoId1);
             await page.goto('/painel');
 
-            // Processo EM_ANDAMENTO
             const processosAndamento = `Proc ANDAMENTO ${Date.now()}`;
             await criarProcesso(page, {
                 descricao: processosAndamento,
@@ -574,17 +558,13 @@ test.describe('Smoke Test - Sistema SGC', () => {
             // Desktop médio (1366x768)
             await page.setViewportSize({width: 1366, height: 768});
 
-            // Tablet (768x1024)
             await page.setViewportSize({width: 768, height: 1024});
 
-            // Mobile (375x667)
             await page.setViewportSize({width: 375, height: 667});
         });
     });
 
-    // ========================================================================
     // SEÇÃO 09 - OPERAÇÕES EM BLOCO (CDUs 22-26)
-    // ========================================================================
     test.describe('09 - Operações em Bloco', () => {
         test('Captura fluxo de aceitar cadastros em bloco', async ({page}) => {
             // Prepara cenário: criar processo com unidades subordinadas e disponibilizar cadastros
@@ -676,9 +656,7 @@ test.describe('Smoke Test - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 10 - GESTÃO DE SUBPROCESSOS (CDUs 27, 32-34)
-    // ========================================================================
     test.describe('10 - Gestão de Subprocessos', () => {
         test('Captura modais de gestão de subprocesso', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -701,7 +679,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
             const processoId = await extrairProcessoId(page);
             if (processoId > 0) cleanup.registrar(processoId);
 
-            // Acessar subprocesso
             await page.getByRole('row', {name: /SECAO_121/i}).click();
             await expect(page).toHaveURL(/\/processo\/\d+\/SECAO_121/);
 
@@ -729,9 +706,7 @@ test.describe('Smoke Test - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 11 - GESTÃO DE UNIDADES E ATRIBUIÇÕES (CDU-28)
-    // ========================================================================
     test.describe('11 - Gestão de Unidades', () => {
         test('Captura página de unidades e atribuição temporária', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -767,9 +742,7 @@ test.describe('Smoke Test - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 12 - HISTÓRICO DE PROCESSOS (CDU-29)
-    // ========================================================================
     test.describe('12 - Histórico', () => {
         test('Captura seção de histórico', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
@@ -788,14 +761,11 @@ test.describe('Smoke Test - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 13 - CONFIGURAÇÕES E ADMINISTRADORES (CDUs 30-31)
-    // ========================================================================
     test.describe('13 - Configurações', () => {
         test('Captura página de configurações e administradores', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Acessar configurações
             await page.getByTestId('btn-configuracoes').click();
             await page.waitForTimeout(500);
 
@@ -821,14 +791,11 @@ test.describe('Smoke Test - Sistema SGC', () => {
         });
     });
 
-    // ========================================================================
     // SEÇÃO 14 - RELATÓRIOS (CDUs 35-36)
-    // ========================================================================
     test.describe('14 - Relatórios', () => {
         test('Captura página e modais de relatórios', async ({page}) => {
             await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
 
-            // Acessar relatórios
             const linkRelatorios = page.getByRole('link', {name: /Relatórios/i});
             if (await linkRelatorios.isVisible().catch(() => false)) {
                 await linkRelatorios.click();
@@ -843,7 +810,6 @@ test.describe('Smoke Test - Sistema SGC', () => {
                     if (await modalRelatorio.isVisible().catch(() => false)) {
                     }
 
-                    // Verificar filtros
                     const filtroTipo = page.getByTestId('sel-filtro-tipo');
                     if (await filtroTipo.isVisible().catch(() => false)) {
                     }

--- a/etc/scripts/gerar_arvore_linhas.js
+++ b/etc/scripts/gerar_arvore_linhas.js
@@ -178,7 +178,6 @@ function isTestFile(filePath) {
     return testPatterns.some(pattern => pattern.test(normalizedPath));
 }
 
-// Execução
 const options = parseArgs();
 
 console.log("Gerando árvore de contagem de linhas...\n");

--- a/etc/scripts/qualidade.js
+++ b/etc/scripts/qualidade.js
@@ -218,7 +218,6 @@ async function runCommand(step) {
             const status = code === 0 ? '✅ Sucesso' : '❌ Falha';
             console.log(`\n🏁 Finalizado: ${step.name} (${status}) - ${duration}s`);
 
-            // Collect stats
             const stats = getStats(step, output);
 
             resolve({
@@ -254,7 +253,6 @@ function generateReport(results) {
 
     md += `## Resumo Executivo\n\n`;
 
-    // Status Table
     md += `| Teste | Status | Duração (s) |\n`;
     md += `| :--- | :---: | :---: |\n`;
 
@@ -265,7 +263,6 @@ function generateReport(results) {
     });
     md += `\n`;
 
-    // Statistics Table
     md += `### Estatísticas Detalhadas\n\n`;
     md += `| Teste | Total | Passou | Falhou | Ignorado |\n`;
     md += `| :--- | :---: | :---: | :---: | :---: |\n`;

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,7 +17,6 @@ const route = useRoute();
 const feedbackStore = useFeedbackStore();
 const toast = useToast();
 
-// Inicializa a store com a instância do toast para que possamos disparar toasts de qualquer lugar
 feedbackStore.init(toast);
 
 const hideExtrasOnce = ref(false);
@@ -27,14 +26,12 @@ function refreshHideFlag() {
   try {
     came = sessionStorage.getItem("cameFromNavbar") === "1";
   } catch {
-    //
   }
   hideExtrasOnce.value = came;
   if (came) {
     try {
       sessionStorage.removeItem("cameFromNavbar");
     } catch {
-      //
     }
   }
 }

--- a/frontend/src/components/atividades/AtividadeItem.vue
+++ b/frontend/src/components/atividades/AtividadeItem.vue
@@ -154,10 +154,8 @@ const emit = defineEmits<{
   (e: "remover-conhecimento", conhecimentoCodigo: number): void;
 }>();
 
-// Estado de Edição da Atividade
 const emEdicao = ref(false);
 
-// Novo Conhecimento
 const novoConhecimento = ref("");
 
 function adicionarConhecimento() {

--- a/frontend/src/components/comum/InlineEditor.stories.ts
+++ b/frontend/src/components/comum/InlineEditor.stories.ts
@@ -41,11 +41,9 @@ export const Default: Story = {
         // Verifica estado inicial
         await expect.element(page.getByText('Texto para editar')).toBeVisible();
 
-        // Inicia edição
         const editBtn = page.getByRole('button', {name: /editar/i});
         await userEvent.click(editBtn);
 
-        // Verifica se o input apareceu
         const input = page.getByRole('textbox');
         await expect.element(input).toHaveValue('Texto para editar');
     },

--- a/frontend/src/components/comum/LoadingButton.stories.ts
+++ b/frontend/src/components/comum/LoadingButton.stories.ts
@@ -26,7 +26,6 @@ export const Default: Story = {
     play: async () => {
         const button = page.getByRole('button');
 
-        // Simula clique
         await userEvent.click(button);
     },
 };
@@ -40,7 +39,6 @@ export const Loading: Story = {
     play: async () => {
         const button = page.getByRole('button');
 
-        // Verifica se o texto de carregamento está visível
         await expect.element(button).toHaveTextContent('Carregando...');
         await expect.element(button).toBeDisabled();
     },

--- a/frontend/src/components/unidade/ArvoreUnidades.stories.ts
+++ b/frontend/src/components/unidade/ArvoreUnidades.stories.ts
@@ -80,7 +80,6 @@ export const Default: Story = {
     `,
     }),
     play: async () => {
-        // Verifica se a árvore foi renderizada
         const item = page.getByText('Presidência');
         await expect.element(item).toBeVisible();
     },

--- a/frontend/src/composables/useErrorHandler.ts
+++ b/frontend/src/composables/useErrorHandler.ts
@@ -17,9 +17,6 @@ export function useErrorHandler() {
     /**
      * Executa uma função assíncrona com tratamento automático de erros.
      *
-     * @param fn - Função assíncrona a ser executada
-     * @param onError - Callback opcional executado quando ocorre erro
-     * @returns Promise com resultado da função
      * @throws Re-lança o erro após tratamento
      */
     async function withErrorHandling<T>(

--- a/frontend/src/composables/useLoadingManager.ts
+++ b/frontend/src/composables/useLoadingManager.ts
@@ -20,8 +20,6 @@ interface LoadingManager {
  * Simplifica o gerenciamento de estados de carregamento em componentes
  * com múltiplas operações assíncronas.
  *
- * @param names - Lista de nomes de estados de loading
- * @returns Gerenciador de loading
  *
  * @example
  * ```ts
@@ -121,7 +119,6 @@ export function useLoadingManager(names: string[]): LoadingManager {
 /**
  * Versão simplificada para um único estado de loading
  *
- * @param initialValue - Valor inicial do loading (padrão: false)
  *
  * @example
  * ```ts

--- a/frontend/src/composables/useLocalStorage.ts
+++ b/frontend/src/composables/useLocalStorage.ts
@@ -2,13 +2,8 @@ import {ref, type Ref, watch} from 'vue';
 
 /**
  * Composable para sincronizar ref com localStorage
- *
- * @param key - Chave do localStorage
- * @param defaultValue - Valor padrão se não houver no localStorage
- * @returns Ref sincronizado com localStorage
  */
 export function useLocalStorage<T>(key: string, defaultValue: T): Ref<T> {
-    // Função para ler do localStorage
     const readValue = (): T => {
         const item = localStorage.getItem(key);
         if (item === null) {
@@ -39,9 +34,6 @@ export function useLocalStorage<T>(key: string, defaultValue: T): Ref<T> {
 
 /**
  * Composable para sincronizar múltiplas refs com localStorage
- *
- * @param items - Mapa de chave -> valor padrão
- * @returns Mapa de chave -> Ref sincronizado
  */
 export function useLocalStorageMultiple<T extends Record<string, any>>(
     items: T

--- a/frontend/src/composables/useProcessoForm.ts
+++ b/frontend/src/composables/useProcessoForm.ts
@@ -69,17 +69,14 @@ export function useProcessoForm(initialData?: Processo) {
     }
 
     return {
-        // State
         descricao,
         tipo,
         dataLimite,
         unidadesSelecionadas,
         fieldErrors,
 
-        // Computed
         isFormInvalid,
 
-        // Actions
         setFromNormalizedError,
         clearErrors,
         hasErrors,

--- a/frontend/src/services/processoService.ts
+++ b/frontend/src/services/processoService.ts
@@ -10,9 +10,7 @@ import type {
 import type {ProcessoDetalheDto, UnidadeParticipanteDto} from "@/types/dtos";
 import apiClient from "../axios-setup";
 
-// ------------------------------------------------------------------------------------------------
 // Mappers Internos (formerly in /mappers/processos.ts)
-// ------------------------------------------------------------------------------------------------
 
 export function mapUnidadeParticipanteDtoToFrontend(
     dto: UnidadeParticipanteDto,
@@ -39,9 +37,6 @@ export function mapProcessoDetalheDtoToFrontend(dto: ProcessoDetalheDto): Proces
     } as Processo;
 }
 
-// ------------------------------------------------------------------------------------------------
-// Processo Services
-// ------------------------------------------------------------------------------------------------
 
 export async function criarProcesso(
     request: CriarProcessoRequest,

--- a/frontend/src/services/subprocessoService.ts
+++ b/frontend/src/services/subprocessoService.ts
@@ -18,9 +18,6 @@ interface ImportarAtividadesRequest {
     codSubprocessoOrigem: number;
 }
 
-// ------------------------------------------------------------------------------------------------
-// Subprocesso Services
-// ------------------------------------------------------------------------------------------------
 
 export async function importarAtividades(
     codSubprocessoDestino: number,
@@ -82,9 +79,7 @@ export async function buscarSubprocessoPorProcessoEUnidade(
     return response.data;
 }
 
-// ------------------------------------------------------------------------------------------------
 // Mapa / Competencias
-// ------------------------------------------------------------------------------------------------
 
 export async function obterMapaVisualizacao(
     codSubprocesso: number,
@@ -204,9 +199,7 @@ export async function removerCompetencia(
     return response.data as MapaCompleto;
 }
 
-// ------------------------------------------------------------------------------------------------
 // Acoes em Bloco
-// ------------------------------------------------------------------------------------------------
 
 export async function aceitarCadastroEmBloco(
     codSubprocesso: number,
@@ -259,9 +252,7 @@ export async function disponibilizarMapaEmBloco(
     });
 }
 
-// ------------------------------------------------------------------------------------------------
 // Analises / Historico
-// ------------------------------------------------------------------------------------------------
 
 export const listarAnalisesCadastro = async (
     codSubprocesso: number,

--- a/frontend/src/services/unidadeService.ts
+++ b/frontend/src/services/unidadeService.ts
@@ -1,9 +1,7 @@
 import type {Unidade, UnidadeSnapshot} from "@/types/tipos";
 import {apiGet} from "@/utils/apiUtils";
 
-// ------------------------------------------------------------------------------------------------
 // Mappers Internos (formerly in /mappers/unidades.ts)
-// ------------------------------------------------------------------------------------------------
 
 export function mapUnidadeSnapshot(obj: any): UnidadeSnapshot {
     return {
@@ -51,9 +49,6 @@ export function mapUnidadesArray(arr: any[] = []): Unidade[] {
     return arr.map(mapUnidade);
 }
 
-// ------------------------------------------------------------------------------------------------
-// Unidade Services
-// ------------------------------------------------------------------------------------------------
 
 export async function buscarTodasUnidades() {
     return apiGet("/unidades");

--- a/frontend/src/services/usuarioService.ts
+++ b/frontend/src/services/usuarioService.ts
@@ -2,9 +2,7 @@ import type {LoginResponseDto, PerfilUnidadeDto, UsuarioDto} from "@/types/dtos"
 import type {Usuario} from "@/types/tipos";
 import apiClient from "../axios-setup";
 
-// ------------------------------------------------------------------------------------------------
 // Mappers Internos (formerly in /mappers/sgrh.ts & /mappers/usuarios.ts)
-// ------------------------------------------------------------------------------------------------
 
 export interface AutenticacaoRequest {
     tituloEleitoral: string;
@@ -120,9 +118,6 @@ export function mapVWUsuariosArray(arr: any[] = []): Usuario[] {
 }
 
 
-// ------------------------------------------------------------------------------------------------
-// Usuario Services
-// ------------------------------------------------------------------------------------------------
 
 export async function autenticar(
     request: AutenticacaoRequest,

--- a/frontend/src/stores/feedback.ts
+++ b/frontend/src/stores/feedback.ts
@@ -65,7 +65,6 @@ export const useFeedbackStore = defineStore('feedback', () => {
 
 // Mantido para compatibilidade
 function close() {
-    // No-op
 }
 
 // Alias for compatibility if needed, or consumers should use useFeedbackStore

--- a/frontend/src/types/tipos.ts
+++ b/frontend/src/types/tipos.ts
@@ -305,7 +305,6 @@ export interface SubprocessoDetalhe {
     permissoes: PermissoesSubprocesso;
 }
 
-// Interfaces de visualização removidas (consolidadas no início do arquivo)
 
 export interface MapaVisualizacao {
     codigo: number;

--- a/frontend/src/utils/apiError.ts
+++ b/frontend/src/utils/apiError.ts
@@ -78,7 +78,6 @@ export function normalizeError(err: unknown): NormalizedError {
         };
     }
 
-    // Fallback
     logger.error("[normalizeError] Erro não mapeado:", err);
     return {
         kind: 'unexpected',

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -7,19 +7,15 @@ function parseStringDate(s: string): Date | null {
     const trimmed = s.trim();
     if (!trimmed) return null;
 
-    // ISO Date/DateTime
     const isoDate = parseISO(trimmed);
     if (isValid(isoDate)) return isoDate;
 
-    // DD/MM/YYYY
     try {
         const ddmmyyyy = parse(trimmed, "dd/MM/yyyy", new Date());
         if (isValid(ddmmyyyy)) return ddmmyyyy;
     } catch {
-        // ignore
     }
 
-    // Numeric string
     if (/^\d{10,}$/.test(trimmed)) {
         const d = new Date(Number(trimmed));
         if (isValid(d)) return d;

--- a/frontend/src/views/processo/AtividadesCadastroView.vue
+++ b/frontend/src/views/processo/AtividadesCadastroView.vue
@@ -226,7 +226,6 @@ const historicoAnalises = computed(() => {
 const {novaAtividade, loadingAdicionar, adicionarAtividade: adicionarAtividadeAction} = useAtividadeForm();
 const erroNovaAtividade = ref<string | null>(null);
 
-// Modais
 const mostrarModalImpacto = ref(false);
 const mostrarModalImportar = ref(false);
 const mostrarModalConfirmacao = ref(false);
@@ -235,7 +234,6 @@ const mostrarModalConfirmacaoRemocao = ref(false);
 const dadosRemocao = ref<DadosRemocao>(null);
 const loadingImpacto = ref(false);
 
-// Validação
 const loadingValidacao = ref(false);
 const errosValidacao = ref<ErroValidacao[]>([]);
 const erroGlobal = ref<string | null>(null);

--- a/frontend/src/views/processo/AtividadesVisualizacaoView.vue
+++ b/frontend/src/views/processo/AtividadesVisualizacaoView.vue
@@ -226,7 +226,6 @@ const historicoAnalises = computed(() => {
   return analisesStore.analisesCadastro || [];
 });
 
-// Modais
 const loadingImpacto = ref(false);
 const mostrarModalImpacto = ref(false);
 const mostrarModalValidar = ref(false);

--- a/frontend/src/views/processo/MapaVisualizacaoView.vue
+++ b/frontend/src/views/processo/MapaVisualizacaoView.vue
@@ -284,7 +284,6 @@ const historicoAnalise = computed(() => {
 
 const temHistoricoAnalise = computed(() => historicoAnalise.value.length > 0);
 
-// Modais
 const mostrarModalAceitar = ref(false);
 const mostrarModalSugestoes = ref(false);
 const mostrarModalVerSugestoes = ref(false);
@@ -295,7 +294,6 @@ const sugestoes = ref("");
 const sugestoesVisualizacao = ref("");
 const observacaoDevolucao = ref("");
 
-// Loading
 const isLoading = ref(false);
 
 // Refs para foco

--- a/frontend/src/views/processo/ProcessoCadastroView.vue
+++ b/frontend/src/views/processo/ProcessoCadastroView.vue
@@ -308,7 +308,6 @@ async function abrirModalConfirmacao() {
 }
 
 async function confirmarIniciarProcesso() {
-  // Limpa erros
   clearErrors();
   isLoading.value = true;
 

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -2,7 +2,6 @@ import {config, RouterLinkStub} from "@vue/test-utils";
 import {createBootstrap} from "bootstrap-vue-next";
 import {vi} from "vitest";
 
-// Mock HTMLCanvasElement.prototype.getContext
 HTMLCanvasElement.prototype.getContext = vi.fn();
 
 
@@ -46,7 +45,6 @@ config.global.directives = {
 
 config.global.plugins.push(createBootstrap());
 
-// Mock localStorage
 const localStorageMock = (function () {
     let store: { [key: string]: string } = {};
     return {
@@ -70,7 +68,6 @@ Object.defineProperty(globalThis, "localStorage", {
 });
 
 
-// Mock window.location
 const locationMock = {
     href: "http://localhost/",
     assign: vi.fn(),


### PR DESCRIPTION
Clean up unnecessary comments across codebase
    
    Removed visual separator lines, obvious `@param` and `@return` comments from JSDoc and Javadoc, and multiline conversational comments or obvious single-line comments.
    Preserved jacoco and IDE/linter directives.

---
*PR created automatically by Jules for task [18377607951588872918](https://jules.google.com/task/18377607951588872918) started by @lgalvao*