### PR TITLE
test: increase overall backend line coverage by 1%

### DIFF
--- a/backend/cobertura_lacunas.json
+++ b/backend/cobertura_lacunas.json
@@ -1,5 +1,5 @@
 {
-  "globalLineCoverage": "96.76%",
+  "globalLineCoverage": "97.93%",
   "totalFilesWithGaps": 23,
   "gaps": [
     {
@@ -161,94 +161,6 @@
       "score": 24.5
     },
     {
-      "class": "sgc.subprocesso.SubprocessoController",
-      "coverage": "82.95%",
-      "missed": [
-        158,
-        159,
-        160,
-        162,
-        164,
-        179,
-        180,
-        181,
-        183,
-        185,
-        318,
-        319,
-        358,
-        359,
-        360,
-        361,
-        362,
-        374,
-        375,
-        394,
-        453,
-        541
-      ],
-      "partial": [
-        "157(1/2)",
-        "178(1/2)"
-      ],
-      "score": 23
-    },
-    {
-      "class": "sgc.mapa.service.MapaManutencaoService",
-      "coverage": "88.46%",
-      "missed": [
-        58,
-        74,
-        78,
-        79,
-        80,
-        81,
-        82,
-        83,
-        84,
-        85,
-        94,
-        98,
-        205,
-        206,
-        295,
-        296,
-        323,
-        332
-      ],
-      "partial": [
-        "147(1/2)",
-        "164(1/2)",
-        "275(1/2)",
-        "306(1/2)",
-        "322(1/2)",
-        "331(1/2)"
-      ],
-      "score": 21
-    },
-    {
-      "class": "sgc.processo.service.ProcessoNotificacaoService",
-      "coverage": "93.02%",
-      "missed": [
-        133,
-        134,
-        135,
-        136,
-        137,
-        138,
-        143,
-        234,
-        235
-      ],
-      "partial": [
-        "127(2/6)",
-        "129(1/2)",
-        "165(1/2)",
-        "230(1/4)"
-      ],
-      "score": 11
-    },
-    {
       "class": "sgc.mapa.AtividadeFacade",
       "coverage": "96.00%",
       "missed": [
@@ -263,17 +175,16 @@
       "score": 4
     },
     {
-      "class": "sgc.processo.service.ProcessoManutencaoService",
-      "coverage": "93.33%",
+      "class": "sgc.subprocesso.SubprocessoController",
+      "coverage": "96.90%",
       "missed": [
-        76,
-        77,
-        83
+        318,
+        319,
+        358,
+        359
       ],
-      "partial": [
-        "75(2/4)"
-      ],
-      "score": 3.5
+      "partial": [],
+      "score": 4
     },
     {
       "class": "sgc.mapa.service.ImpactoMapaService",
@@ -290,6 +201,18 @@
       "score": 3
     },
     {
+      "class": "sgc.processo.service.ProcessoManutencaoService",
+      "coverage": "95.56%",
+      "missed": [
+        76,
+        83
+      ],
+      "partial": [
+        "75(1/4)"
+      ],
+      "score": 2.5
+    },
+    {
       "class": "sgc.alerta.EmailService",
       "coverage": "94.29%",
       "missed": [
@@ -297,6 +220,18 @@
         63
       ],
       "partial": [],
+      "score": 2
+    },
+    {
+      "class": "sgc.processo.service.ProcessoNotificacaoService",
+      "coverage": "100.00%",
+      "missed": [],
+      "partial": [
+        "127(1/6)",
+        "129(1/2)",
+        "165(1/2)",
+        "230(1/4)"
+      ],
       "score": 2
     },
     {
@@ -322,13 +257,25 @@
       "score": 2
     },
     {
+      "class": "sgc.mapa.service.MapaManutencaoService",
+      "coverage": "100.00%",
+      "missed": [],
+      "partial": [
+        "147(1/2)",
+        "164(1/2)",
+        "275(1/2)",
+        "306(1/2)"
+      ],
+      "score": 2
+    },
+    {
       "class": "sgc.organizacao.service.ResponsavelUnidadeService",
       "coverage": "100.00%",
       "missed": [],
       "partial": [
-        "69(1/2)",
-        "79(1/2)",
-        "119(1/2)"
+        "68(1/2)",
+        "78(1/2)",
+        "118(1/2)"
       ],
       "score": 1.5
     },
@@ -359,9 +306,9 @@
       "coverage": "100.00%",
       "missed": [],
       "partial": [
-        "153(1/2)",
-        "225(1/2)",
-        "310(1/6)"
+        "152(1/2)",
+        "224(1/2)",
+        "309(1/6)"
       ],
       "score": 1.5
     },

--- a/backend/src/test/java/sgc/mapa/service/MapaManutencaoServiceCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/mapa/service/MapaManutencaoServiceCoverageExtraTest.java
@@ -1,0 +1,116 @@
+package sgc.mapa.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.comum.erros.ErroValidacao;
+import sgc.comum.model.ComumRepo;
+import sgc.mapa.dto.CriarAtividadeRequest;
+import sgc.mapa.dto.CriarConhecimentoRequest;
+import sgc.mapa.model.Atividade;
+import sgc.mapa.model.Competencia;
+import sgc.mapa.model.Conhecimento;
+import sgc.mapa.model.Mapa;
+import sgc.mapa.model.*;
+import sgc.mapa.service.*;
+import sgc.mapa.dto.*;
+import sgc.subprocesso.service.SubprocessoService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MapaManutencaoService - Cobertura Extra")
+class MapaManutencaoServiceCoverageExtraTest {
+
+    @Mock private AtividadeRepo atividadeRepo;
+    @Mock private CompetenciaRepo competenciaRepo;
+    @Mock private ConhecimentoRepo conhecimentoRepo;
+    @Mock private MapaRepo mapaRepo;
+    @Mock private ComumRepo repo;
+    @Mock private SubprocessoService subprocessoService;
+
+    @InjectMocks
+    private MapaManutencaoService mapaService;
+
+    @Test
+    void buscarAtividadesPorMapaCodigoSemRelacionamentos_ok() {
+        when(atividadeRepo.findByMapaCodigoSemFetch(1L)).thenReturn(List.of(new Atividade()));
+        mapaService.buscarAtividadesPorMapaCodigoSemRelacionamentos(1L);
+        verify(atividadeRepo).findByMapaCodigoSemFetch(1L);
+    }
+
+    @Test
+    void buscarCompetenciasPorCodMapaSemRelacionamentos_ok() {
+        when(competenciaRepo.findByMapaCodigoSemFetch(1L)).thenReturn(List.of(new Competencia()));
+        mapaService.buscarCompetenciasPorCodMapaSemRelacionamentos(1L);
+        verify(competenciaRepo).findByMapaCodigoSemFetch(1L);
+    }
+
+    @Test
+    void buscarIdsAssociacoesCompetenciaAtividade_ok() {
+        Object[] row1 = new Object[]{1L, null, 2L};
+        Object[] row2 = new Object[]{1L, null, 3L};
+        when(competenciaRepo.findCompetenciaAndAtividadeIdsByMapaCodigo(1L)).thenReturn(List.of(row1, row2));
+
+        Map<Long, Set<Long>> result = mapaService.buscarIdsAssociacoesCompetenciaAtividade(1L);
+
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(1L).size());
+    }
+
+    @Test
+    void listarConhecimentosEntidadesPorAtividade_ok() {
+        when(conhecimentoRepo.findByAtividade_Codigo(1L)).thenReturn(List.of(new Conhecimento()));
+        mapaService.listarConhecimentosEntidadesPorAtividade(1L);
+        verify(conhecimentoRepo).findByAtividade_Codigo(1L);
+    }
+
+    @Test
+    void listarConhecimentosPorMapa_ok() {
+        when(conhecimentoRepo.findByMapaCodigo(1L)).thenReturn(List.of(new Conhecimento()));
+        mapaService.listarConhecimentosPorMapa(1L);
+        verify(conhecimentoRepo).findByMapaCodigo(1L);
+    }
+
+    @Test
+    void salvarCompetencia_ok() {
+        Competencia c = new Competencia();
+        mapaService.salvarCompetencia(c);
+        verify(competenciaRepo).save(c);
+    }
+
+    @Test
+    void excluirMapa_ok() {
+        mapaService.excluirMapa(1L);
+        verify(mapaRepo).deleteById(1L);
+    }
+
+    @Test
+    void validarDescricaoAtividadeUnica_erro() {
+        Atividade a = new Atividade();
+        a.setDescricao("Desc");
+        when(atividadeRepo.findByMapaCodigoSemFetch(1L)).thenReturn(List.of(a));
+
+        CriarAtividadeRequest req = new CriarAtividadeRequest(1L, "desc");
+
+        assertThrows(ErroValidacao.class, () -> mapaService.criarAtividade(req));
+    }
+
+    @Test
+    void validarDescricaoConhecimentoUnica_erro() {
+        Conhecimento c = new Conhecimento();
+        c.setDescricao("Desc");
+        when(conhecimentoRepo.findByAtividade_Codigo(1L)).thenReturn(List.of(c));
+
+        CriarConhecimentoRequest req = new CriarConhecimentoRequest(1L, "desc");
+
+        assertThrows(ErroValidacao.class, () -> mapaService.criarConhecimento(1L, req));
+    }
+}

--- a/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServiceCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServiceCoverageExtraTest.java
@@ -1,0 +1,61 @@
+package sgc.processo.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.organizacao.OrganizacaoFacade;
+import sgc.organizacao.model.Unidade;
+import sgc.processo.dto.AtualizarProcessoRequest;
+import sgc.processo.dto.CriarProcessoRequest;
+import sgc.processo.erros.ErroProcesso;
+import sgc.processo.model.Processo;
+import sgc.processo.model.ProcessoRepo;
+import sgc.processo.model.SituacaoProcesso;
+import sgc.processo.model.TipoProcesso;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProcessoManutencaoService - Cobertura Extra")
+class ProcessoManutencaoServiceCoverageExtraTest {
+
+    @Mock private ProcessoRepo processoRepo;
+    @Mock private OrganizacaoFacade organizacaoFacade;
+    @Mock private ProcessoValidador processoValidador;
+    @Mock private ProcessoConsultaService processoConsultaService;
+
+    @InjectMocks
+    private ProcessoManutencaoService manutencaoService;
+
+    @Test
+    @DisplayName("criar - erro unidades sem mapa para REVISAO")
+    void criar_erroUnidadesSemMapa() {
+        CriarProcessoRequest req = new CriarProcessoRequest("desc", TipoProcesso.REVISAO, LocalDateTime.now(), List.of(1L));
+        Unidade u = new Unidade();
+        u.setCodigo(1L);
+        when(organizacaoFacade.unidadePorCodigo(1L)).thenReturn(u);
+        when(processoValidador.validarTiposUnidades(anyList())).thenReturn(Optional.empty());
+        when(processoValidador.getMensagemErroUnidadesSemMapa(anyList())).thenReturn(Optional.of("Erro"));
+
+        assertThrows(ErroProcesso.class, () -> manutencaoService.criar(req));
+    }
+
+    @Test
+    @DisplayName("atualizar - erro unidades sem mapa para DIAGNOSTICO")
+    void atualizar_erroUnidadesSemMapa() {
+        AtualizarProcessoRequest req = new AtualizarProcessoRequest(1L, "desc", TipoProcesso.DIAGNOSTICO, LocalDateTime.now(), List.of(1L));
+        Processo p = new Processo();
+        p.setSituacao(SituacaoProcesso.CRIADO);
+        when(processoConsultaService.buscarProcessoCodigo(1L)).thenReturn(p);
+        when(processoValidador.getMensagemErroUnidadesSemMapa(anyList())).thenReturn(Optional.of("Erro"));
+
+        assertThrows(ErroProcesso.class, () -> manutencaoService.atualizar(1L, req));
+    }
+}

--- a/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageExtraTest.java
@@ -1,0 +1,92 @@
+package sgc.processo.service;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.alerta.*;
+import sgc.organizacao.*;
+import sgc.organizacao.dto.*;
+import sgc.organizacao.model.*;
+import sgc.processo.model.*;
+import sgc.subprocesso.service.*;
+
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProcessoNotificacaoService - Cobertura Extra")
+class ProcessoNotificacaoServiceCoverageExtraTest {
+
+    @Mock private AlertaFacade servicoAlertas;
+    @Mock private EmailService emailService;
+    @Mock private EmailModelosService emailModelosService;
+    @Mock private OrganizacaoFacade organizacaoFacade;
+    @Mock private UsuarioFacade usuarioService;
+    @Mock private ProcessoRepo processoRepo;
+    @Mock private SubprocessoService subprocessoService;
+
+    @InjectMocks
+    private ProcessoNotificacaoService notificacaoService;
+
+    @Test
+    @DisplayName("emailFinalizacaoProcesso - deve cobrir ramos extras para INTERMEDIARIA, RAIZ, e envio para substituto")
+    void emailFinalizacaoProcesso_RamosExtras() {
+        Processo proc = new Processo();
+        proc.setCodigo(1L);
+        proc.setDescricao("Processo 1");
+
+
+        Unidade u1 = new Unidade();
+        u1.setCodigo(10L);
+        u1.setSigla("U1");
+        u1.setNome("Unidade 1");
+        u1.setTipo(TipoUnidade.RAIZ);
+        u1.setSituacao(SituacaoUnidade.ATIVA);
+
+        Unidade u2 = new Unidade();
+        u2.setCodigo(20L);
+        u2.setSigla("U2");
+        u2.setNome("Unidade 2");
+        u2.setTipo(TipoUnidade.INTERMEDIARIA);
+        u2.setSituacao(SituacaoUnidade.ATIVA);
+
+        Unidade uSub = new Unidade();
+        uSub.setCodigo(30L);
+        uSub.setSigla("USUB");
+        uSub.setUnidadeSuperior(u2);
+        proc.adicionarParticipantes(Set.of(u1, u2));
+
+        when(processoRepo.findByIdComParticipantes(1L)).thenReturn(Optional.of(proc));
+        when(organizacaoFacade.unidadesPorCodigos(anyList())).thenReturn(List.of(u1, u2));
+
+        UnidadeResponsavelDto resp1 = new UnidadeResponsavelDto(10L, "titular1", "nome1", "sub1", "nomesub1");
+        UnidadeResponsavelDto resp2 = new UnidadeResponsavelDto(20L, "titular2", "nome2", null, null);
+        when(organizacaoFacade.buscarResponsaveisUnidades(anyList())).thenReturn(Map.of(10L, resp1, 20L, resp2));
+
+        Usuario userSub = new Usuario();
+        userSub.setEmail("sub@test.com");
+        when(usuarioService.buscarUsuariosPorTitulos(anyList())).thenReturn(Map.of("sub1", userSub));
+
+        when(emailModelosService.criarEmailProcessoFinalizadoPorUnidade(any(), any())).thenReturn("html");
+
+        notificacaoService.emailFinalizacaoProcesso(1L);
+
+        verify(emailService, atLeastOnce()).enviarEmailHtml(eq("sub@test.com"), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("enviarEmailParaSubstituto - captura exception e faz warning")
+    void enviarEmailParaSubstituto_Exception() {
+        Usuario userSub = new Usuario();
+        userSub.setEmail("sub@test.com");
+
+        doThrow(new RuntimeException("Test Exception")).when(emailService).enviarEmailHtml(anyString(), anyString(), anyString());
+
+        notificacaoService.enviarEmailParaSubstituto("sub1", Map.of("sub1", userSub), "assunto", "html", "Unidade Teste");
+
+        // Verifica se a excecao eh capturada sem explodir
+        verify(emailService).enviarEmailHtml(anyString(), anyString(), anyString());
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java
@@ -1,0 +1,230 @@
+package sgc.subprocesso;
+
+import com.fasterxml.jackson.databind.*;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.boot.webmvc.test.autoconfigure.*;
+import org.springframework.context.annotation.*;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.*;
+import org.springframework.test.context.bean.override.mockito.*;
+import org.springframework.test.web.servlet.*;
+import sgc.comum.ComumDtos.*;
+import sgc.comum.erros.*;
+import sgc.mapa.dto.*;
+import sgc.mapa.model.*;
+import sgc.organizacao.*;
+import sgc.seguranca.*;
+import sgc.subprocesso.dto.*;
+import sgc.subprocesso.model.*;
+import sgc.subprocesso.service.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(SubprocessoController.class)
+@Import(RestExceptionHandler.class)
+@DisplayName("SubprocessoController - Cobertura Extra")
+class SubprocessoControllerCoverageExtraTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+    @MockitoBean
+    private SubprocessoService subprocessoService;
+    @MockitoBean
+    private OrganizacaoFacade organizacaoFacade;
+    @MockitoBean
+    private SgcPermissionEvaluator permissionEvaluator;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("disponibilizarCadastro - erro validacao")
+    @WithMockUser
+    void disponibilizarCadastroErro() throws Exception {
+        Atividade a = new Atividade();
+        a.setCodigo(1L);
+        a.setDescricao("desc");
+        when(subprocessoService.obterAtividadesSemConhecimento(1L)).thenReturn(List.of(a));
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("DISPONIBILIZAR_CADASTRO"))).thenReturn(true);
+
+        mockMvc.perform(post("/api/subprocessos/1/cadastro/disponibilizar").with(csrf()))
+                .andExpect(status().isUnprocessableEntity());
+
+    }
+
+    @Test
+    @DisplayName("disponibilizarRevisao - erro validacao")
+    @WithMockUser
+    void disponibilizarRevisaoErro() throws Exception {
+        Atividade a = new Atividade();
+        a.setCodigo(1L);
+        a.setDescricao("desc");
+        when(subprocessoService.obterAtividadesSemConhecimento(1L)).thenReturn(List.of(a));
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("DISPONIBILIZAR_REVISAO_CADASTRO"))).thenReturn(true);
+
+        mockMvc.perform(post("/api/subprocessos/1/disponibilizar-revisao").with(csrf()))
+                .andExpect(status().isUnprocessableEntity());
+
+    }
+
+    @Test
+    @DisplayName("obterMapaCompleto - erro generico")
+    @WithMockUser
+    void obterMapaCompletoErro() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("VISUALIZAR_SUBPROCESSO"))).thenReturn(true);
+        when(subprocessoService.mapaCompletoPorSubprocesso(1L)).thenThrow(new RuntimeException("erro"));
+
+        mockMvc.perform(get("/api/subprocessos/1/mapa-completo"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("salvarMapaCompleto - ok")
+    @WithMockUser
+    void salvarMapaCompletoOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("EDITAR_MAPA"))).thenReturn(true);
+        SalvarMapaRequest req = new SalvarMapaRequest(null, List.of());
+        when(subprocessoService.salvarMapa(eq(1L), any())).thenReturn(new Mapa());
+
+        mockMvc.perform(post("/api/subprocessos/1/mapa-completo")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("disponibilizarMapaEmBloco - ok")
+    @WithMockUser
+    void disponibilizarMapaEmBlocoOk() throws Exception {
+        ProcessarEmBlocoRequest req = new ProcessarEmBlocoRequest("DISPONIBILIZAR", List.of(1L), LocalDate.now());
+        when(permissionEvaluator.hasPermission(any(), any(), eq("Subprocesso"), eq("DISPONIBILIZAR_MAPA"))).thenReturn(true);
+
+        mockMvc.perform(post("/api/subprocessos/1/disponibilizar-mapa-bloco")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("obterMapaParaAjuste - ok")
+    @WithMockUser
+    void obterMapaParaAjusteOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("AJUSTAR_MAPA"))).thenReturn(true);
+        when(subprocessoService.obterMapaParaAjuste(1L)).thenReturn(MapaAjusteDto.builder().build());
+
+        mockMvc.perform(get("/api/subprocessos/1/mapa-ajuste"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("obterSugestoes - ok")
+    @WithMockUser
+    void obterSugestoesOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("VISUALIZAR_SUBPROCESSO"))).thenReturn(true);
+        when(subprocessoService.obterSugestoes()).thenReturn(Map.of());
+
+        mockMvc.perform(get("/api/subprocessos/1/sugestoes"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("criarAnaliseValidacao - ok")
+    @WithMockUser(roles = {"GESTOR"})
+    void criarAnaliseValidacaoOk() throws Exception {
+        CriarAnaliseRequest req = new CriarAnaliseRequest("191919", "obs", "SGL", "mot", sgc.subprocesso.model.TipoAcaoAnalise.ACEITE_MAPEAMENTO);
+        when(subprocessoService.buscarSubprocesso(1L)).thenReturn(new Subprocesso());
+        Analise a = new Analise();
+        when(subprocessoService.criarAnalise(any(), any(), eq(sgc.subprocesso.model.TipoAnalise.VALIDACAO))).thenReturn(a);
+        when(subprocessoService.paraHistoricoDto(a)).thenReturn(new AnaliseHistoricoDto(null, null, null, null, null, null, null, null));
+
+        mockMvc.perform(post("/api/subprocessos/1/analises-validacao")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+    }
+    @Test
+    @DisplayName("criarAnaliseCadastro - ok")
+    @WithMockUser(roles = {"GESTOR"})
+    void criarAnaliseCadastroOk() throws Exception {
+        CriarAnaliseRequest req = new CriarAnaliseRequest("191919", "obs", "SGL", "mot", sgc.subprocesso.model.TipoAcaoAnalise.ACEITE_MAPEAMENTO);
+        when(subprocessoService.buscarSubprocesso(1L)).thenReturn(new Subprocesso());
+        Analise a = new Analise();
+        when(subprocessoService.criarAnalise(any(), any(), eq(sgc.subprocesso.model.TipoAnalise.CADASTRO))).thenReturn(a);
+        when(subprocessoService.paraHistoricoDto(a)).thenReturn(new AnaliseHistoricoDto(null, null, null, null, null, null, null, null));
+
+        mockMvc.perform(post("/api/subprocessos/1/analises-cadastro")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("obterMapaParaVisualizacao - ok")
+    @WithMockUser
+    void obterMapaParaVisualizacaoOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("VISUALIZAR_SUBPROCESSO"))).thenReturn(true);
+        when(subprocessoService.mapaParaVisualizacao(1L)).thenReturn(MapaVisualizacaoResponse.builder().build());
+
+        mockMvc.perform(get("/api/subprocessos/1/mapa-visualizacao"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("salvarAjustesMapa - ok")
+    @WithMockUser
+    void salvarAjustesMapaOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("EDITAR_MAPA"))).thenReturn(true);
+        SalvarAjustesRequest req = new SalvarAjustesRequest(List.of(new CompetenciaAjusteDto(1L, "desc", null)));
+
+        mockMvc.perform(post("/api/subprocessos/1/mapa-ajuste/atualizar")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("apresentarSugestoes - ok")
+    @WithMockUser
+    void apresentarSugestoesOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("APRESENTAR_SUGESTOES"))).thenReturn(true);
+        TextoRequest req = new TextoRequest("Sugestao");
+
+        mockMvc.perform(post("/api/subprocessos/1/apresentar-sugestoes")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("obterHistoricoValidacao - ok")
+    @WithMockUser
+    void obterHistoricoValidacaoOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("VISUALIZAR_SUBPROCESSO"))).thenReturn(true);
+        when(subprocessoService.listarHistoricoValidacao(1L)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/subprocessos/1/historico-validacao"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("verificarImpactos - ok")
+    @WithMockUser
+    void verificarImpactosOk() throws Exception {
+        when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("VERIFICAR_IMPACTOS"))).thenReturn(true);
+        when(subprocessoService.verificarImpactos(eq(1L), any())).thenReturn(ImpactoMapaResponse.builder().build());
+
+        mockMvc.perform(get("/api/subprocessos/1/impactos-mapa"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
This PR increases the overall backend line coverage by targeting previously untested lines in core services.

### Details:
- Created `SubprocessoControllerCoverageExtraTest` to cover edge cases, validation errors, block processing endpoints, and visualization methods.
- Created `ProcessoManutencaoServiceCoverageExtraTest` to test validation errors when creating or updating a process with a unit that has no competency map during REVISAO or DIAGNOSTICO.
- Created `MapaManutencaoServiceCoverageExtraTest` to verify direct repository fetches, association fetching, duplicate validation scenarios, and map exclusion.
- Created `ProcessoNotificacaoServiceCoverageExtraTest` to test alternative paths when notifying intermediate and root units, as well as substitutes, upon process completion.

Coverage reports verify that the project's overall line coverage has successfully risen from ~96.7% to 97.93%.

---
*PR created automatically by Jules for task [15086670453864220333](https://jules.google.com/task/15086670453864220333) started by @lgalvao*