### PR TITLE
fix: resolve e2e testing bugs and application race condition during process start

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -451,6 +451,7 @@ test.describe('Smoke Test - Sistema SGC', () => {
             await navegarParaAtividadesVisualizacao(page);
 
             await page.getByTestId('btn-acao-analisar-principal').click();
+            await page.getByTestId('inp-aceite-cadastro-obs').fill('Homologado sem ressalvas');
             await page.getByTestId('btn-aceite-cadastro-confirmar').click();
             await page.waitForTimeout(100);
 

--- a/frontend/src/views/processo/ProcessoCadastroView.vue
+++ b/frontend/src/views/processo/ProcessoCadastroView.vue
@@ -24,7 +24,7 @@
       <div class="d-flex justify-content-between">
         <div>
           <LoadingButton
-              :disabled="isFormInvalid || isLoading"
+              :disabled="isFormInvalid || isLoading || isLoadingData"
               data-testid="btn-processo-iniciar"
               icon="play-fill"
               text="Iniciar processo"
@@ -32,7 +32,7 @@
               @click="abrirModalConfirmacao"
           />
           <LoadingButton
-              :disabled="isFormInvalid"
+              :disabled="isFormInvalid || isLoadingData"
               :loading="isLoading"
               class="ms-2"
               data-testid="btn-processo-salvar"
@@ -194,9 +194,12 @@ function mostrarAlerta(variant: AlertState['variant'], title: string, body: stri
   window.scrollTo(0, 0);
 }
 
+const isLoadingData = ref(false);
+
 onMounted(async () => {
   const codProcesso = route.query.codProcesso;
   if (codProcesso) {
+    isLoadingData.value = true;
     try {
       await processosStore.buscarProcessoDetalhe(Number(codProcesso));
       const processo = processosStore.processoDetalhe;
@@ -221,6 +224,8 @@ onMounted(async () => {
     } catch (error) {
       mostrarAlerta('danger', "Erro ao carregar processo", "Não foi possível carregar os detalhes do processo.");
       logger.error("Erro ao carregar processo:", error);
+    } finally {
+      isLoadingData.value = false;
     }
   } else if (tipo.value) {
     await unidadesStore.buscarUnidadesParaProcesso(tipo.value);


### PR DESCRIPTION
This pull request fixes a race condition where the `btn-processo-iniciar` could be clicked before the frontend had finished fetching existing process details. This caused it to treat it as a new process, leading to duplications and subsequently making e2e tests fail when they expected the correct ID to exist. The PR also improves the fidelity of the `cdu-04` e2e test, matching it closer to a standard user flow without artificial cleanup hooks. Lastly, it resolves a 400 error in `smoke.spec.ts` where an observation text was omitted.

---
*PR created automatically by Jules for task [5909840882177959567](https://jules.google.com/task/5909840882177959567) started by @lgalvao*