### PR TITLE
chore: clean up unnecessary comments across the codebase

### DIFF
--- a/backend/src/test/java/sgc/subprocesso/model/SituacaoSubprocessoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/SituacaoSubprocessoTest.java
@@ -103,10 +103,7 @@ class SituacaoSubprocessoTest {
         assertThat(DIAGNOSTICO_AUTOAVALIACAO_EM_ANDAMENTO.podeTransicionarPara(MAPEAMENTO_CADASTRO_EM_ANDAMENTO, TipoProcesso.DIAGNOSTICO)).isFalse();
         assertThat(DIAGNOSTICO_AUTOAVALIACAO_EM_ANDAMENTO.podeTransicionarPara(DIAGNOSTICO_MONITORAMENTO, TipoProcesso.DIAGNOSTICO)).isTrue();
     }
-
-    // ===========================================
     // Testes mesclados de SituacaoSubprocessoCoverageTest
-    // ===========================================
 
     @Test
     @DisplayName("Mistura de tipos deve retornar false")
@@ -152,10 +149,7 @@ class SituacaoSubprocessoTest {
     void testTransicoesInvalidasAdicionais(SituacaoSubprocesso de, SituacaoSubprocesso para, TipoProcesso tipo, boolean esperado) {
         assertThat(de.podeTransicionarPara(para, tipo)).isEqualTo(esperado);
     }
-
-    // ===========================================
     // Testes mesclados de SituacaoSubprocessoGapTest
-    // ===========================================
 
     @Test
     @DisplayName("Deve cobrir todas as branches de podeIniciar (método privado)")

--- a/backend/src/test/resources/integration-test-seed.sql
+++ b/backend/src/test/resources/integration-test-seed.sql
@@ -1,6 +1,4 @@
--- ================================================================================
 -- SEED PARA TESTES DE INTEGRAÇÃO V2
--- ================================================================================
 -- 
 -- Este arquivo contém APENAS dados NÃO mantidos pelo sistema SGC:
 --   - Unidades (VW_UNIDADE)
@@ -13,11 +11,7 @@
 -- criados programaticamente em cada teste para garantir independência.
 --
 -- Última atualização: 2026-02-09
--- ================================================================================
-
--- ================================================================================
 -- UNIDADES
--- ================================================================================
 -- Hierarquia de Unidades para Testes
 --
 -- ADMIN (1)
@@ -110,10 +104,7 @@ VALUES (17, 'Coordenadoria 22', 'COORD_22', 'INTERMEDIARIA', 'ATIVA', 11, '13131
 INSERT INTO sgc.vw_unidade (codigo, nome, sigla, tipo, situacao, unidade_superior_codigo, titulo_titular,
                             matricula_titular, data_inicio_titularidade)
 VALUES (18, 'Seção 221', 'SECAO_221', 'OPERACIONAL', 'ATIVA', 17, '141414', '00141414', CURRENT_TIMESTAMP);
-
--- ================================================================================
 -- USUÁRIOS
--- ================================================================================
 
 -- Administradores
 -- Admin principal para testes V2 (usado por @WithMockAdmin)
@@ -208,10 +199,7 @@ VALUES ('282828', '00282828', 'Eric Clapton', 'eric.clapton@tre-pe.jus.br', '202
 
 INSERT INTO sgc.vw_usuario (titulo, matricula, nome, email, ramal, unidade_lot_codigo, unidade_comp_codigo)
 VALUES ('292929', '00292929', 'Flea', 'flea@tre-pe.jus.br', '2029', 18, 18);
-
--- ================================================================================
 -- PERFIS DE USUÁRIOS
--- ================================================================================
 
 -- Perfis ADMIN
 -- Perfil para Admin Teste V2 (usado por @WithMockAdmin)
@@ -314,10 +302,7 @@ VALUES ('282828', 'SERVIDOR', 15);
 
 INSERT INTO sgc.vw_usuario_perfil_unidade (usuario_titulo, perfil, unidade_codigo)
 VALUES ('292929', 'SERVIDOR', 18);
-
--- ================================================================================
 -- RESPONSABILIDADES (Titulares das Unidades)
--- ================================================================================
 
 INSERT INTO sgc.vw_responsabilidade (unidade_codigo, usuario_titulo, usuario_matricula, tipo, data_inicio)
 VALUES (1, '111111', '00111111', 'TITULAR', CURRENT_TIMESTAMP);
@@ -372,17 +357,11 @@ VALUES (17, '131313', '00131313', 'TITULAR', CURRENT_TIMESTAMP);
 
 INSERT INTO sgc.vw_responsabilidade (unidade_codigo, usuario_titulo, usuario_matricula, tipo, data_inicio)
 VALUES (18, '141414', '00141414', 'TITULAR', CURRENT_TIMESTAMP);
-
--- ================================================================================
 -- PARÂMETROS DO SISTEMA
--- ================================================================================
 
 INSERT INTO sgc.parametro (codigo, chave, descricao, valor)
 VALUES (1, 'DIAS_INATIVACAO_PROCESSO', 'Dias para inativação de processos', '30');
 
 INSERT INTO sgc.parametro (codigo, chave, descricao, valor)
 VALUES (2, 'DIAS_ALERTA_NOVO', 'Dias para indicação de alerta como novo', '3');
-
--- ================================================================================
 -- FIM DO SEED
--- ================================================================================

--- a/frontend/src/components/__tests__/TabelaProcessos.spec.ts
+++ b/frontend/src/components/__tests__/TabelaProcessos.spec.ts
@@ -38,7 +38,6 @@ describe("TabelaProcessos.vue", () => {
     const context = setupComponentTest();
 
     it("deve renderizar a tabela e os cabeçalhos corretamente", async () => {
-        // Do not stub BTable so we can check headers rendered by it
         context.wrapper = mount(TabelaProcessos, {
             ...getCommonMountOptions(),
             props: {
@@ -90,7 +89,6 @@ describe("TabelaProcessos.vue", () => {
     });
 
     it("deve emitir o evento ordenar ao receber o evento sort-changed", async () => {
-        // Here we stub BTable to easily trigger sort-changed
         context.wrapper = mount(TabelaProcessos, {
             ...getCommonMountOptions({}, {
                 BTable: {
@@ -277,7 +275,6 @@ describe("TabelaProcessos.vue", () => {
 
     describe("Modo Compacto", () => {
         it("deve exibir o rótulo reduzido 'Unidades' quando compacto é true", async () => {
-            // Need real BTable to check headers
             context.wrapper = mount(TabelaProcessos, {
                 ...getCommonMountOptions(),
                 props: {

--- a/frontend/src/components/processo/ModalAcaoBloco.vue
+++ b/frontend/src/components/processo/ModalAcaoBloco.vue
@@ -153,8 +153,6 @@ function setProcessando(val: boolean) {
 function setErro(msg: string | null) {
   erro.value = msg;
 }
-
-// Expor métodos para controle do pai e satisfazer o linter (uso no template)
 defineExpose({
   abrir,
   fechar,

--- a/frontend/src/services/usuarioService.ts
+++ b/frontend/src/services/usuarioService.ts
@@ -23,8 +23,6 @@ export interface Unidade {
     sigla: string;
 }
 
-// NOTE: 'Usuario' type is imported from "@/types/tipos" to avoid conflict/duplication
-
 export interface PerfilUnidade {
     perfil: Perfil;
     unidade: Unidade;

--- a/frontend/src/test-utils/storeTestHelpers.ts
+++ b/frontend/src/test-utils/storeTestHelpers.ts
@@ -3,8 +3,6 @@ import {beforeEach, expect, it, vi} from "vitest";
 
 /**
  * Utilitário para configurar testes de Store com Pinia
- * @param useStore Função que retorna a store
- * @returns Objeto de contexto contendo a store (populada no beforeEach)
  */
 export function setupStoreTest<T>(useStore: () => T) {
     const context = {store: undefined as unknown as T};
@@ -41,7 +39,6 @@ export function testErrorHandling<T>(
     errorType?: Error | any
 ) {
     it("deve lançar um erro em caso de falha", async () => {
-        // Se errorType for passado, verifica o tipo, senão verifica apenas se lança
         if (errorType) {
             expect(action()).rejects.toThrow(errorType);
         } else {


### PR DESCRIPTION
This PR addresses a cleanup task to remove unnecessary comments from the codebase. Specifically, it targets conversational multiline comments (likely artifacts from AI tools), redundant JSDoc/JavaDoc parameter descriptions, obvious inline comments, and large visual block separators. The changes touch both frontend (Vue components, services, tests) and backend (Java tests, SQL scripts) files. No code logic was modified.

---
*PR created automatically by Jules for task [18029856941672146340](https://jules.google.com/task/18029856941672146340) started by @lgalvao*