### PR TITLE
docs: add E2E test alignment reports for CDUs

### DIFF
--- a/cdu-01-alignment.md
+++ b/cdu-01-alignment.md
@@ -1,0 +1,14 @@
+# CDU-01 - Realizar login e exibir estrutura das telas - Alignment
+
+## Current Status
+- The test verifies invalid credentials.
+- It verifies successful login for a single-profile user (GESTOR).
+- It verifies the profile selection screen for a multi-profile user (ADMIN + CHEFE).
+- It verifies the presence of navbar elements for an ADMIN (Painel, Unidades, Relatórios, Histórico, Configurações, Logout, User Info).
+- It verifies the footer text.
+
+## Gaps & Missing Coverage
+1. **Navbar items per profile:** Step 9.1.1 states that GESTOR, CHEFE, and SERVIDOR should see `Minha unidade` instead of `Unidades`, and they should not see the gear icon (Configurações). The test only checks the navbar as an ADMIN. It does not verify the differing navbar state for non-admins.
+
+## Recommended Changes
+- Add a scenario where a non-ADMIN user (e.g., CHEFE or GESTOR) logs in, and assert that they see the `Minha unidade` link instead of `Unidades`, and that the `Configurações` (gear icon) is explicitly *not* visible.

--- a/cdu-02-alignment.md
+++ b/cdu-02-alignment.md
@@ -1,0 +1,18 @@
+# CDU-02 - Visualizar Painel - Alignment
+
+## Current Status
+- The test verifies the basic structure (Processos and Alertas headers).
+- It verifies table sorting.
+- It verifies an ADMIN can see "Criado" processes.
+- It verifies a GESTOR *cannot* see "Criado" processes.
+- It tests that the creation button is hidden for GESTOR.
+
+## Gaps & Missing Coverage
+1. **Data Completeness for ADMIN:** Step 2.1 says ADMIN sees all processes in progress, and step 2.2 says they see all recent alerts for the ADMIN unit. The test doesn't verify the specific content of the alerts table for the ADMIN.
+2. **Unit grouping:** Step 3 states that in the "Unidades participantes" column, operational units should be hidden if their parent is fully participating. This logic is tested somewhat in process creation, but not explicitly verified in the Panel's table view.
+3. **CHEFE/SERVIDOR profile:** The test only covers ADMIN and GESTOR. It doesn't test the panel visualization for CHEFE or SERVIDOR (e.g., verifying CHEFE sees their unit's active processes).
+
+## Recommended Changes
+- Verify the grouping of units in the "Unidades participantes" column on the panel matches the logic in Step 3.
+- Add scenarios to verify the Panel visualization specifically for a CHEFE and a SERVIDOR.
+- Add a test for the Alerts table to ensure it populates correctly based on the logged-in profile.

--- a/cdu-03-alignment.md
+++ b/cdu-03-alignment.md
@@ -1,0 +1,16 @@
+# CDU-03 - Criar processo - Alignment
+
+## Current Status
+- The test verifies the tree selection logic (indeterminate states, auto-selecting parents).
+- It tests restrictions (preventing selection of units already in an active mapping process).
+- It tests that units without a map cannot be selected for a Revision process.
+- It tests cancellation and confirmation messages.
+- It tests initiating a process directly instead of just saving.
+
+## Gaps & Missing Coverage
+1. **Validation of Input fields:** Step 4 states the system must validate the required fields (Description, Date, Type). The test doesn't try to save a process with missing data to ensure validation errors appear.
+2. **Warning for Interoperacional Root:** Step 7.1.1 states that if the root unit is interoperational, the system should ask if the mapping will be for the unit's own activities or its subordinates. This specific confirmation modal/behavior is not tested.
+
+## Recommended Changes
+- Implement a scenario to test validation by submitting an empty or incomplete form and verifying the resulting error messages.
+- If applicable to the system's current behavior, implement a test for the interoperational root unit warning (Step 7.1.1).

--- a/cdu-04-alignment.md
+++ b/cdu-04-alignment.md
@@ -1,0 +1,16 @@
+# CDU-04 - Iniciar processo de mapeamento - Alignment
+
+## Current Status
+- The test creates a mapping process.
+- It verifies the confirmation modal and canceling it.
+- It initiates the process, verifies the toast message, and redirect.
+- It navigates to the process details and verifies the subprocesses were created and are in 'Não iniciado' state.
+
+## Gaps & Missing Coverage
+1. **Subprocess Data:** Step 9 specifies initial values (Date copied, Status, empty Observações/Sugestões). The test only checks the status.
+2. **Movements:** Step 11 dictates a movement "Processo iniciado". Not checked.
+3. **Emails & Alerts:** Steps 12 and 13 mandate emails and alerts to target and superior units. Not checked.
+
+## Recommended Changes
+- Check the internal movement log on a created subprocess.
+- Verify the email dispatches and internal alerts for the participating units (both target and superior).

--- a/cdu-05-alignment.md
+++ b/cdu-05-alignment.md
@@ -1,0 +1,18 @@
+# CDU-05 - Iniciar processo de revisao - Alignment
+
+## Current Status
+- The test runs a massive setup to create a finalized mapping process.
+- It creates a Revision process.
+- It starts the Revision process.
+- It verifies the confirmation modal, the status update ("Em andamento"), and redirect.
+
+## Gaps & Missing Coverage
+1. **Subprocess Creation specifics:** Step 11 describes the initial values for the revision subprocesses (Date, Situation: 'Não iniciado', Observation/Suggestion fields empty). The test checks the status but not the empty fields or the copied date specifically.
+2. **Movements:** Step 12 dictates a movement record "Revisão do cadastro iniciada". Not checked.
+3. **Emails & Alerts:** Steps 13 and 14 mandate emails to target and superior units, and internal alerts. Not checked.
+4. **Knowledge Import:** Step 9 mentions creating the subprocess with an exact copy of the *current* mapping activities and knowledges. The test doesn't log in as the CHEFE to explicitly verify that the previously created activities/knowledges are present inside the new revision subprocess right after creation.
+
+## Recommended Changes
+- After starting the revision process, log in as the CHEFE and verify that the activities/knowledges from the mapping phase were correctly copied over to the revision subprocess.
+- Verify the internal movement log text.
+- Verify the email dispatches and internal alerts for both the target and superior units.

--- a/cdu-06-alignment.md
+++ b/cdu-06-alignment.md
@@ -1,0 +1,14 @@
+# CDU-06 - Detalhar processo - Alignment
+
+## Current Status
+- The test sets up mapping processes.
+- It verifies an ADMIN sees the Details page, the Unit table, and the "Finalizar processo" button.
+- It verifies a GESTOR sees the Details page, the Unit table, and *does not* see the "Finalizar processo" button.
+
+## Gaps & Missing Coverage
+1. **Change Deadline / Situation Elements (ADMIN):** Step 2.2.1 states that ADMINs should see elements to change the deadline or the situation (e.g., Reopen) within the unit details area. The test doesn't check if these elements exist when an ADMIN clicks into a unit.
+2. **Block Actions:** Step 2.2.2 states that if subordinate units are ready for block acceptance or homologation, specific buttons ("Aceitar/Homologar em bloco") should be visible. The test does not set up a process to this state and does not check for these buttons.
+
+## Recommended Changes
+- Add assertions in the ADMIN scenario to check for the presence of the deadline alteration and status alteration buttons/elements when viewing a subordinate unit.
+- Implement a scenario where units are in 'Cadastro disponibilizado' and verify the presence of the "Aceitar em bloco" (GESTOR) and "Homologar em bloco" (ADMIN) buttons on the process details page.

--- a/cdu-07-alignment.md
+++ b/cdu-07-alignment.md
@@ -1,0 +1,16 @@
+# CDU-07 - Detalhar subprocesso - Alignment
+
+## Current Status
+- The test verifies that ADMINs, GESTORs, and CHEFEs can access the subprocess details page.
+- It checks that the CHEFE is routed directly to their unit's subprocess.
+- It verifies the presence of unit data (sigla, situation, deadline), the movements table, and the action cards.
+
+## Gaps & Missing Coverage
+1. **Responsibility Information:** Step 2.1.2 and 2.1.3 specify that the "Titular" and "Responsável" data (Name, Ramal, Email, Responsability Type) must be displayed. The test does not verify the presence of this detailed responsibility information.
+2. **Localização Atual:** Step 2.1.5 requires displaying the "Localização atual" (Current Location). The test checks "situacao" and "prazo" but skips this field.
+3. **Card Availability Rules:** Step 2.3.1 outlines strict rules for when the "Atividades" and "Mapa" cards are enabled vs disabled based on profile and process state. The test only checks if *any* activity card is visible, but doesn't test the disabled/enabled states for the different profiles across the process lifecycle.
+
+## Recommended Changes
+- Add assertions to verify the presence of the Titular/Responsável details (Name, Ramal, Email).
+- Add an assertion to check the "Localização atual" field.
+- Enhance the test to verify that the "Mapa de Competências" card is properly disabled for non-ADMINs before homologation, and enabled afterwards.

--- a/cdu-08-alignment.md
+++ b/cdu-08-alignment.md
@@ -1,0 +1,19 @@
+# CDU-08 - Manter cadastro de atividades e conhecimentos - Alignment
+
+## Current Status
+- The test sets up a Mapping process.
+- It tests the CHEFE navigating to activities and opening/canceling the import modal.
+- It tests adding an activity and knowledge, and verifies the state changes to "Cadastro em andamento".
+- It tests editing and removing activities and knowledges.
+- It tests that the "Impactos" button is missing in a Mapping process.
+- It tests making the registry available.
+- It tests that the "Impactos" button *is* present in a Revision process.
+
+## Gaps & Missing Coverage
+1. **Importation Execution (Step 13):** The test opens the import modal and *cancels* it. It never actually completes the flow to import activities from a finalized process (Steps 13.1 - 13.7). It also completely misses testing the negative validation where duplicated activities are rejected (Step 13.7.2).
+2. **Auto-save Verification:** Step 15.1 dictates that all actions (create/edit/delete) are auto-saved. While the test performs these actions, it would be much stronger if it reloaded the page (or logged out and in) to verify the data actually persisted without a manual "Save All" button.
+
+## Recommended Changes
+- Implement the complete importation flow: Select a finalized process, select a unit, select activities, and confirm import.
+- Implement the negative importation flow: Try to import an activity that already exists and assert the specific error/warning message.
+- Add a page reload after adding/editing an activity to explicitly verify the auto-save functionality.

--- a/cdu-09-alignment.md
+++ b/cdu-09-alignment.md
@@ -1,0 +1,16 @@
+# CDU-09 - Disponibilizar cadastro de atividades e conhecimentos - Alignment
+
+## Current Status
+- The test checks validation (blocking availability when an activity lacks a knowledge).
+- It tests a successful availability flow.
+- It tests the CHEFE viewing the Devolution analysis history and then making the registry available again.
+
+## Gaps & Missing Coverage
+1. **Movement Records:** Step 11 requires a specific movement record ("Disponibilização do cadastro de atividades"). The test does not assert the `tbl-movimentacoes` list.
+2. **Notifications & Alerts:** Steps 12 and 13 require an email notification and an internal alert to be sent to the superior unit. The test does not verify these.
+3. **Target State:** Step 10 specifies the state changes to "Cadastro disponibilizado". The test checks the toast message, but not the actual situation text in the header for the successful flow (it checks "Cadastro em andamento" for the devolution, but misses verifying the final state).
+
+## Recommended Changes
+- Add assertions for the internal alerts and email notifications sent to the superior unit.
+- Verify the internal movement log texts match the requirements.
+- Verify the situation text in the subprocess header updates to "Cadastro disponibilizado".

--- a/cdu-10-alignment.md
+++ b/cdu-10-alignment.md
@@ -1,0 +1,16 @@
+# CDU-10 - Analisar validação de cadastro e conhecimentos (Mapeamento) - Alignment
+
+## Current Status
+- This test (which is actually covering the availability/devolution of a *Revision*, though the file says CDU-10 which might be a naming mixup as mapping is CDU-09/13 and revision is CDU-10/14 usually) sets up a Revision process.
+- It tests validating that an activity needs a knowledge.
+- It tests making the revision available.
+- It tests devolution and viewing the history.
+- It tests that the history is cleared upon a subsequent availability action.
+
+## Gaps & Missing Coverage
+1. **Movement Records:** The test partially checks movements (`tbl-movimentacoes`) for "Disponibilização da revisão...", but not for the devolutions.
+2. **Alerts & Notifications:** Missing checks for internal alerts and emails sent during devolution and availability actions.
+
+## Recommended Changes
+- Check internal movement logs for Devolution actions.
+- Add assertions for internal alerts and email notifications for all state transitions (Disponibilizar, Devolver).

--- a/cdu-11-alignment.md
+++ b/cdu-11-alignment.md
@@ -1,0 +1,17 @@
+# CDU-11 - Manter atividades do subprocesso de mapeamento - Alignment
+
+## Current Status
+- The test runs a massive setup that initiates a mapping process, creates a map, homologates it, finishes the mapping process, and creates a revision process.
+- It tests that a CHEFE can add a new activity to the revision, view impacts (none).
+- It tests that a CHEFE can edit/remove base activities and view impacts (shows impacted competencies).
+- It tests that a GESTOR and an ADMIN can view the impacts in the visualizer screens.
+
+## Gaps & Missing Coverage
+- The test relies heavily on the same flow from CDU-16 (Ajustar mapa).
+- The file name and test structure for `cdu-11.spec.ts` are a bit intertwined with CDU-16.
+- The requirements for CDU-11 explicitly state how the CHEFE interacts with the revision (auto-copying mapping data, seeing the impacts of modifications, and making it available). The test *does* cover these core interactions (adding, editing, removing and seeing impacts).
+- However, similar to other tests, it does not explicitly verify the auto-save functionality mentioned in the requirements, nor does it check the exact `tbl-movimentacoes` log or alerts/emails that might be defined in the core requirement (though CDU-11 is usually just the data manipulation, making it available is CDU-10).
+
+## Recommended Changes
+- Verify the auto-save by reloading the page after an edit.
+- Ensure the test explicitly checks that the "Base" activities (copied from the mapping phase) are loaded correctly initially before edits are made.

--- a/cdu-12-alignment.md
+++ b/cdu-12-alignment.md
@@ -1,0 +1,17 @@
+# CDU-12 - Visualizar cadastro de atividades e conhecimentos - Alignment
+
+## Current Status
+- The test prepares a mapping process up to the 'Cadastro disponibilizado' state.
+- It tests a GESTOR viewing the activities via the Process Details screen.
+- It tests a CHEFE viewing the activities directly (their own unit).
+- It prepares the process to finalization (homologation of map).
+- It tests a GESTOR viewing the activities of the finalized process.
+- It tests a CHEFE viewing the activities of the finalized process.
+
+## Gaps & Missing Coverage
+- The test correctly verifies navigation logic based on user profile (Step 2 vs Step 3).
+- It correctly verifies the structural UI components outlined in Step 5 (Activities as table headers/blocks, knowledges inside them).
+- The test fully aligns with the specified requirements.
+
+## Recommended Changes
+- None required. The test effectively covers the requirement.

--- a/cdu-13-alignment.md
+++ b/cdu-13-alignment.md
@@ -1,0 +1,15 @@
+# CDU-13 - Analisar cadastro de atividades e conhecimentos - Alignment
+
+## Current Status
+- The test performs a full analysis chain: CHEFE -> GESTOR (accept) -> GESTOR 2 (devolve) -> GESTOR (devolve) -> CHEFE (fix) -> GESTOR (accept) -> GESTOR 2 (accept) -> ADMIN (homologate).
+- It tests the devolution modal and history viewing.
+- It tests the accept modal and final homologation.
+
+## Gaps & Missing Coverage
+1. **Notifications & Alerts for Devolution:** Steps 9.9 and 9.10 dictate emails and alerts to the lower unit upon devolution. Not checked.
+2. **Notifications & Alerts for Accept:** Steps 10.7 and 10.8 dictate emails and alerts to the superior unit upon acceptance. Not checked.
+3. **Movement History Records:** Steps 9.6, 10.6, and 11.5 define specific texts for the movement history ("Cadastro de atividades e conhecimentos devolvido...", "...aceito", "...homologado"). Not checked.
+
+## Recommended Changes
+- Verify the email dispatch and internal alerts created during devolution and acceptance actions.
+- Check the movement history tab to ensure the descriptions exactly match the requirements.

--- a/cdu-14-alignment.md
+++ b/cdu-14-alignment.md
@@ -1,0 +1,19 @@
+# CDU-14 - Analisar revisão de cadastro de atividades e conhecimentos - Alignment
+
+## Current Status
+- The test simulates a full mapping process to create a baseline.
+- It simulates a revision process where the CHEFE makes changes and makes them available.
+- It tests the GESTOR viewing the impacts correctly.
+- It tests the GESTOR executing a devolution, verifying the result and movement history.
+- It tests the CHEFE fixing the devolution and sending it back.
+- It tests the GESTOR canceling a devolution and accepting the revision.
+- It tests the ADMIN viewing the final history and homologating.
+
+## Gaps & Missing Coverage
+1. **Notifications & Alerts for Devolution:** Step 9 requires emails and alerts to the lower unit upon devolution. The test doesn't check these.
+2. **Notifications & Alerts for Accept:** Step 10 requires emails and alerts to the superior unit upon acceptance. The test doesn't check these.
+3. **Internal Movement Logs:** While the test checks the analysis history (e.g., "Devolução", "ACEITE_REVISAO"), it doesn't explicitly check the `tbl-movimentacoes` for the exact text specified in Step 9.6 ("Revisão do cadastro de atividades devolvida para ajustes") or Step 10.6 ("Revisão do cadastro de atividades aceita").
+
+## Recommended Changes
+- Add assertions for the internal alerts and email notifications in both the Devolution and Accept flows.
+- Verify the exact movement descriptions in the `tbl-movimentacoes` tab.

--- a/cdu-15-alignment.md
+++ b/cdu-15-alignment.md
@@ -1,0 +1,17 @@
+# CDU-15 - Manter mapa de competências - Alignment
+
+## Current Status
+- The test prepares the map to 'Cadastro homologado' state.
+- It tests accessing the edition page.
+- It tests creating a competency with activities.
+- It tests editing a competency (name and associated activities).
+- It tests canceling the exclusion of a competency.
+- It tests confirming the exclusion of a competency.
+- It tests making the map available ("Disponibilizar").
+
+## Gaps & Missing Coverage
+1. **Activity count badge and tooltip (Step 4.4):** The requirement states there should be a badge with the count of knowledges on the right of the activity description, and hovering over it should display a tooltip with the list of knowledges. The test does not verify this visual element.
+
+## Recommended Changes
+- Add an assertion to verify the presence of the knowledge count badge next to an activity within a competency block.
+- Simulate a hover over the badge and assert the visibility of the tooltip containing the associated knowledges.

--- a/cdu-16-alignment.md
+++ b/cdu-16-alignment.md
@@ -1,0 +1,18 @@
+# CDU-16 - Ajustar mapa de competências - Alignment
+
+## Current Status
+- The test sets up a massive end-to-end flow: Maps a unit, homologates the map, finishes the process, creates a *Revision* process, makes the Chefe alter/add/remove activities, and gets the revision homologated.
+- It tests navigating to the map adjustment screen.
+- It tests viewing the "Impactos" modal, correctly identifying inserted activities and impacted competencies.
+- It tests opening the competency edit modal and canceling.
+- It tests associating the new activity to a new competency.
+
+## Gaps & Missing Coverage
+1. **Activity Association Validation:** The requirement states (Step 3) that unassociated activities must be highlighted with an alert icon, and competencies without activities highlighted with an error icon. The test does not verify these visual cues.
+2. **Competency Deletion:** Steps 8-9 describe the flow to delete a competency. The test covers editing/canceling and creating, but not deleting.
+3. **Saving/Updating Competency:** Step 7 describes updating the name/description of an existing competency. The test only cancels the edit modal, it doesn't confirm a change and verify it.
+
+## Recommended Changes
+- Add assertions to verify the warning/error icons on unassociated activities or empty competencies.
+- Implement a scenario to edit a competency's name, save it, and verify the change in the UI.
+- Implement a scenario to delete a competency and verify it is removed from the list.

--- a/cdu-17-alignment.md
+++ b/cdu-17-alignment.md
@@ -1,0 +1,18 @@
+# CDU-17 - Disponibilizar mapa de competências - Alignment
+
+## Current Status
+- The test prepares a process up to the point where the ADMIN creates competencies.
+- It tests opening and canceling the availability modal.
+- It tests confirming the availability modal (via a helper function), and checks the final state "Mapa disponibilizado".
+
+## Gaps & Missing Coverage
+1. **Validation Checks (Step 8/9):** The requirement states the system must verify if all competencies have activities and vice-versa. If not, it blocks the availability and shows an error indicating which items are unassociated. The test never executes this negative path.
+2. **Observation Field (Step 10/13):** The modal has an optional `Observações` field which should be recorded in the map's details. The test doesn't check if this field exists, nor does it fill it or verify its persistence.
+3. **Alerts & Notifications:** Steps 16, 17, and 18 dictate emails to the target unit and superior units, and an internal alert. The test does not verify these.
+4. **Movements:** Step 15 dictates a movement record. Not verified.
+
+## Recommended Changes
+- Implement a scenario where an activity is left unassociated, try to click "Disponibilizar", and assert the specific error message block.
+- In the success scenario, ensure the modal's "Observações" field is used, and verify it appears in the map's view later.
+- Add assertions for the internal alerts and email notifications.
+- Verify the movement history log.

--- a/cdu-18-alignment.md
+++ b/cdu-18-alignment.md
@@ -1,0 +1,14 @@
+# CDU-18 - Visualizar mapa de competências - Alignment
+
+## Current Status
+- The test relies on "seed" data (a finalized process with ID 99).
+- It tests an ADMIN viewing the map via process details.
+- It tests a CHEFE viewing the map via their own panel.
+- It verifies the UI structure: title, unit identification, and the nested display of Competency -> Activities -> Knowledges.
+
+## Gaps & Missing Coverage
+- The test perfectly aligns with the requirements. It effectively covers different profile accesses and meticulously verifies the nested visual structure of the map as defined in Step 5.
+- (Minor): It relies on seed data which could be brittle if the seed changes, but assuming the seed is stable, the functional coverage is complete.
+
+## Recommended Changes
+- None required. The test is well-aligned with the requirement.

--- a/cdu-19-alignment.md
+++ b/cdu-19-alignment.md
@@ -1,0 +1,16 @@
+# CDU-19 - Validar mapa de competências - Alignment
+
+## Current Status
+- The test creates a full map and leaves it in the "Mapa disponibilizado" state.
+- It tests the CHEFE canceling the validation modal.
+- It tests the CHEFE confirming the validation, moving the state to "Mapa validado".
+
+## Gaps & Missing Coverage
+1. **Sugestões Flow (Steps 3-4):** The requirement details the flow for when the unit has suggestions ("Indicou sugestões para o mapa de competências? Sim"), including the status change to 'Mapa com sugestões', email notifications, and alerts. The test *completely ignores* the suggestions flow.
+2. **Movements Verification:** Step 6 dictates specific movement texts ("Apresentação de sugestões..." or "Validação do mapa..."). The test does not check the history table for these.
+3. **Alerts & Notifications:** Steps 5.4 and 5.5 require emails and alerts to the superior unit upon validation. The test does not verify them.
+
+## Recommended Changes
+- Implement a completely new scenario simulating the CHEFE clicking "Tenho sugestões" (or equivalent UI action for suggestions), filling out the suggestions, and verifying the state changes to 'Mapa com sugestões'.
+- Verify the email dispatch and internal alert for the superior unit for both the validation and the suggestions flows.
+- Verify the `tbl-movimentacoes` history logs for the correct descriptions.

--- a/cdu-20-alignment.md
+++ b/cdu-20-alignment.md
@@ -1,0 +1,19 @@
+# CDU-20 - Analisar validação de mapa de competências - Alignment
+
+## Current Status
+- The test covers a full map validation flow.
+- It tests the CHEFE validating the map.
+- It tests a GESTOR opening the devolution modal, checking the mandatory observation, and canceling it.
+- It tests GESTORs accepting the map.
+- It tests ADMIN homologating the map.
+
+## Gaps & Missing Coverage
+1. **Devolution Execution:** The test *cancels* the devolution. It never actually executes the devolution to check the resulting state, movement, alerts, and emails (Steps 8.5-8.11).
+2. **Alerts & Notifications for Devolution:** Steps 8.9 and 8.10 dictate emails and alerts to the lower unit upon devolution. This is untested.
+3. **Alerts & Notifications for Accept:** Steps 9.7 and 9.8 dictate emails and alerts to the superior unit upon acceptance. The test doesn't check these explicitly.
+4. **History/Movements:** Steps 8.8 (Devolution) and 9.6 (Accept) specify specific movement descriptions. The test does not assert the internal logs.
+
+## Recommended Changes
+- Add a specific negative/devolution scenario where a GESTOR actually confirms the devolution. Verify the state changes to 'Mapa com sugestões' or similar, and check the movement, alert, and email.
+- In the accept/homologation scenarios, add assertions for the internal alerts and email notifications.
+- Verify the internal movement log texts match the requirements.

--- a/cdu-21-alignment.md
+++ b/cdu-21-alignment.md
@@ -1,0 +1,16 @@
+# CDU-21 - Finalizar processo - Alignment
+
+## Current Status
+- The test prepares an exhaustive end-to-end flow up to "Mapa homologado".
+- It checks the process details and verifies the "Finalizar" button.
+- It cancels the action.
+- It completes the action and verifies the process is finalized.
+- It checks the absence of action buttons on a finalized process.
+
+## Gaps & Missing Coverage
+1. **Notification and Alerts:** Step 7 in the (implied) requirements usually mandates notifications and alerts to all participating units when a process is finalized. Assuming this exists (though I cannot see the explicit CDU-21 markdown), it's likely missing from the test.
+2. **Validation:** Step 4 (implied) usually has a validation if *all* units have completed their maps before allowing the process to finalize. The test prepares one unit perfectly but doesn't test the block if another unit is incomplete.
+
+## Recommended Changes
+- If the requirement specifies notifications/alerts on finalization, add assertions for them.
+- Add a negative test scenario where the ADMIN tries to finalize a process while a unit is still "Em andamento" or "Mapa criado", verifying the system blocks the action.

--- a/cdu-22-alignment.md
+++ b/cdu-22-alignment.md
@@ -1,0 +1,14 @@
+# CDU-22 - Aceitar cadastros em bloco - Alignment
+
+## Current Status
+- The test sets up a mapping process and makes the CHEFE make the registry available.
+- It tests the GESTOR canceling the block acceptance modal.
+- It tests the GESTOR confirming the block acceptance modal.
+
+## Gaps & Missing Coverage
+1. **Analysis and Movement Records:** Steps 8.1 and 8.2 mandate specific records ("Aceite" and "Cadastro de atividades e conhecimentos aceito"). The test doesn't check these internal logs.
+2. **Alerts and Notifications:** Steps 8.3 and 8.4 dictate alerts and emails for the *superior* unit. The test does not verify them.
+
+## Recommended Changes
+- Check the internal analysis history and movement logs after block acceptance.
+- Verify the alerts and email notifications specifically directed at the superior unit.

--- a/cdu-23-alignment.md
+++ b/cdu-23-alignment.md
@@ -1,0 +1,16 @@
+# CDU-23 - Homologar cadastros em bloco - Alignment
+
+## Current Status
+- The test prepares the map process up to the 'Cadastro disponibilizado' and 'Cadastro aceito' (by gestores) states.
+- It checks the modal cancelation (Scenario 1).
+- It checks the modal confirmation and success message (Scenario 2).
+
+## Gaps & Missing Coverage
+1. **Movement Verification:** Step 8.1 requires a movement record "Cadastro de atividades e conhecimentos homologado". The test does not verify this.
+2. **State Transition:** Step 8.2 says the situation must change to "Cadastro homologado". The test asserts the page stays on `/processo/\d+$` but doesn't check the specific unit's new status.
+3. **Alerts and Notifications:** Steps 8.3 and 8.4 dictate internal alerts and email notifications for the target units. The test doesn't cover these.
+
+## Recommended Changes
+- Verify the internal movement log in the subprocess details.
+- Explicitly verify the subprocess situation changes to "Cadastro homologado".
+- Add checks for the internal alerts and email notifications.

--- a/cdu-24-alignment.md
+++ b/cdu-24-alignment.md
@@ -1,0 +1,15 @@
+# CDU-24 - Disponibilizar mapas de competências em bloco - Alignment
+
+## Current Status
+- The test sets up a full mapping process until the "Mapa criado" state.
+- It returns to the process details, triggers the block availability modal, fills the mandatory date, and confirms.
+- It verifies the success message and redirect to the Panel.
+
+## Gaps & Missing Coverage
+1. **Validation Checks (Step 8/9):** The requirement states the system verifies if all competencies are associated with activities, and vice-versa. If negative, an error is shown (Step 9). The test does not cover this negative validation scenario.
+2. **Alerts & Notifications:** Step 10.4 (Notification to unit), 10.5 (Alert to unit), and 10.7 (Notification to superior units) are not explicitly verified by the test.
+3. **History/Movement:** Step 10.3 specifies a movement record. The test doesn't check the internal history of the subprocess.
+
+## Recommended Changes
+- Implement a negative test scenario where a competency or activity is unassociated, and verify the specific error message preventing block availability.
+- Add assertions to verify the internal alerts and email notifications for both the target units and their superiors.

--- a/cdu-25-alignment.md
+++ b/cdu-25-alignment.md
@@ -1,0 +1,16 @@
+# CDU-25 - Aceitar validação de mapas de competências em bloco - Alignment
+
+## Current Status
+- The test prepares a process up to the "Mapa validado" state by the unit CHEFE.
+- It checks that the GESTOR sees the "Aceitar em bloco" button and opens the modal.
+- It cancels the modal and verifies it hides.
+
+## Gaps & Missing Coverage
+1. **Completion Scenario Missing:** Like CDU-26, the test stops at canceling the modal. It never actually clicks the "Registrar aceite" button to confirm the block acceptance (Steps 8-10).
+2. **Analysis/Movement/Alerts Verification:** Steps 9.1-9.4 detail specific history records, analysis results ("Aceite"), internal alerts, and email notifications to the superior unit. None of these are tested because the success path is not executed.
+3. **Confirmation and Redirect:** Step 10 specifies a confirmation message and redirect to the Panel, which is untested.
+
+## Recommended Changes
+- Add the critical success path: selecting units and confirming the block acceptance.
+- Verify the subsequent state change, internal history, alerts, and email notifications to superior units.
+- Verify the success message and redirect to the Panel.

--- a/cdu-26-alignment.md
+++ b/cdu-26-alignment.md
@@ -1,0 +1,17 @@
+# CDU-26 - Homologar validação de mapas de competências em bloco - Alignment
+
+## Current Status
+- The test extensively sets up a map process up to the "Mapa validado" state, creating the competency and making the CHEFE and GESTORs accept it.
+- It verifies the presence of the block homologation button and modal.
+- It verifies the cancelation of the modal.
+
+## Gaps & Missing Coverage
+1. **Completion Scenario:** The test does *not* actually test the successful execution of the homologation (Step 8-10). It only cancels the modal (Cenario 3) and ends there. The core functionality of "Homologar em bloco" is missing from the test.
+2. **Movements & Alerts:** Since the success scenario is not tested, Steps 9.1 (Movement), 9.2 (Status change), 9.3 (Alert), and 9.4 (Email Notification) are not verified.
+3. **Message & Redirect:** Step 10 specifies a success message and a redirect to the Panel. This is not tested.
+
+## Recommended Changes
+- Implement the success scenario, where the ADMIN confirms the homologation in the modal.
+- Verify the status of the involved subprocesses changes to "Mapa homologado".
+- Check for the creation of internal alerts and email notifications for the target units.
+- Verify the success message and redirect to the Panel.

--- a/cdu-27-alignment.md
+++ b/cdu-27-alignment.md
@@ -1,0 +1,15 @@
+# CDU-27 - Alterar data limite de subprocesso - Alignment
+
+## Current Status
+- The test prepares a process and navigates to the subprocess details.
+- It verifies the modal, the required fields, and the successful update of the deadline date.
+
+## Gaps & Missing Coverage
+1. **Notification Verification:** Step 7 states a notification by email should be sent to the unit. The test does not verify this dispatch.
+2. **Alert Verification:** Step 8 dictates an alert should be created for the destination unit. The test does not check the unit's panel for this alert.
+3. **Modal Current Date:** Step 4 states the modal should be pre-filled with the current deadline. The test only fills the field with a new date but doesn't verify its initial pre-filled value.
+
+## Recommended Changes
+- Add a check to confirm the input field initially contains the correct current deadline before modifying it.
+- Verify the internal alert generated for the destination unit.
+- Verify the email notification dispatch content.

--- a/cdu-28-alignment.md
+++ b/cdu-28-alignment.md
@@ -1,0 +1,16 @@
+# CDU-28 - Manter atribuição temporária - Alignment
+
+## Current Status
+- The test covers navigation, access to the target unit (`SECRETARIA_2`), and the opening of the assignment creation modal.
+- It tests validation logic (missing or invalid dates).
+- It verifies the successful creation of a temporary assignment.
+
+## Gaps & Missing Coverage
+1. **Notification:** Step 9 requires an email notification to be sent to the user receiving the temporary assignment. The test does not verify this dispatch.
+2. **Alert:** Step 10 mandates an internal alert for the assigned user. The test does not check the new CHEFE's panel for this alert.
+3. **Effect Verification:** Step 11 states the assigned user gains CHEFE rights. The test does not actually log in as the assigned server to verify their new permissions (e.g., accessing the unit, seeing buttons only CHEFEs see).
+
+## Recommended Changes
+- Implement a scenario where the assigned server logs in and successfully performs an action requiring CHEFE permissions to prove the assignment worked.
+- Verify the internal alert is present in the server's panel.
+- Verify the email notification dispatch content.

--- a/cdu-29-alignment.md
+++ b/cdu-29-alignment.md
@@ -1,0 +1,13 @@
+# CDU-29 - Consultar histórico de processos - Alignment
+
+## Current Status
+- The test checks navigation to the history page for ADMIN, GESTOR, and CHEFE.
+- It verifies the presence of specific columns: `Processo`, `Tipo`, `Finalizado em`, `Unidades participantes`.
+
+## Gaps & Missing Coverage
+1. **Data Content:** Step 2 specifies the table presents all processes with the 'Finalizado' status. The test does not verify that only finalized processes are shown, or that the process units are correctly grouped as on the Panel.
+2. **Process Details Uneditable:** Step 4 states "O sistema apresenta a página Detalhes do processo, sem permitir mudanças ou mostrar botões de ação." The test does not click a finalized process, access the details, or verify the absence of action buttons.
+
+## Recommended Changes
+- Add a setup scenario to create, initiate, and finalize a process. Then verify that it appears in the history table.
+- Implement a scenario to open the details of a finalized process and assert the absence of any action buttons (e.g., 'Finalizar', 'Alterar data', 'Reabrir', etc.).

--- a/cdu-30-alignment.md
+++ b/cdu-30-alignment.md
@@ -1,0 +1,15 @@
+# CDU-30 - Manter Administradores - Alignment
+
+## Current Status
+- The test only covers the initial visualization of the administrators list.
+- It checks for the table and the "Adicionar" button.
+
+## Gaps & Missing Coverage
+1. **Add Flow completely missing:** Steps 4-8 describe the full flow of adding a new administrator via a modal by their voter title (`título eleitoral`), including validation for existing users or already-admins. The test does not execute or verify any of this.
+2. **Remove Flow completely missing:** Steps 9-15 describe the removal flow, including validations (cannot remove oneself, cannot remove the last admin). The test does not cover this at all.
+3. **Table Data Match:** Step 2 specifies the list should show name, voter title, registration (matrícula), and unit. The test does not verify these columns exist.
+
+## Recommended Changes
+- Implement a scenario to test adding a new administrator, including success and validation error states.
+- Implement a scenario to test removing an administrator, specifically testing the safeguard against removing oneself or the final administrator.
+- Add assertions to ensure the correct columns are displayed in the list.

--- a/cdu-31-alignment.md
+++ b/cdu-31-alignment.md
@@ -1,0 +1,14 @@
+# CDU-31 - Configurar sistema - Alignment
+
+## Current Status
+- The test verifies navigation to the parameters page, visibility of form inputs, and the saving of a configuration.
+
+## Gaps & Missing Coverage
+1. **Specific Fields:** The requirement outlines two specific settings: `Dias para inativação de processos` and `Dias para indicação de alerta como novo`. The test indiscriminately picks the first `input[type="number"]` without verifying its label or specific purpose.
+2. **Validation:** The requirement states the value must be an integer, 1 or more. The test does not verify this validation rule (e.g., trying to input 0, negative numbers, or non-integers).
+3. **Immediate Effect:** The requirement explicitly states "O efeito das configurações deve ser imediato". The test does not verify if the changed parameter actually takes effect immediately in the system behavior.
+
+## Recommended Changes
+- Explicitly target and verify the two settings fields by their labels or test IDs.
+- Add negative testing to ensure values less than 1 or invalid formats are rejected.
+- Ideally, add a scenario to verify the "immediate effect" (e.g., by changing the "new alert days" and checking an existing alert's status).

--- a/cdu-32-alignment.md
+++ b/cdu-32-alignment.md
@@ -1,0 +1,14 @@
+# CDU-32 - Reabrir cadastro - Alignment
+
+## Current Status
+- The test prepares a process, makes a unit finalize its mapping registration, and has managers/admins homologate it.
+- The test verifies the "Reabrir cadastro" modal, the disabled state without justification, and the final state change ("Em andamento") after confirmation.
+
+## Gaps & Missing Coverage
+1. **Notification Discrepancy:** The requirement (Step 8) mandates sending emails to the requesting unit and superior units. The test does not verify email dispatches.
+2. **Alerts Verification:** Step 9 mandates alerts for both the target unit and superior units. The test verifies the internal history ("Reabertura de cadastro" on `tbl-movimentacoes`), but doesn't check the specific alerts on the units' panels.
+3. **Target Situation Accuracy:** The test checks `Em andamento`. The requirement (Step 6) explicitly states `MAPEAMENTO_CADASTRO_EM_ANDAMENTO`. The frontend text might be "Em andamento", which is acceptable, but the internal state could be verified more strictly.
+
+## Recommended Changes
+- Add tests to ensure that the correct alerts are present in the target unit's panel *and* the superior unit's panel.
+- Implement tests to verify email notification dispatch content and recipients.

--- a/cdu-33-alignment.md
+++ b/cdu-33-alignment.md
@@ -1,0 +1,14 @@
+# CDU-33 - Reabrir revisão de cadastro - Alignment
+
+## Current Status
+- The test extensively sets up a mapping process, creates a map, and then initiates a revision process up to the 'Revisão do cadastro homologada' state.
+- It verifies the presence of the 'Reabrir revisão' button, fills out a justification, confirms, and checks the resulting status and history.
+
+## Gaps & Missing Coverage
+1. **Notification to Superior Units:** Step 8 of the requirement states that email notifications should be sent to both the requesting unit and superior units. The test does not verify the dispatch of these emails.
+2. **Alert to Superior Units:** Step 9.2 states an alert should be created for superior units. The test verifies the alert for the requesting unit (partially, just the general history) but does not verify the specific alerts generated for superior units.
+3. **Target State:** The test asserts the situation goes to "Revisão em andamento", matching step 6 ("REVISAO_CADASTRO_EM_ANDAMENTO"). However, it could be more thorough by verifying the explicit history observation ("Revisão de cadastro reaberta", step 7).
+
+## Recommended Changes
+- Add assertions to verify that internal alerts are explicitly created for *both* the target unit and its superior units.
+- Implement a check for the email notifications sent to both the target and superior units.

--- a/cdu-34-alignment.md
+++ b/cdu-34-alignment.md
@@ -1,0 +1,16 @@
+# CDU-34 - Enviar lembrete de prazo - Alignment
+
+## Current Status
+- The test creates a process, initiates it, and navigates to the subprocess.
+- It verifies the manual sending of a reminder by the ADMIN and checks if the history/alert is recorded.
+- It verifies the reception of the alert on the destination unit's panel.
+
+## Gaps & Missing Coverage
+1. **Indicator UI:** Step 2 of the requirement says "O sistema exibe os processos e subprocessos, indicando com cores ou ícones aqueles que estão próximos do prazo ou atrasados." The test does not verify these visual indicators (colors/icons).
+2. **Mass Selection:** Step 3 says "O usuário seleciona uma ou mais unidades/subprocessos que possuem pendências." The test currently opens a specific subprocess and clicks "Enviar lembrete" inside it, rather than selecting multiple from the tracking screen.
+3. **Email Notification Check:** The test does not verify the actual dispatch/payload of the email sent to the unit's responsibles, only the internal history and alert.
+
+## Recommended Changes
+- Add a setup scenario where a process is genuinely close to its deadline or delayed, and assert the presence of the correct color/icon indicators in the UI.
+- Verify the bulk selection mechanism from the tracking view, rather than only testing the individual reminder inside a subprocess.
+- Add coverage/verification for the email dispatch mechanism.

--- a/cdu-35-alignment.md
+++ b/cdu-35-alignment.md
@@ -1,0 +1,17 @@
+# CDU-35 - Gerar relatório de andamento - Alignment
+
+## Current Status
+- The test verifies navigation to reports and the presence of the "Andamento Geral" modal.
+- It checks for filters: "Tipo", "Data Início", and "Data Fim", and a generic "Exportar CSV" button.
+
+## Gaps & Missing Coverage
+1. **Filter Discrepancy:** The requirement specifies selecting a "Processo" (e.g., "Mapeamento 2027"), but the test checks for "Tipo", "Data Início", and "Data Fim".
+2. **Table Columns:** The requirement lists specific columns to be displayed: Sigla da unidade, Nome da unidade, Situação atual, Data da última movimentação, Responsável, Titular. The test only verifies that a `table` exists, without verifying its structure or columns.
+3. **Export Format Mismatch:** The requirement mentions clicking a `PDF` button to export, but the test checks for an `Exportar CSV` button.
+4. **Data Population:** The test does not verify if the report populates with data when a process is selected.
+
+## Recommended Changes
+- Modify the test to check for the correct filter ("Processo") instead of generic date/type filters.
+- Add assertions to verify the presence of the specific columns detailed in the requirement.
+- Fix the export format mismatch by checking for a PDF export action.
+- Add a test scenario that actually selects a process and verifies the data loaded in the table.

--- a/cdu-36-alignment.md
+++ b/cdu-36-alignment.md
@@ -1,0 +1,16 @@
+# CDU-36 - Gerar relatório de mapas - Alignment
+
+## Current Status
+- The test verifies basic navigation and visibility of the "Mapas Vigentes" modal.
+- The test checks for an "Exportar CSV" button instead of the "PDF" mentioned in the requirements.
+
+## Gaps & Missing Coverage
+1. **Filters:** The test does not verify the definition of filters (Processo - mandatory, Unidade - optional) as specified in the requirement.
+2. **Action Verification:** The test does not interact with the filters or trigger the "Gerar" / "Exportar" action.
+3. **Format Mismatch:** The requirement specifies a "PDF" file generation, whereas the test expects a button for "CSV". This is a significant discrepancy.
+4. **Data Coverage:** The requirement dictates specific data within the PDF (Unidade, Competências, Atividades, Conhecimentos). There is no check to ensure the generated file matches this or if the API request correctly requests these fields.
+
+## Recommended Changes
+- Update the test to verify the presence and functionality of the "Processo" and "Unidade" filters.
+- Correct the expected export format from CSV to PDF (or adjust the requirement if CSV is the actual intended format).
+- Simulate/mock or actually perform the "Gerar" action and verify that the file download is triggered with the correct parameters.

--- a/frontend/src/views/__tests__/UnidadesView.spec.ts
+++ b/frontend/src/views/__tests__/UnidadesView.spec.ts
@@ -83,19 +83,17 @@ describe("Unidades.vue", () => {
         expect(store.clearError).toHaveBeenCalled();
     });
 
-    it("deve exibir TreeTable quando houver unidades", () => {
+    it("deve exibir ArvoreUnidades quando houver unidades", () => {
         const wrapper = createWrapper({unidades: mockUnidades});
-        const arvore = wrapper.find("[data-testid='tree-table']");
+        const arvore = wrapper.findComponent({name: 'ArvoreUnidades'});
         expect(arvore.exists()).toBe(true);
-
-        const arvoreComponent = wrapper.findComponent({name: "TreeTable"});
-        expect(arvoreComponent.props("data")).toBeDefined();
+        expect(arvore.props("unidades")).toBeDefined();
     });
 
     it("deve exibir mensagem quando não houver unidades", () => {
         const wrapper = createWrapper({unidades: []});
         expect(wrapper.text()).toContain("Nenhuma unidade encontrada.");
-        expect(wrapper.find("[data-testid='tree-table']").exists()).toBe(false);
+        expect(wrapper.findComponent({name: 'ArvoreUnidades'}).exists()).toBe(false);
     });
 
 });


### PR DESCRIPTION
Generated alignment reports comparing E2E tests against their respective Use Case requirements.

These reports highlight gaps in test coverage such as missing verifications for email notifications, internal system alerts, edge-case UI validations (tooltips, warning icons), and complex data validations during bulk actions.

A minor drive-by fix was included for a failing frontend test (`UnidadesView.spec.ts`) discovered while running quality checks prior to submission.

---
*PR created automatically by Jules for task [5615520109274952676](https://jules.google.com/task/5615520109274952676) started by @lgalvao*