### PR TITLE
refactor: remove unnecessary and conversational comments

### DIFF
--- a/backend/src/main/java/sgc/e2e/E2eController.java
+++ b/backend/src/main/java/sgc/e2e/E2eController.java
@@ -175,7 +175,6 @@ public class E2eController {
                         + SQL_SUBPROCESSO_POR_PROCESSO,
                 codigo);
 
-
         if (!mapaIds.isEmpty()) {
             Map<String, Object> params = Map.of("ids", mapaIds);
 

--- a/backend/src/main/java/sgc/organizacao/UsuarioFacade.java
+++ b/backend/src/main/java/sgc/organizacao/UsuarioFacade.java
@@ -95,7 +95,6 @@ public class UsuarioFacade {
                 .collect(toMap(Usuario::getTituloEleitoral, u -> u, (u1, u2) -> u1));
     }
 
-
     private PerfilDto toPerfilDto(UsuarioPerfil atribuicao) {
         return PerfilDto.builder()
                 .usuarioTitulo(atribuicao.getUsuario().getTituloEleitoral())

--- a/backend/src/main/java/sgc/organizacao/service/ResponsavelUnidadeService.java
+++ b/backend/src/main/java/sgc/organizacao/service/ResponsavelUnidadeService.java
@@ -181,7 +181,6 @@ public class ResponsavelUnidadeService {
                 .build();
     }
 
-
     /**
      * Busca os códigos das unidades onde o usuário é o responsável atual.
      */

--- a/backend/src/main/java/sgc/processo/dto/ProcessoDetalheDto.java
+++ b/backend/src/main/java/sgc/processo/dto/ProcessoDetalheDto.java
@@ -34,7 +34,6 @@ public class ProcessoDetalheDto {
     private boolean podeAceitarCadastroBloco;
     private boolean podeDisponibilizarMapaBloco;
 
-
     @Getter
     @Setter
     @Builder
@@ -52,7 +51,6 @@ public class ProcessoDetalheDto {
         private LocalDateTime dataLimite;
         private Long mapaCodigo;
         private Long codSubprocesso;
-
 
         public static UnidadeParticipanteDto fromUnidade(Unidade unidade) {
             return UnidadeParticipanteDto.builder()

--- a/backend/src/main/java/sgc/processo/model/UnidadeProcesso.java
+++ b/backend/src/main/java/sgc/processo/model/UnidadeProcesso.java
@@ -9,7 +9,6 @@ import sgc.organizacao.model.*;
 import java.io.*;
 import java.time.*;
 
-
 /**
  * Entidade que representa a associação entre um Processo e uma Unidade participante,
  * armazenando um snapshot dos dados da unidade no momento em que o processo foi iniciado.

--- a/backend/src/main/java/sgc/processo/painel/PainelController.java
+++ b/backend/src/main/java/sgc/processo/painel/PainelController.java
@@ -1,6 +1,5 @@
 package sgc.processo.painel;
 
-
 import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.tags.*;
 import lombok.*;

--- a/backend/src/main/java/sgc/subprocesso/dto/CompetenciaAjusteDto.java
+++ b/backend/src/main/java/sgc/subprocesso/dto/CompetenciaAjusteDto.java
@@ -18,7 +18,6 @@ public class CompetenciaAjusteDto {
     private final Long codCompetencia;
     private final String nome;
 
-
     @Builder.Default
     private final List<AtividadeAjusteDto> atividades = List.of();
 }

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoService.java
@@ -221,7 +221,6 @@ public class SubprocessoService {
         return (destino != null) ? destino : sp.getUnidade();
     }
 
-
     @Transactional
     public void atualizarParaEmAndamento(Long mapaCodigo) {
         var subprocesso = subprocessoRepo.findByMapa_Codigo(mapaCodigo).orElseThrow();
@@ -436,7 +435,6 @@ public class SubprocessoService {
                 SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO);
         return sp;
     }
-
 
     @Transactional
     public void salvarAjustesMapa(Long codSubprocesso, List<CompetenciaAjusteDto> competencias) {
@@ -763,7 +761,6 @@ public class SubprocessoService {
                 .toList();
     }
 
-
     @Transactional(readOnly = true)
     public List<AnaliseHistoricoDto> listarHistoricoCadastro(Long codSubprocesso) {
         return listarAnalisesPorSubprocesso(codSubprocesso).stream()
@@ -794,6 +791,5 @@ public class SubprocessoService {
                 .tipo(analise.getTipo())
                 .build();
     }
-
 
 }

--- a/backend/src/test/java/sgc/alerta/AlertaFacadeCoverageTest.java
+++ b/backend/src/test/java/sgc/alerta/AlertaFacadeCoverageTest.java
@@ -36,9 +36,7 @@ class AlertaFacadeCoverageTest {
 
         when(alertaService.salvar(any(Alerta.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-
         alertaFacade.criarAlertaCadastroDisponibilizado(processo, unidadeOrigem, unidadeDestino);
-
 
         ArgumentCaptor<Alerta> captor = ArgumentCaptor.forClass(Alerta.class);
         verify(alertaService).salvar(captor.capture());

--- a/backend/src/test/java/sgc/alerta/AlertaFacadeTest.java
+++ b/backend/src/test/java/sgc/alerta/AlertaFacadeTest.java
@@ -61,9 +61,7 @@ class AlertaFacadeTest {
             alertaSalvo.setCodigo(100L);
             when(alertaService.salvar(any())).thenReturn(alertaSalvo);
 
-
             Alerta resultado = service.criarAlertaAdmin(p, u, "desc");
-
 
             assertThat(resultado).isNotNull();
             verify(alertaService).salvar(any());
@@ -86,9 +84,7 @@ class AlertaFacadeTest {
 
             when(alertaService.salvar(any())).thenAnswer(i -> i.getArgument(0));
 
-
             service.criarAlertasProcessoIniciado(p, List.of(u));
-
 
             verify(alertaService).salvar(argThat(a -> "Início do processo".equals(a.getDescricao())));
         }
@@ -104,9 +100,7 @@ class AlertaFacadeTest {
 
             when(alertaService.salvar(any())).thenAnswer(i -> i.getArgument(0));
 
-
             List<Alerta> resultado = service.criarAlertasProcessoIniciado(p, List.of(u));
-
 
             assertThat(resultado).hasSize(2);
             verify(alertaService, times(2)).salvar(any());
@@ -128,9 +122,7 @@ class AlertaFacadeTest {
 
             when(alertaService.salvar(any())).thenAnswer(i -> i.getArgument(0));
 
-
             service.criarAlertaCadastroDisponibilizado(p, uOrigem, uDestino);
-
 
             verify(alertaService).salvar(any());
         }
@@ -146,9 +138,7 @@ class AlertaFacadeTest {
 
             when(alertaService.salvar(any())).thenAnswer(i -> i.getArgument(0));
 
-
             service.criarAlertaCadastroDevolvido(p, uDestino, "motivo");
-
 
             verify(alertaService).salvar(any());
         }
@@ -223,9 +213,7 @@ class AlertaFacadeTest {
             when(alertaService.porUnidadeDestino(codUnidade)).thenReturn(List.of(alerta));
             when(alertaService.alertasUsuarios(eq(usuarioTitulo), anyList())).thenReturn(List.of());
 
-
             List<Alerta> resultado = service.alertasPorUsuario(usuarioTitulo);
-
 
             assertThat(resultado).hasSize(1);
             assertThat(resultado.getFirst().getCodigo()).isEqualTo(100L);
@@ -259,9 +247,7 @@ class AlertaFacadeTest {
             when(alertaService.porUnidadeDestino(codUnidade)).thenReturn(List.of(alerta));
             when(alertaService.alertasUsuarios(eq(usuarioTitulo), anyList())).thenReturn(List.of(alertaUsuarioExistente));
 
-
             List<Alerta> resultado = service.alertasPorUsuario(usuarioTitulo);
-
 
             assertThat(resultado).hasSize(1);
             assertThat(resultado.getFirst().getDataHoraLeitura()).isNotNull();

--- a/backend/src/test/java/sgc/alerta/notificacao/EmailModelosServiceTest.java
+++ b/backend/src/test/java/sgc/alerta/notificacao/EmailModelosServiceTest.java
@@ -45,10 +45,8 @@ class EmailModelosServiceTest {
             String siglaUnidade = "UT";
             String nomeProcesso = "Processo Teste";
 
-
             emailModelosService.criarEmailProcessoFinalizadoPorUnidade(
                     siglaUnidade, nomeProcesso);
-
 
             assertEquals("processo-finalizado-por-unidade", templateNameCaptor.getValue());
             Context context = contextCaptor.getValue();
@@ -65,10 +63,8 @@ class EmailModelosServiceTest {
             String nomeProcesso = "Processo Teste";
             List<String> siglas = List.of("SUB1", "SUB2");
 
-
             emailModelosService.criarEmailProcessoFinalizadoUnidadesSubordinadas(
                     siglaUnidade, nomeProcesso, siglas);
-
 
             assertEquals("processo-finalizado-unidades-subordinadas", templateNameCaptor.getValue());
             Context context = contextCaptor.getValue();

--- a/backend/src/test/java/sgc/arquitetura/ArchConsistencyTest.java
+++ b/backend/src/test/java/sgc/arquitetura/ArchConsistencyTest.java
@@ -98,7 +98,6 @@ public class ArchConsistencyTest {
             })
             .because("Controllers e Services devem estar em pacotes @NullMarked para garantir null-safety");
 
-
     @ArchTest
     static final ArchRule facades_should_have_facade_suffix = classes()
             .that()
@@ -168,7 +167,6 @@ public class ArchConsistencyTest {
             .should()
             .haveSimpleNameEndingWith("Repo")
             .because("Repositories should have 'Repo' suffix for consistency");
-
 
     /**
      * Verifica ausência de ciclos internos nos pacotes workflow de cada módulo.

--- a/backend/src/test/java/sgc/comum/config/ConfigOpenApiCoverageTest.java
+++ b/backend/src/test/java/sgc/comum/config/ConfigOpenApiCoverageTest.java
@@ -20,9 +20,7 @@ class ConfigOpenApiCoverageTest {
 
         ConfigOpenApi configOpenApi = new ConfigOpenApi(config);
 
-
         OpenAPI result = configOpenApi.customOpenAPI();
-
 
         assertThat(result.getInfo().getTitle()).isEqualTo("SGC API");
         assertThat(result.getInfo().getDescription()).isEqualTo("Sistema de Gestão de Competências");
@@ -43,9 +41,7 @@ class ConfigOpenApiCoverageTest {
 
         ConfigOpenApi configOpenApi = new ConfigOpenApi(config);
 
-
         OpenAPI result = configOpenApi.customOpenAPI();
-
 
         assertThat(result.getInfo().getTitle()).isEqualTo("Meu Titulo");
         assertThat(result.getInfo().getDescription()).isEqualTo("Minha Descricao");

--- a/backend/src/test/java/sgc/comum/erros/RestExceptionHandlerCoverageTest.java
+++ b/backend/src/test/java/sgc/comum/erros/RestExceptionHandlerCoverageTest.java
@@ -17,9 +17,7 @@ class RestExceptionHandlerCoverageTest {
         ErroInterno ex = new ErroInterno("Messagem interna de teste") {
         };
 
-
         ResponseEntity<?> response = handler.handleErroInterno(ex);
-
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -41,9 +39,7 @@ class RestExceptionHandlerCoverageTest {
         }
         ErroTeste ex = new ErroTeste();
 
-
         ResponseEntity<?> response = handler.handleErroNegocio(ex);
-
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/backend/src/test/java/sgc/comum/json/DeserializadorHtmlSanitizadoTest.java
+++ b/backend/src/test/java/sgc/comum/json/DeserializadorHtmlSanitizadoTest.java
@@ -31,9 +31,7 @@ class DeserializadorHtmlSanitizadoTest {
         String inputMalicioso = "<script>alert('XSS')</script>Texto limpo";
         when(parser.getValueAsString()).thenReturn(inputMalicioso);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         assertThat(resultado).doesNotContain("<script>", "alert")
                 .contains("Texto limpo");
@@ -46,9 +44,7 @@ class DeserializadorHtmlSanitizadoTest {
         String inputMalicioso = "<img src='x' onerror='alert(1)'>";
         when(parser.getValueAsString()).thenReturn(inputMalicioso);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         assertThat(resultado).doesNotContain("onerror", "alert");
     }
@@ -60,9 +56,7 @@ class DeserializadorHtmlSanitizadoTest {
         String textoSimples = "Este é um texto simples sem tags HTML";
         when(parser.getValueAsString()).thenReturn(textoSimples);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         assertThat(resultado).isEqualTo(textoSimples);
     }
@@ -75,9 +69,7 @@ class DeserializadorHtmlSanitizadoTest {
 
         when(parser.getValueAsString()).thenReturn(input);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         assertThat(resultado).isEqualTo(input);
     }
@@ -89,9 +81,7 @@ class DeserializadorHtmlSanitizadoTest {
         String inputMalicioso = "'; DROP TABLE users; --";
         when(parser.getValueAsString()).thenReturn(inputMalicioso);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         // O sanitizador HTML remove tags, mas texto plano permanece
         assertThat(resultado).isNotNull();
@@ -104,9 +94,7 @@ class DeserializadorHtmlSanitizadoTest {
         String inputMalicioso = "<a href='javascript:alert(1)'>Click me</a>";
         when(parser.getValueAsString()).thenReturn(inputMalicioso);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         assertThat(resultado).doesNotContain("javascript:", "alert");
     }
@@ -119,9 +107,7 @@ class DeserializadorHtmlSanitizadoTest {
         String inputMalicioso = "<iframe src='http://malicious.com'></iframe>Texto";
         when(parser.getValueAsString()).thenReturn(inputMalicioso);
 
-
         String resultado = deserializador.deserialize(parser, context);
-
 
         assertThat(resultado)
                 .doesNotContain("<iframe", "malicious.com")

--- a/backend/src/test/java/sgc/e2e/E2eControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/e2e/E2eControllerCoverageTest.java
@@ -25,7 +25,6 @@ class E2eControllerCoverageTest {
 
         when(jdbcTemplate.getDataSource()).thenReturn(null);
 
-
         controller.resetDatabase();
 
         // Assert - Não deve lançar exceção nem fazer nada (cobertura da linha 62)

--- a/backend/src/test/java/sgc/e2e/E2eControllerTest.java
+++ b/backend/src/test/java/sgc/e2e/E2eControllerTest.java
@@ -137,9 +137,7 @@ class E2eControllerTest {
         assertCount("sgc.vw_unidade", 1);
         assertCount("sgc.vw_usuario", 1);
 
-
         controller.limparProcessoComDependentes(100L);
-
 
         assertCount("sgc.processo", 0);
         assertCount("sgc.subprocesso", 0);
@@ -171,13 +169,11 @@ class E2eControllerTest {
         assertCount("sgc.vw_unidade WHERE codigo=888", 1);
         assertCount("sgc.processo WHERE codigo=888", 1);
 
-
         try {
             controller.resetDatabase();
         } catch (RuntimeException e) {
             // Na implementação real do resetDatabase, ele desativa constraints.
         }
-
 
         assertCount("sgc.vw_unidade WHERE codigo=888", 0);
         assertCount("sgc.processo WHERE codigo=888", 0);
@@ -238,9 +234,7 @@ class E2eControllerTest {
         proc.setCodigo(100L);
         when(processoFacade.criar(any(CriarProcessoRequest.class))).thenReturn(proc);
 
-
         Processo result = controller.criarProcessoMapeamento(req);
-
 
         assertEquals(100L, result.getCodigo());
         verify(processoFacade).criar(any(CriarProcessoRequest.class));
@@ -262,9 +256,7 @@ class E2eControllerTest {
         when(processoFacade.criar(any(CriarProcessoRequest.class))).thenReturn(proc);
         when(processoFacade.obterEntidadePorId(100L)).thenReturn(proc);
 
-
         Processo result = controller.criarProcessoRevisao(req);
-
 
         assertEquals(100L, result.getCodigo());
         verify(processoFacade).iniciarProcesso(100L, List.of(1L));
@@ -286,9 +278,7 @@ class E2eControllerTest {
         when(processoFacade.criar(any(CriarProcessoRequest.class))).thenReturn(proc);
         when(processoFacade.obterEntidadePorId(100L)).thenReturn(proc);
 
-
         Processo result = controller.criarProcessoMapeamento(req);
-
 
         assertEquals(100L, result.getCodigo());
         verify(processoFacade).iniciarProcesso(100L, List.of(1L));
@@ -373,9 +363,7 @@ class E2eControllerTest {
                 E2eController.ProcessoFixtureRequest.class, TipoProcesso.class);
         method.setAccessible(true);
 
-
         method.invoke(controller, req, TipoProcesso.DIAGNOSTICO);
-
 
         verify(processoFacade).iniciarProcesso(100L, List.of(1L));
     }
@@ -403,9 +391,7 @@ class E2eControllerTest {
                 E2eController.ProcessoFixtureRequest.class, TipoProcesso.class);
         method.setAccessible(true);
 
-
         method.invoke(controller, req, TipoProcesso.MAPEAMENTO);
-
 
         verify(processoFacade).iniciarProcesso(eq(100L), anyList());
     }

--- a/backend/src/test/java/sgc/integracao/CDU01IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU01IntegrationTest.java
@@ -85,7 +85,6 @@ class CDU01IntegrationTest extends BaseIntegrationTest {
 
         entityManager.clear(); // Clear cache to ensure subsequent reads fetch fresh data including profiles
 
-        // Reload entities to ensure they are managed and up-to-date
         unidadeAdmin = unidadeRepo.findById(unidadeAdmin.getCodigo()).orElseThrow();
         unidadeGestor = unidadeRepo.findById(unidadeGestor.getCodigo()).orElseThrow();
         usuarioAdmin = usuarioRepo.findById(usuarioAdmin.getTituloEleitoral()).orElseThrow();

--- a/backend/src/test/java/sgc/integracao/CDU02IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU02IntegrationTest.java
@@ -52,7 +52,6 @@ class CDU02IntegrationTest extends BaseIntegrationTest {
     void setup() {
         // Setup Programático - Não depende do data.sql
 
-
         // Raiz
         unidadeRaiz = UnidadeFixture.unidadePadrao();
         unidadeRaiz.setCodigo(null); // Auto-increment
@@ -72,7 +71,6 @@ class CDU02IntegrationTest extends BaseIntegrationTest {
         unidadeFilha2.setNome("Unidade Filha 2 Teste");
         unidadeFilha2.setUnidadeSuperior(unidadeRaiz);
         unidadeFilha2 = unidadeRepo.save(unidadeFilha2);
-
 
         processoRaiz = ProcessoFixture.processoEmAndamento();
         processoRaiz.setCodigo(null);

--- a/backend/src/test/java/sgc/integracao/CDU03IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU03IntegrationTest.java
@@ -34,7 +34,6 @@ class CDU03IntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void setup() {
 
-        // Create fixtures using saveAndFlush to ensure visibility
         unidade1 = UnidadeFixture.unidadePadrao();
         unidade1.setCodigo(null);
         unidade1.setNome("Unidade 1");
@@ -124,7 +123,6 @@ class CDU03IntegrationTest extends BaseIntegrationTest {
             // Ignore for test purposes
         }
 
-        // Re-add the assertion to keep the test failing, but now we get the output
         mockMvc.perform(
                         post(API_PROCESSOS)
                                 .with(csrf())
@@ -223,7 +221,6 @@ class CDU03IntegrationTest extends BaseIntegrationTest {
         // 2. Remover o processo
         mockMvc.perform(post(API_PROCESSOS + "/{codProcesso}/excluir", processoId).with(csrf()))
                 .andExpect(status().isNoContent()); // 204 No Content para remoção bem-sucedida
-
 
         mockMvc.perform(get(API_PROCESSOS_ID, processoId)).andExpect(status().isNotFound());
     }

--- a/backend/src/test/java/sgc/integracao/CDU04IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU04IntegrationTest.java
@@ -92,7 +92,6 @@ class CDU04IntegrationTest extends BaseIntegrationTest {
 
         Long processoId = objectMapper.readTree(result.getResponse().getContentAsString()).get("codigo").asLong();
 
-
         IniciarProcessoRequest iniciarReq = new IniciarProcessoRequest(TipoProcesso.MAPEAMENTO,
                 List.of(unidadeLivre.getCodigo()));
 
@@ -102,10 +101,8 @@ class CDU04IntegrationTest extends BaseIntegrationTest {
                         .content(objectMapper.writeValueAsString(iniciarReq)))
                 .andExpect(status().isOk());
 
-
         Processo processo = processoRepo.findById(processoId).orElseThrow();
         assertThat(processo.getSituacao()).isEqualTo(SituacaoProcesso.EM_ANDAMENTO);
-
 
         List<Subprocesso> subprocessos = subprocessoRepo.findByProcessoCodigo(processoId);
         assertThat(subprocessos).hasSize(1);
@@ -121,10 +118,8 @@ class CDU04IntegrationTest extends BaseIntegrationTest {
         List<Competencia> competencias = competenciaRepo.findByMapa_Codigo(sub.getMapa().getCodigo());
         assertThat(competencias).isEmpty();
 
-
         long alertasCount = alertaRepo.count();
         assertThat(alertasCount).isGreaterThan(0);
-
 
         // e não podem ser verificadas diretamente via Mockito
         // O teste de envio de emails está em NotificacaoEmailServiceTest

--- a/backend/src/test/java/sgc/integracao/CDU05IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU05IntegrationTest.java
@@ -47,7 +47,6 @@ class CDU05IntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void setUp() {
 
-
         unidade = UnidadeFixture.unidadePadrao();
         unidade.setCodigo(null);
         unidade.setSigla("U_REV");
@@ -104,7 +103,6 @@ class CDU05IntegrationTest extends BaseIntegrationTest {
         mapaOriginal.setObservacoesDisponibilizacao("Observações Legadas");
         mapaRepo.save(mapaOriginal);
 
-
         List<Long> unidades = new ArrayList<>();
         unidades.add(unidade.getCodigo());
         CriarProcessoRequest criarRequestDTO = criarCriarProcessoReq("Processo de Revisão para Iniciar",
@@ -129,12 +127,10 @@ class CDU05IntegrationTest extends BaseIntegrationTest {
                         .content(objectMapper.writeValueAsString(iniciarReq)))
                 .andExpect(status().isOk());
 
-
         Processo processo = processoRepo.findByIdComParticipantes(processoId).orElseThrow();
         assertThat(processo.getParticipantes()).hasSize(2); // Unidade alvo + Unidade Superior
         assertThat(processo.getParticipantes().stream().map(UnidadeProcesso::getSigla).toList())
                 .containsExactlyInAnyOrder("U_REV", "U_SUP");
-
 
         List<Subprocesso> subprocessos = subprocessoRepo.findByProcessoCodigo(processoId);
         assertThat(subprocessos).hasSize(1);
@@ -153,7 +149,6 @@ class CDU05IntegrationTest extends BaseIntegrationTest {
         assertThat(competenciasCopiadas).hasSize(1);
         assertThat(competenciasCopiadas.getFirst().getDescricao())
                 .isEqualTo(competenciaOriginal.getDescricao());
-
 
         List<Movimentacao> movs = movimentacaoRepo.findBySubprocessoCodigo(subprocessoCriado.getCodigo());
         assertThat(movs).hasSize(1);
@@ -218,7 +213,6 @@ class CDU05IntegrationTest extends BaseIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(iniciarReq)))
                 .andExpect(status().isOk());
-
 
         mockMvc.perform(post(API_PROCESSOS_ID_INICIAR, processoId)
                         .with(csrf())

--- a/backend/src/test/java/sgc/integracao/CDU08IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU08IntegrationTest.java
@@ -51,7 +51,6 @@ class CDU08IntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void setUp() {
 
-
         Unidade raiz = unidadeRepo.findById(1L).orElseThrow();
         Unidade unidadeOrigem = UnidadeFixture.unidadePadrao();
         unidadeOrigem.setCodigo(null);
@@ -66,7 +65,6 @@ class CDU08IntegrationTest extends BaseIntegrationTest {
         unidadeDestino.setNome("Unidade Destino");
         unidadeDestino.setUnidadeSuperior(raiz);
         unidadeDestino = unidadeRepo.save(unidadeDestino);
-
 
         chefe = UsuarioFixture.usuarioPadrao();
         chefe.setTituloEleitoral("888888888888");

--- a/backend/src/test/java/sgc/integracao/CDU09IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU09IntegrationTest.java
@@ -45,7 +45,6 @@ class CDU09IntegrationTest extends BaseIntegrationTest {
         Long SP_CODIGO = 60000L;
         Subprocesso sp = subprocessoRepo.findById(SP_CODIGO).orElseThrow();
 
-
         // Simula uma análise anterior (que deve ser exibida no histórico)
         analiseRepo.saveAndFlush(Analise.builder()
                 .subprocesso(sp)
@@ -67,7 +66,6 @@ class CDU09IntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].observacoes", is("Favor ajustar atividades")));
 
-
         // Limpa mapa para garantir que falhe por falta de atividades
         competenciaRepo.deleteByMapa_Codigo(sp.getMapa().getCodigo());
         entityManager.flush();
@@ -76,7 +74,6 @@ class CDU09IntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(post("/api/subprocessos/{id}/cadastro/disponibilizar", SP_CODIGO).with(csrf()))
                 .andExpect(status().isUnprocessableContent())
                 .andExpect(jsonPath("$.message").value("O mapa de competências deve ter ao menos uma atividade cadastrada."));
-
 
         var spEtapa3 = subprocessoRepo.findById(SP_CODIGO).orElseThrow();
         var competencia = competenciaRepo.save(Competencia.builder().descricao("Java").mapa(spEtapa3.getMapa()).build());
@@ -96,7 +93,6 @@ class CDU09IntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(post("/api/subprocessos/{id}/cadastro/disponibilizar", SP_CODIGO).with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.mensagem", is("Cadastro de atividades disponibilizado")));
-
 
         Subprocesso atualizado = subprocessoRepo.findById(SP_CODIGO).orElseThrow();
 

--- a/backend/src/test/java/sgc/integracao/CDU10IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU10IntegrationTest.java
@@ -46,13 +46,11 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
     @Autowired
     private MovimentacaoRepo movimentacaoRepo;
 
-
     private Unidade unidadeSuperior;
     private Subprocesso subprocessoRevisao;
 
     @BeforeEach
     void setUp() {
-
 
         unidadeSuperior = UnidadeFixture.unidadeComSigla("COSIS");
         unidadeSuperior.setCodigo(null);
@@ -62,7 +60,6 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         unidadeChefe.setCodigo(null);
         unidadeChefe.setUnidadeSuperior(unidadeSuperior);
         unidadeChefe = unidadeRepo.save(unidadeChefe);
-
 
         Usuario usuarioChefe = UsuarioFixture.usuarioComTitulo("333333333333");
         usuarioChefe.setUnidadeLotacao(unidadeChefe);
@@ -76,7 +73,6 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         setupUsuarioPerfil(usuarioChefe, unidadeChefe, Perfil.CHEFE);
         definirTitular(unidadeChefe, usuarioChefe);
         definirTitular(unidadeSuperior, usuarioSuperior);
-
 
         Processo processoRevisao = ProcessoFixture.processoPadrao();
         processoRevisao.setCodigo(null);
@@ -183,14 +179,12 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         mockMvc.perform(post("/api/subprocessos/{id}/disponibilizar-revisao", subprocessoId))
                 .andExpect(status().isOk());
 
-
         Analise analiseAceite = new Analise();
         analiseAceite.setSubprocesso(subprocessoRevisao);
         analiseAceite.setUnidadeCodigo(unidadeSuperior.getCodigo());
         analiseAceite.setAcao(TipoAcaoAnalise.ACEITE_REVISAO);
         analiseAceite.setDataHora(LocalDateTime.now());
         analiseRepo.saveAndFlush(analiseAceite);
-
 
         Analise analiseDevolucao = new Analise();
         analiseDevolucao.setSubprocesso(subprocessoRevisao);
@@ -199,7 +193,6 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         analiseDevolucao.setObservacoes("Segunda devolução");
         analiseDevolucao.setDataHora(LocalDateTime.now());
         analiseRepo.saveAndFlush(analiseDevolucao);
-
 
         Subprocesso sp = subprocessoRepo.findById(subprocessoId).get();
         sp.setSituacaoForcada(SituacaoSubprocesso.REVISAO_CADASTRO_EM_ANDAMENTO);
@@ -223,7 +216,6 @@ class CDU10IntegrationTest extends BaseIntegrationTest {
         // 5. Nova disponibilização
         mockMvc.perform(post("/api/subprocessos/{id}/disponibilizar-revisao", subprocessoId))
                 .andExpect(status().isOk());
-
 
         List<Analise> analisesDepois = analiseRepo.findBySubprocessoCodigoOrderByDataHoraDesc(subprocessoId);
         assertThat(analisesDepois).hasSize(2); // Histórico é mantido

--- a/backend/src/test/java/sgc/integracao/CDU13IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU13IntegrationTest.java
@@ -143,7 +143,6 @@ class CDU13IntegrationTest extends BaseIntegrationTest {
         String observacoes = "Favor revisar a atividade X e Y.";
         JustificativaRequest requestBody = new JustificativaRequest(observacoes);
 
-
         mockMvc.perform(
                         post(
                                 "/api/subprocessos/{id}/devolver-cadastro",
@@ -153,7 +152,6 @@ class CDU13IntegrationTest extends BaseIntegrationTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();
@@ -295,12 +293,10 @@ class CDU13IntegrationTest extends BaseIntegrationTest {
                 .build();
         movimentacaoRepo.saveAndFlush(movRedisponibiliza);
 
-        // Ensure user is configured correctly like in other passing tests
         gestor.setPerfilAtivo(Perfil.GESTOR);
         gestor.setUnidadeAtivaCodigo(unidadeSuperior.getCodigo());
         gestor.setAuthorities(Set.of(Perfil.GESTOR.toGrantedAuthority()));
 
-        // Clear persistence context to ensure controller fetches fresh data (including new movement)
         entityManager.flush();
         entityManager.clear();
 

--- a/backend/src/test/java/sgc/integracao/CDU14IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU14IntegrationTest.java
@@ -84,7 +84,6 @@ class CDU14IntegrationTest extends BaseIntegrationTest {
             return mapaRepo.save(novoMapa);
         });
 
-        // Ensure mapa has at least one atividade with conhecimento for validation
         if (atividadeRepo.findByMapa_Codigo(mapaVigente.getCodigo()).isEmpty()) {
             Atividade atividade = Atividade.builder().mapa(mapaVigente).descricao("Atividade CDU-14 Test")
                     .build();
@@ -217,7 +216,6 @@ class CDU14IntegrationTest extends BaseIntegrationTest {
             assertThat(analiseRepo.findBySubprocessoCodigoOrderByDataHoraDesc(subprocessoId)).hasSize(1);
             assertThat(alertaRepo.findByProcessoCodigo(sp.getProcesso().getCodigo())).hasSize(6);
             assertThat(movimentacaoRepo.findBySubprocessoCodigo(subprocessoId)).hasSize(3);
-
 
             // Esperamos pelo menos 2 e-mails: Início de Processo e Aceite
             aguardarEmail(2);

--- a/backend/src/test/java/sgc/integracao/CDU17IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU17IntegrationTest.java
@@ -49,7 +49,6 @@ class CDU17IntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        // Ensure Admin user has profile in ADMIN (ID 1)
         jdbcTemplate.update("MERGE INTO SGC.VW_USUARIO_PERFIL_UNIDADE (usuario_titulo, unidade_codigo, perfil) KEY(usuario_titulo, unidade_codigo, perfil) VALUES (?, ?, ?)",
                 "111111111111", 1, "ADMIN");
 
@@ -100,7 +99,6 @@ class CDU17IntegrationTest extends BaseIntegrationTest {
         Competencia competencia = Competencia.builder().descricao("Competencia Valida").mapa(mapa).build();
         competencia = competenciaRepo.save(competencia);
 
-        // Associar (ManyToMany manually if needed or via helper methods)
         atividade.getCompetencias().add(competencia);
         atividadeRepo.save(atividade);
 

--- a/backend/src/test/java/sgc/integracao/CDU22IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU22IntegrationTest.java
@@ -114,14 +114,12 @@ class CDU22IntegrationTest extends BaseIntegrationTest {
                 .subprocessos(subprocessosSelecionados)
                 .build();
 
-
         mockMvc.perform(
                         post("/api/subprocessos/{id}/aceitar-cadastro-bloco", codigoContexto)
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/CDU23IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU23IntegrationTest.java
@@ -128,14 +128,12 @@ class CDU23IntegrationTest extends BaseIntegrationTest {
                 .subprocessos(subprocessosSelecionados)
                 .build();
 
-
         mockMvc.perform(
                         post("/api/subprocessos/{id}/homologar-cadastro-bloco", codigoContexto)
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/CDU24IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU24IntegrationTest.java
@@ -139,14 +139,12 @@ class CDU24IntegrationTest extends BaseIntegrationTest {
                 .dataLimite(LocalDate.now().plusDays(10))
                 .build();
 
-
         mockMvc.perform(
                         post("/api/subprocessos/{id}/disponibilizar-mapa-bloco", codigoContexto)
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/CDU25IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU25IntegrationTest.java
@@ -111,14 +111,12 @@ class CDU25IntegrationTest extends BaseIntegrationTest {
                 .subprocessos(subprocessosSelecionados)
                 .build();
 
-
         mockMvc.perform(
                         post("/api/subprocessos/{id}/aceitar-validacao-bloco", codigoContexto)
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/CDU26IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU26IntegrationTest.java
@@ -125,14 +125,12 @@ class CDU26IntegrationTest extends BaseIntegrationTest {
                 .subprocessos(subprocessosSelecionados)
                 .build();
 
-
         mockMvc.perform(
                         post("/api/subprocessos/{id}/homologar-validacao-bloco", codigoContexto)
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/CDU27IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU27IntegrationTest.java
@@ -69,14 +69,12 @@ class CDU27IntegrationTest extends BaseIntegrationTest {
         LocalDate novaData = LocalDate.now().plusDays(20);
         DataRequest request = new DataRequest(novaData);
 
-
         mockMvc.perform(
                         post("/api/subprocessos/{codigo}/data-limite", subprocesso.getCodigo())
                                 .with(csrf())
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/CDU28IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU28IntegrationTest.java
@@ -58,7 +58,6 @@ class CDU28IntegrationTest extends BaseIntegrationTest {
                 "Férias do titular"
         );
 
-
         mockMvc.perform(
                         post("/api/unidades/{codUnidade}/atribuicoes-temporarias", unidade.getCodigo())
                                 .with(csrf())

--- a/backend/src/test/java/sgc/integracao/CDU32IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU32IntegrationTest.java
@@ -96,7 +96,6 @@ class CDU32IntegrationTest extends BaseIntegrationTest {
                                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
 
-
         entityManager.flush();
         entityManager.clear();
 

--- a/backend/src/test/java/sgc/integracao/CDU34IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU34IntegrationTest.java
@@ -75,7 +75,6 @@ class CDU34IntegrationTest extends BaseIntegrationTest {
                 .unidadeCodigo(unidade.getCodigo())
                 .build();
 
-
         mockMvc.perform(
                         post("/api/processos/{codigo}/enviar-lembrete", processo.getCodigo())
                                 .with(csrf())
@@ -83,7 +82,6 @@ class CDU34IntegrationTest extends BaseIntegrationTest {
                                 .content(objectMapper.writeValueAsString(request)))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
-
 
         entityManager.flush();
         entityManager.clear();

--- a/backend/src/test/java/sgc/integracao/MapaManutencaoServiceIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/MapaManutencaoServiceIntegrationTest.java
@@ -229,7 +229,6 @@ class MapaManutencaoServiceIntegrationTest extends BaseIntegrationTest {
             CriarConhecimentoRequest req1 = CriarConhecimentoRequest.builder().descricao("Conhecimento 1").build();
             Conhecimento c1 = service.criarConhecimento(atividade.getCodigo(), req1);
 
-            // Flush and clear cache to ensure DB has the correct state and the entity manager fetches it afresh
             entityManager.flush();
             entityManager.clear();
 
@@ -248,7 +247,6 @@ class MapaManutencaoServiceIntegrationTest extends BaseIntegrationTest {
 
             service.excluirConhecimento(atividade.getCodigo(), c1.getCodigo());
 
-            // Flush to trigger actual DB deletion and clear the persistence context cache to ensure correct check
             entityManager.flush();
             entityManager.clear();
 

--- a/backend/src/test/java/sgc/integracao/ProcessoManutencaoServiceIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/ProcessoManutencaoServiceIntegrationTest.java
@@ -129,7 +129,6 @@ class ProcessoManutencaoServiceIntegrationTest extends BaseIntegrationTest {
         void deveLancarErroAoAtualizarProcessoEmAndamento() {
             Processo p = processoRepo.findById(50000L).orElseThrow();
 
-
             AtualizarProcessoRequest request = AtualizarProcessoRequest.builder()
                     .codigo(p.getCodigo())
                     .descricao("Atualizada")
@@ -166,7 +165,6 @@ class ProcessoManutencaoServiceIntegrationTest extends BaseIntegrationTest {
         @DisplayName("Deve lançar erro ao apagar processo fora da situação CRIADO")
         void deveLancarErroAoApagarProcessoEmAndamento() {
             Processo p = processoRepo.findById(50000L).orElseThrow();
-
 
             assertThatThrownBy(() -> service.apagar(p.getCodigo()))
                     .isInstanceOf(ErroValidacao.class);

--- a/backend/src/test/java/sgc/integracao/SubprocessoBuscaIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoBuscaIntegrationTest.java
@@ -35,7 +35,6 @@ class SubprocessoBuscaIntegrationTest extends BaseIntegrationTest {
         unidade.setUnidadeSuperior(raiz);
         unidade = unidadeRepo.save(unidade);
 
-
         processo = Processo.builder()
                 .descricao("Processo Busca")
                 .tipo(TipoProcesso.MAPEAMENTO)
@@ -43,7 +42,6 @@ class SubprocessoBuscaIntegrationTest extends BaseIntegrationTest {
                 .dataLimite(LocalDateTime.now().plusDays(30))
                 .build();
         processoRepo.save(processo);
-
 
         subprocesso = Subprocesso.builder()
                 .unidade(unidade)

--- a/backend/src/test/java/sgc/integracao/SubprocessoFluxoIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoFluxoIntegrationTest.java
@@ -172,7 +172,6 @@ class SubprocessoFluxoIntegrationTest extends BaseIntegrationTest {
         sp = subprocessoRepo.findById(spId).orElseThrow();
         assertThat(sp.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO);
 
-
         // Situação deve mudar para MAPA_VALIDADO
         // A Disponibilização enviou o processo para a Unidade Superior (RAIZ).
         // Quem valida a disponibilização é o Chefe da Unidade SUPERIOR (que recebeu o processo).
@@ -191,7 +190,6 @@ class SubprocessoFluxoIntegrationTest extends BaseIntegrationTest {
 
         sp = subprocessoRepo.findById(spId).orElseThrow();
         assertThat(sp.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO);
-
 
         // O teste já cobre:
         // - Adicionar competência (Escrita na Unidade Filha)

--- a/backend/src/test/java/sgc/mapa/model/ConhecimentoJsonViewTest.java
+++ b/backend/src/test/java/sgc/mapa/model/ConhecimentoJsonViewTest.java
@@ -32,7 +32,6 @@ class ConhecimentoJsonViewTest {
         assertThat(json).contains("\"descricao\":\"Conhecimento Teste\"");
         assertThat(json).contains("\"atividadeCodigo\":1");
 
-
         assertThat(json).doesNotContain("\"atividade\"");
     }
 }

--- a/backend/src/test/java/sgc/mapa/service/AtividadeFacadeTest.java
+++ b/backend/src/test/java/sgc/mapa/service/AtividadeFacadeTest.java
@@ -237,7 +237,6 @@ class AtividadeFacadeTest {
             when(usuarioService.usuarioAutenticado()).thenReturn(usuario);
             when(mapaManutencaoService.criarConhecimento(atividadeCodigo, request)).thenReturn(conhecimentoSalvo);
 
-
             when(subprocessoService.obterEntidadePorCodigoMapa(mapaCodigo)).thenReturn(subprocesso);
             when(subprocessoService.obterStatus(subCodigo)).thenReturn(new SubprocessoSituacaoDto(subCodigo, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO));
             when(subprocessoService.listarAtividadesSubprocesso(subCodigo)).thenReturn(Collections.singletonList(

--- a/backend/src/test/java/sgc/mapa/service/CopiaMapaServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/mapa/service/CopiaMapaServiceCoverageTest.java
@@ -58,9 +58,7 @@ class CopiaMapaServiceCoverageTest {
 
         when(competenciaRepo.findByMapa_Codigo(codMapaOrigem)).thenReturn(List.of(compFonte));
 
-
         service.copiarMapaParaUnidade(codMapaOrigem);
-
 
         verify(competenciaRepo).saveAll(anyList());
     }
@@ -81,9 +79,7 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of()); // Destino vazio
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
-
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, null);
-
 
         verify(atividadeRepo).saveAll(anyList());
     }
@@ -104,9 +100,7 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of());
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
-
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, List.of(10L));
-
 
         verify(atividadeRepo).saveAll(atividadesCaptor.capture());
         assertThat(atividadesCaptor.getValue()).hasSize(1);
@@ -127,10 +121,8 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of());
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
-
         // ID 999 não existe no mapa de origem — deve ser ignorado sem lançar exceção
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, List.of(999L));
-
 
         verify(atividadeRepo, never()).saveAll(anyList());
     }
@@ -149,9 +141,7 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of(ativDestino));
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
-
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, null);
-
 
         verify(atividadeRepo, never()).saveAll(anyList());
     }

--- a/backend/src/test/java/sgc/mapa/service/MapaSalvamentoServiceTest.java
+++ b/backend/src/test/java/sgc/mapa/service/MapaSalvamentoServiceTest.java
@@ -172,7 +172,6 @@ class MapaSalvamentoServiceTest {
 
         mapaSalvamentoService.salvarMapaCompleto(codMapa, request);
 
-
         assertThat(ativ.getCompetencias()).isEmpty();
     }
 

--- a/backend/src/test/java/sgc/organizacao/HierarquiaServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/HierarquiaServiceTest.java
@@ -22,7 +22,6 @@ class HierarquiaServiceTest {
     @InjectMocks
     private HierarquiaService hierarquiaService;
 
-
     @Test
     @DisplayName("Deve retornar true se usuario é responsavel")
     void deveRetornarTrueSeUsuarioResponsavel() {
@@ -118,7 +117,6 @@ class HierarquiaServiceTest {
 
         assertThat(hierarquiaService.isMesmaOuSubordinada(alvo, superior)).isTrue();
     }
-
 
     @Test
     @DisplayName("Deve retornar true quando é superior imediata")

--- a/backend/src/test/java/sgc/organizacao/UsuarioFacadeTest.java
+++ b/backend/src/test/java/sgc/organizacao/UsuarioFacadeTest.java
@@ -73,9 +73,7 @@ class UsuarioFacadeTest {
             configurarAutenticacao(titulo);
             when(usuarioService.buscarComAtribuicoes(titulo)).thenReturn(usuario);
 
-
             Usuario resultado = facade.usuarioAutenticado();
-
 
             assertThat(resultado).isNotNull();
             assertThat(resultado.getTituloEleitoral()).isEqualTo(titulo);
@@ -102,9 +100,7 @@ class UsuarioFacadeTest {
             when(context.getAuthentication()).thenReturn(auth);
             SecurityContextHolder.setContext(context);
 
-
             Usuario resultado = facade.usuarioAutenticado();
-
 
             assertThat(resultado).isSameAs(usuario);
             verifyNoInteractions(usuarioService);
@@ -125,9 +121,7 @@ class UsuarioFacadeTest {
             when(usuarioService.buscarComAtribuicoesOpt(titulo))
                     .thenReturn(Optional.of(usuario));
 
-
             Usuario resultado = facade.carregarUsuarioParaAutenticacao(titulo);
-
 
             assertThat(resultado).isNotNull();
             assertThat(resultado.getTituloEleitoral()).isEqualTo(titulo);
@@ -150,9 +144,7 @@ class UsuarioFacadeTest {
             when(usuarioService.buscarAdministradores()).thenReturn(List.of(admin));
             when(usuarioService.buscarOpt(titulo)).thenReturn(Optional.of(usuario));
 
-
             List<AdministradorDto> resultado = facade.listarAdministradores();
-
 
             assertThat(resultado).hasSize(1);
             assertThat(resultado.getFirst().tituloEleitoral()).isEqualTo(titulo);
@@ -167,9 +159,7 @@ class UsuarioFacadeTest {
 
             when(usuarioService.buscar(titulo)).thenReturn(usuario);
 
-
             AdministradorDto resultado = facade.adicionarAdministrador(titulo);
-
 
             assertThat(resultado).isNotNull();
             verify(usuarioService).adicionarAdministrador(titulo);
@@ -182,9 +172,7 @@ class UsuarioFacadeTest {
             String tituloRemover = "111111";
             String tituloAtual = "222222";
 
-
             facade.removerAdministrador(tituloRemover, tituloAtual);
-
 
             verify(usuarioService).removerAdministrador(tituloRemover);
         }
@@ -212,9 +200,7 @@ class UsuarioFacadeTest {
             when(usuarioService.buscarPorTitulos(titulos))
                     .thenReturn(List.of(usuario1, usuario2));
 
-
             Map<String, Usuario> resultado = facade.buscarUsuariosPorTitulos(titulos);
-
 
             assertThat(resultado).hasSize(2).containsKeys("111111", "222222");
         }

--- a/backend/src/test/java/sgc/organizacao/UsuarioServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/UsuarioServiceTest.java
@@ -51,7 +51,6 @@ class UsuarioServiceTest {
 
             Optional<Usuario> result = usuarioServiceInternal.buscarOpt(TITULO_ADMIN);
 
-
             assertTrue(result.isPresent());
             assertEquals(TITULO_ADMIN, result.get().getTituloEleitoral());
             assertEquals(NOME_ADMIN, result.get().getNome());
@@ -63,7 +62,6 @@ class UsuarioServiceTest {
 
             var usuario = usuarioService.buscarPorLogin(TITULO_ADMIN);
 
-
             assertNotNull(usuario);
             assertEquals(TITULO_ADMIN, usuario.getTituloEleitoral());
         }
@@ -73,7 +71,6 @@ class UsuarioServiceTest {
         void deveBuscarUsuariosAtivos() {
 
             List<Usuario> result = usuarioServiceInternal.buscarTodos();
-
 
             assertNotNull(result);
             assertFalse(result.isEmpty());
@@ -86,9 +83,7 @@ class UsuarioServiceTest {
 
             List<String> titulos = List.of(TITULO_CHEFE_UNIT2, TITULO_ADMIN);
 
-
             Map<String, Usuario> result = usuarioService.buscarUsuariosPorTitulos(titulos);
-
 
             assertNotNull(result);
             assertEquals(2, result.size());
@@ -105,7 +100,6 @@ class UsuarioServiceTest {
         void deveBuscarUnidadePorCodigo() {
 
             Unidade result = unidadeService2.buscarPorId(COD_UNIT_SEC1);
-
 
             assertNotNull(result);
             assertEquals(COD_UNIT_SEC1, result.getCodigo());
@@ -127,7 +121,6 @@ class UsuarioServiceTest {
 
             List<UnidadeDto> result = hierarquiaService.buscarSubordinadas(COD_UNIT_SEC1);
 
-
             assertNotNull(result);
             assertFalse(result.isEmpty());
             for (UnidadeDto unidade : result) {
@@ -140,7 +133,6 @@ class UsuarioServiceTest {
         void deveConstruirArvoreHierarquica() {
 
             List<UnidadeDto> result = hierarquiaService.buscarArvoreHierarquica();
-
 
             assertNotNull(result);
             assertFalse(result.isEmpty());
@@ -179,7 +171,6 @@ class UsuarioServiceTest {
 
             UnidadeResponsavelDto result = responsavelService.buscarResponsavelUnidade(2L);
 
-
             assertNotNull(result);
             assertEquals(2L, result.unidadeCodigo());
             assertEquals(TITULO_CHEFE_UNIT2, result.titularTitulo());
@@ -190,7 +181,6 @@ class UsuarioServiceTest {
         void deveBuscarUnidadesOndeEhResponsavel() {
 
             List<Long> result = responsavelService.buscarUnidadesOndeEhResponsavel(TITULO_CHEFE_UNIT2);
-
 
             assertNotNull(result);
             assertFalse(result.isEmpty());
@@ -203,9 +193,7 @@ class UsuarioServiceTest {
 
             List<Long> unidades = List.of(2L, 9L);
 
-
             Map<Long, UnidadeResponsavelDto> result = responsavelService.buscarResponsaveisUnidades(unidades);
-
 
             assertNotNull(result);
             assertTrue(result.containsKey(2L));
@@ -223,7 +211,6 @@ class UsuarioServiceTest {
         void deveBuscarPerfisUsuario() {
 
             List<PerfilDto> result = usuarioService.buscarPerfisUsuario(TITULO_CHEFE_UNIT2);
-
 
             assertNotNull(result);
             assertFalse(result.isEmpty());

--- a/backend/src/test/java/sgc/organizacao/ValidadorDadosOrgServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/ValidadorDadosOrgServiceTest.java
@@ -136,7 +136,6 @@ class ValidadorDadosOrgServiceTest {
         }
     }
 
-
     @Nested
     @DisplayName("Cenários de Violação")
     class CenariosViolacao {

--- a/backend/src/test/java/sgc/organizacao/model/UnidadeTest.java
+++ b/backend/src/test/java/sgc/organizacao/model/UnidadeTest.java
@@ -15,10 +15,8 @@ class UnidadeTest {
         usuario.setTituloEleitoral("123456789012");
         usuario.setMatricula("12345678");
 
-
         unidade.setTituloTitular(usuario.getTituloEleitoral());
         unidade.setMatriculaTitular(usuario.getMatricula());
-
 
         assertThat(unidade.getTituloTitular()).isEqualTo("123456789012");
         assertThat(unidade.getMatriculaTitular()).isEqualTo("12345678");

--- a/backend/src/test/java/sgc/organizacao/service/ResponsavelUnidadeServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/ResponsavelUnidadeServiceTest.java
@@ -52,9 +52,7 @@ class ResponsavelUnidadeServiceTest {
             when(atribuicaoTemporariaRepo.findAll()).thenReturn(List.of(atribuicao));
             when(repo.buscar(Usuario.class, "123456789012")).thenReturn(usuario);
 
-
             List<AtribuicaoDto> resultado = service.buscarTodasAtribuicoes();
-
 
             assertThat(resultado).hasSize(1);
             assertThat(resultado.getFirst().unidadeCodigo()).isEqualTo(10L);
@@ -91,9 +89,7 @@ class ResponsavelUnidadeServiceTest {
             when(repo.buscar(Unidade.class, codUnidade)).thenReturn(unidade);
             when(repo.buscar(Usuario.class, "123456789012")).thenReturn(usuario);
 
-
             service.criarAtribuicaoTemporaria(codUnidade, request);
-
 
             ArgumentCaptor<AtribuicaoTemporaria> captor = ArgumentCaptor.forClass(AtribuicaoTemporaria.class);
             verify(atribuicaoTemporariaRepo).save(captor.capture());
@@ -134,9 +130,7 @@ class ResponsavelUnidadeServiceTest {
             when(repo.buscar(Responsabilidade.class, 1L)).thenReturn(resp);
             when(repo.buscar(Usuario.class, "123456789012")).thenReturn(usuarioCompleto);
 
-
             Usuario resultado = service.buscarResponsavelAtual(siglaUnidade);
-
 
             assertThat(resultado).isNotNull();
             assertThat(resultado.getTituloEleitoral()).isEqualTo("123456789012");
@@ -174,9 +168,7 @@ class ResponsavelUnidadeServiceTest {
             when(repo.buscar(Usuario.class, "222222222222")).thenReturn(substituto);
             when(repo.buscar(Usuario.class, "111111111111")).thenReturn(titularOficial);
 
-
             UnidadeResponsavelDto resultado = service.buscarResponsavelUnidade(unidadeCodigo);
-
 
             assertThat(resultado).isNotNull();
             assertThat(resultado.titularTitulo()).isEqualTo("111111111111");

--- a/backend/src/test/java/sgc/processo/model/ModelCoverageTest.java
+++ b/backend/src/test/java/sgc/processo/model/ModelCoverageTest.java
@@ -44,10 +44,8 @@ class ModelCoverageTest {
         u2.setMatriculaTitular("5678");
         u2.setTituloTitular("789012");
 
-
         processo.adicionarParticipantes(Set.of(u1, u2));
         assertThat(processo.getParticipantes()).hasSize(2);
-
 
         // Isso cobre both true/false do removeIf em Proceso.java:86
         processo.sincronizarParticipantes(new HashSet<>(Collections.singletonList(u2)));

--- a/backend/src/test/java/sgc/processo/model/ProcessoPbtTest.java
+++ b/backend/src/test/java/sgc/processo/model/ProcessoPbtTest.java
@@ -17,9 +17,7 @@ class ProcessoPbtTest {
         processo.setParticipantes(new ArrayList<>()); // Inicializa lista vazia
         processo.adicionarParticipantes(unidadesIniciais);
 
-
         processo.sincronizarParticipantes(novasUnidades);
-
 
         List<Long> codigosParticipantes = processo.getCodigosParticipantes();
         List<Long> codigosNovasUnidades = novasUnidades.stream()

--- a/backend/src/test/java/sgc/processo/model/ProcessoRepoPerformanceTest.java
+++ b/backend/src/test/java/sgc/processo/model/ProcessoRepoPerformanceTest.java
@@ -46,9 +46,7 @@ class ProcessoRepoPerformanceTest {
         entityManager.flush();
         entityManager.clear();
 
-
         List<Processo> processos = processoRepo.listarPorSituacaoComParticipantes(SituacaoProcesso.FINALIZADO);
-
 
         assertThat(processos).isNotEmpty();
 

--- a/backend/src/test/java/sgc/processo/model/ProcessoRepoTest.java
+++ b/backend/src/test/java/sgc/processo/model/ProcessoRepoTest.java
@@ -64,13 +64,11 @@ class ProcessoRepoTest {
 
         entityManager.flush(); // Ensure Persistence
 
-
         Page<Processo> resultado = processoRepo.findDistinctByParticipantes_IdUnidadeCodigoInAndSituacaoNot(
                 List.of(u1.getCodigo()),
                 SituacaoProcesso.CRIADO,
                 PageRequest.of(0, 10)
         );
-
 
         assertThat(resultado.getContent())
                 .hasSize(1)
@@ -95,13 +93,11 @@ class ProcessoRepoTest {
 
         entityManager.flush();
 
-
         Page<Processo> resultado = processoRepo.findDistinctByParticipantes_IdUnidadeCodigoInAndSituacaoNot(
                 List.of(u1.getCodigo()),
                 SituacaoProcesso.CRIADO,
                 PageRequest.of(0, 10)
         );
-
 
         assertThat(resultado.getContent())
                 .hasSize(2)
@@ -121,13 +117,11 @@ class ProcessoRepoTest {
 
         entityManager.flush();
 
-
         Page<Processo> resultado = processoRepo.findDistinctByParticipantes_IdUnidadeCodigoInAndSituacaoNot(
                 List.of(u1.getCodigo(), u2.getCodigo()), // Busco por AMBAS
                 SituacaoProcesso.CRIADO,
                 PageRequest.of(0, 10)
         );
-
 
         assertThat(resultado.getContent())
                 .hasSize(1) // DISTINCT deve garantir apenas 1 resultado
@@ -154,7 +148,6 @@ class ProcessoRepoTest {
                 PageRequest.of(0, 2)
         );
 
-
         assertThat(resultado.getTotalElements()).isEqualTo(5);
         assertThat(resultado.getTotalPages()).isEqualTo(3);
         assertThat(resultado.getContent()).hasSize(2);
@@ -172,13 +165,11 @@ class ProcessoRepoTest {
 
         entityManager.flush();
 
-
         Page<Processo> resultado = processoRepo.findDistinctByParticipantes_IdUnidadeCodigoInAndSituacaoNot(
                 List.of(u1.getCodigo()),
                 SituacaoProcesso.CRIADO,
                 PageRequest.of(0, 10)
         );
-
 
         assertThat(resultado.getContent())
                 .hasSize(2)

--- a/backend/src/test/java/sgc/processo/model/ProcessoTest.java
+++ b/backend/src/test/java/sgc/processo/model/ProcessoTest.java
@@ -31,7 +31,6 @@ class ProcessoTest {
             SituacaoProcesso situacao = SituacaoProcesso.CRIADO;
             LocalDateTime dataCriacao = LocalDateTime.now();
 
-
             Processo novoProcesso = Processo.builder()
                     .descricao(descricao)
                     .tipo(tipo)
@@ -39,7 +38,6 @@ class ProcessoTest {
                     .dataCriacao(dataCriacao)
                     .build();
             novoProcesso.setCodigo(codigo);
-
 
             assertThat(novoProcesso.getCodigo()).isEqualTo(codigo);
             assertThat(novoProcesso.getDescricao()).isEqualTo(descricao);
@@ -57,14 +55,12 @@ class ProcessoTest {
             SituacaoProcesso situacao = SituacaoProcesso.CRIADO;
             LocalDateTime dataLimite = LocalDateTime.now().plusDays(30);
 
-
             Processo novoProcesso = Processo.builder()
                     .descricao(descricao)
                     .tipo(tipo)
                     .situacao(situacao)
                     .dataLimite(dataLimite)
                     .build();
-
 
             assertThat(novoProcesso.getDescricao()).isEqualTo(descricao);
             assertThat(novoProcesso.getTipo()).isEqualTo(tipo);
@@ -85,7 +81,6 @@ class ProcessoTest {
             TipoProcesso tipo = TipoProcesso.MAPEAMENTO;
             List<UnidadeProcesso> participantes = new ArrayList<>();
 
-
             Processo novoProcesso = Processo.builder()
                     .dataCriacao(dataCriacao)
                     .dataFinalizacao(dataFinalizacao)
@@ -95,7 +90,6 @@ class ProcessoTest {
                     .tipo(tipo)
                     .participantes(participantes)
                     .build();
-
 
             assertThat(novoProcesso.getDataCriacao()).isEqualTo(dataCriacao);
             assertThat(novoProcesso.getDataFinalizacao()).isEqualTo(dataFinalizacao);
@@ -117,7 +111,6 @@ class ProcessoTest {
 
             List<UnidadeProcesso> participantes = processo.getParticipantes();
 
-
             assertThat(participantes)
                     .isNotNull()
                     .isEmpty();
@@ -135,10 +128,8 @@ class ProcessoTest {
             unidade2.setCodigo(2L);
             unidade2.setNome("Unidade 2");
 
-
             processo.adicionarParticipantes(Set.of(unidade1));
             processo.adicionarParticipantes(Set.of(unidade2));
-
 
             assertThat(processo.getParticipantes()).hasSize(2);
             assertThat(processo.getParticipantes())
@@ -161,9 +152,7 @@ class ProcessoTest {
             UnidadeProcesso snapshot = UnidadeProcesso.criarSnapshot(processo, unidade);
             novosParticipantes.add(snapshot);
 
-
             processo.setParticipantes(novosParticipantes);
-
 
             assertThat(processo.getParticipantes())
                     .isEqualTo(novosParticipantes)
@@ -180,9 +169,7 @@ class ProcessoTest {
 
             LocalDateTime dataCriacao = LocalDateTime.now();
 
-
             processo.setDataCriacao(dataCriacao);
-
 
             assertThat(processo.getDataCriacao())
                     .isNotNull()
@@ -195,9 +182,7 @@ class ProcessoTest {
 
             LocalDateTime dataFinalizacao = LocalDateTime.now().plusDays(30);
 
-
             processo.setDataFinalizacao(dataFinalizacao);
-
 
             assertThat(processo.getDataFinalizacao()).isEqualTo(dataFinalizacao);
         }
@@ -208,9 +193,7 @@ class ProcessoTest {
 
             LocalDateTime dataLimite = LocalDateTime.now().plusDays(15);
 
-
             processo.setDataLimite(dataLimite);
-
 
             assertThat(processo.getDataLimite())
                     .isEqualTo(dataLimite);
@@ -226,7 +209,6 @@ class ProcessoTest {
 
             processo.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
 
-
             assertThat(processo.getSituacao()).isEqualTo(SituacaoProcesso.EM_ANDAMENTO);
         }
 
@@ -235,7 +217,6 @@ class ProcessoTest {
         void deveConfigurarTipoDoProcesso() {
 
             processo.setTipo(TipoProcesso.REVISAO);
-
 
             assertThat(processo.getTipo()).isEqualTo(TipoProcesso.REVISAO);
         }
@@ -270,9 +251,7 @@ class ProcessoTest {
 
             String descricao = "Mapeamento de Competências 2024";
 
-
             processo.setDescricao(descricao);
-
 
             assertThat(processo.getDescricao()).isEqualTo(descricao);
         }

--- a/backend/src/test/java/sgc/processo/painel/PainelFacadeTest.java
+++ b/backend/src/test/java/sgc/processo/painel/PainelFacadeTest.java
@@ -170,7 +170,6 @@ class PainelFacadeTest {
         assertThat(result).hasSize(1);
     }
 
-
     @Test
     @DisplayName("Deve lidar com solicitação não paginada")
     void deveLidarComSolicitacaoNaoPaginada() {
@@ -200,15 +199,12 @@ class PainelFacadeTest {
         when(up2.getUnidadeCodigo()).thenReturn(10L); // Mesmo código
         when(up2.getSigla()).thenReturn("U1"); // Mock de sigla
 
-
         when(p.getParticipantes()).thenReturn(List.of(up1, up2));
 
         when(hierarquiaService.buscarMapaHierarquia()).thenReturn(new HashMap<>());
         when(processoFacade.listarTodos(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(p)));
 
-
         Page<ProcessoResumoDto> result = painelFacade.listarProcessos(Perfil.ADMIN, 100L, PageRequest.of(0, 10));
-
 
         assertThat(result.getContent().getFirst().unidadesParticipantes()).contains("U1");
     }
@@ -221,7 +217,6 @@ class PainelFacadeTest {
         when(p.getCodigo()).thenReturn(1L);
         when(p.getSituacao()).thenReturn(SituacaoProcesso.EM_ANDAMENTO);
         when(p.getTipo()).thenReturn(TipoProcesso.MAPEAMENTO);
-
 
         UnidadeProcesso up1 = mock(UnidadeProcesso.class);
         when(up1.getUnidadeCodigo()).thenReturn(1L);
@@ -241,9 +236,7 @@ class PainelFacadeTest {
         when(hierarquiaService.buscarMapaHierarquia()).thenReturn(hierarquia);
         when(processoFacade.listarTodos(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(p)));
 
-
         Page<ProcessoResumoDto> result = painelFacade.listarProcessos(Perfil.ADMIN, 100L, PageRequest.of(0, 10));
-
 
         // Se U2 participa e U1 participa, e U2 é única subordinada de U1, deve mostrar apenas U1
         assertThat(result.getContent().getFirst().unidadesParticipantes()).isEqualTo("U1");

--- a/backend/src/test/java/sgc/processo/painel/PainelServiceIntegrationTest.java
+++ b/backend/src/test/java/sgc/processo/painel/PainelServiceIntegrationTest.java
@@ -44,7 +44,6 @@ class PainelServiceIntegrationTest {
             );
             processoFacade.criar(reqMapeamento);
 
-
             CriarProcessoRequest reqRevisao = new CriarProcessoRequest(
                     "Processo Revisão Teste",
                     TipoProcesso.REVISAO,
@@ -54,13 +53,11 @@ class PainelServiceIntegrationTest {
             Processo processoRevisao = processoFacade.criar(reqRevisao);
             Long codigoProcessoRevisao = processoRevisao.getCodigo();
 
-
             Page<ProcessoResumoDto> processos = painelService.listarProcessos(
                     Perfil.ADMIN,
                     null,
                     PageRequest.of(0, 20) // Página 0, 20 itens por página
             );
-
 
             List<ProcessoResumoDto> listaProcessos = processos.getContent();
 
@@ -102,13 +99,11 @@ class PainelServiceIntegrationTest {
                 processoFacade.criar(req);
             }
 
-
             Page<ProcessoResumoDto> processos = painelService.listarProcessos(
                     Perfil.ADMIN,
                     null,
                     PageRequest.of(0, 50) // Página grande
             );
-
 
             // (Mais os 2 processos seed do banco)
             assertThat(processos.getTotalElements())
@@ -138,7 +133,6 @@ class PainelServiceIntegrationTest {
             );
             Processo processoRevisao = processoFacade.criar(reqRevisao);
 
-
             Page<ProcessoResumoDto> page = painelService.listarProcessos(Perfil.ADMIN, null, PageRequest.of(0, 50));
             List<ProcessoResumoDto> lista = page.getContent();
 
@@ -149,7 +143,6 @@ class PainelServiceIntegrationTest {
             ProcessoResumoDto dtoRevisao = lista.stream()
                     .filter(p -> p.codigo().equals(processoRevisao.getCodigo()))
                     .findFirst().orElseThrow();
-
 
             assertThat(dtoSeed.linkDestino()).contains(processoSeed.getCodigo().toString());
             assertThat(dtoRevisao.linkDestino()).contains(processoRevisao.getCodigo().toString());

--- a/backend/src/test/java/sgc/processo/painel/PainelServiceTest.java
+++ b/backend/src/test/java/sgc/processo/painel/PainelServiceTest.java
@@ -241,7 +241,6 @@ class PainelServiceTest {
             alerta.setDescricao("Alerta teste");
             alerta.setDataHora(LocalDateTime.now());
 
-
             Processo p = new Processo();
             p.setCodigo(123L);
             alerta.setProcesso(p);

--- a/backend/src/test/java/sgc/processo/service/ProcessoConsultaServiceTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoConsultaServiceTest.java
@@ -59,9 +59,7 @@ class ProcessoConsultaServiceTest {
                 anyList(), eq(processoIgnorar)
         )).thenReturn(unidadesMock);
 
-
         Set<Long> resultado = processoConsultaService.buscarIdsUnidadesComProcessosAtivos(processoIgnorar);
-
 
         assertThat(resultado).hasSize(3).containsExactlyInAnyOrder(1L, 2L, 3L);
 
@@ -81,9 +79,7 @@ class ProcessoConsultaServiceTest {
                 anyList(), eq(processoIgnorar)
         )).thenReturn(List.of());
 
-
         Set<Long> resultado = processoConsultaService.buscarIdsUnidadesComProcessosAtivos(processoIgnorar);
-
 
         assertThat(resultado).isEmpty();
     }
@@ -106,9 +102,7 @@ class ProcessoConsultaServiceTest {
         when(processoRepo.findUnidadeCodigosBySituacaoAndTipo(SituacaoProcesso.EM_ANDAMENTO, TipoProcesso.REVISAO))
                 .thenReturn(List.of());
 
-
         List<Long> ids = processoConsultaService.unidadesBloqueadasPorTipo(TipoProcesso.REVISAO);
-
 
         assertThat(ids).isEmpty();
     }
@@ -193,9 +187,7 @@ class ProcessoConsultaServiceTest {
         when(processoRepo.listarPorSituacaoComParticipantes(SituacaoProcesso.FINALIZADO))
                 .thenReturn(List.of());
 
-
         List<Processo> resultado = processoConsultaService.processosFinalizados();
-
 
         assertThat(resultado).isEmpty();
         verify(processoRepo).listarPorSituacaoComParticipantes(SituacaoProcesso.FINALIZADO);

--- a/backend/src/test/java/sgc/processo/service/ProcessoDetalheBuilderCoverageTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoDetalheBuilderCoverageTest.java
@@ -29,7 +29,6 @@ class ProcessoDetalheBuilderCoverageTest {
     @InjectMocks
     private ProcessoDetalheBuilder builder;
 
-
     @Test
     @DisplayName("build deve mapear subprocesso e mapa quando existem")
     void deveMapearSubprocessoEMapa() {
@@ -57,15 +56,12 @@ class ProcessoDetalheBuilderCoverageTest {
 
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(codProcesso)).thenReturn(List.of(sp));
 
-
         ProcessoDetalheDto dto = builder.build(processo, new Usuario());
-
 
         assertThat(dto.getUnidades()).hasSize(1);
         ProcessoDetalheDto.UnidadeParticipanteDto result = dto.getUnidades().getFirst();
         assertThat(result.getCodSubprocesso()).isEqualTo(500L);
     }
-
 
     @Test
     @DisplayName("build deve manter unidadeDto quando sp é nulo")
@@ -86,9 +82,7 @@ class ProcessoDetalheBuilderCoverageTest {
 
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(codProcesso)).thenReturn(new ArrayList<>());
 
-
         ProcessoDetalheDto dto = builder.build(processo, new Usuario());
-
 
         assertThat(dto.getUnidades()).hasSize(1);
         assertThat(dto.getUnidades().getFirst().getSigla()).isEqualTo("TESTE");

--- a/backend/src/test/java/sgc/processo/service/ProcessoDetalheBuilderTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoDetalheBuilderTest.java
@@ -26,7 +26,6 @@ class ProcessoDetalheBuilderTest {
     @Mock
     private SubprocessoRepo subprocessoRepo;
 
-
     @Mock
     private SgcPermissionEvaluator permissionEvaluator;
 
@@ -49,7 +48,6 @@ class ProcessoDetalheBuilderTest {
         usuario.setTituloEleitoral("12345678901");
         return usuario;
     }
-
 
     @Test
     @DisplayName("Deve construir DTO com dados básicos e unidades quando dados válidos")
@@ -77,9 +75,7 @@ class ProcessoDetalheBuilderTest {
 
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(List.of(sp));
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto).isNotNull();
         assertThat(dto.getCodigo()).isEqualTo(1L);
@@ -107,9 +103,7 @@ class ProcessoDetalheBuilderTest {
         when(subprocessoValidacaoService.validarSubprocessosParaFinalizacao(1L))
                 .thenReturn(SubprocessoValidacaoService.ValidationResult.ofValido());
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.isPodeFinalizar()).isTrue();
     }
@@ -127,9 +121,7 @@ class ProcessoDetalheBuilderTest {
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(Collections.emptyList());
         doReturn(false).when(permissionEvaluator).checkPermission(usuario, processo, "FINALIZAR_PROCESSO");
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.isPodeFinalizar()).isFalse();
     }
@@ -149,9 +141,7 @@ class ProcessoDetalheBuilderTest {
         when(subprocessoValidacaoService.validarSubprocessosParaFinalizacao(1L))
                 .thenReturn(SubprocessoValidacaoService.ValidationResult.ofInvalido("Subprocessos não homologados"));
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.isPodeFinalizar()).isFalse();
     }
@@ -172,9 +162,7 @@ class ProcessoDetalheBuilderTest {
         processo.adicionarParticipantes(Set.of(u1, u2));
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(Collections.emptyList());
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.getUnidades()).hasSize(2);
         assertThat(dto.getUnidades().get(0).getSigla()).isEqualTo("A");
@@ -211,9 +199,7 @@ class ProcessoDetalheBuilderTest {
 
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(List.of(spPai, spFilho));
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.getUnidades()).hasSize(1); // Somente o pai na raiz
         ProcessoDetalheDto.UnidadeParticipanteDto paiDto = dto.getUnidades().getFirst();
@@ -268,12 +254,10 @@ class ProcessoDetalheBuilderTest {
         Unidade filho = criarUnidade(2L, "FILHO", "FILHO");
         filho.setUnidadeSuperior(pai);
 
-
         processo.adicionarParticipantes(Set.of(filho));
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(Collections.emptyList());
 
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.getUnidades()).hasSize(1);
         assertThat(dto.getUnidades().getFirst().getSigla()).isEqualTo("FILHO");
@@ -304,9 +288,7 @@ class ProcessoDetalheBuilderTest {
 
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(List.of(sp));
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.getUnidades()).hasSize(1);
     }
@@ -333,9 +315,7 @@ class ProcessoDetalheBuilderTest {
         // Subprocesso existe mas unidade não está em participantes
         when(subprocessoRepo.findByProcessoCodigoWithUnidade(1L)).thenReturn(List.of(sp));
 
-
         ProcessoDetalheDto dto = builder.build(processo, usuario);
-
 
         assertThat(dto.getUnidades()).isEmpty();
     }

--- a/backend/src/test/java/sgc/processo/service/ProcessoFacadeTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoFacadeTest.java
@@ -90,7 +90,6 @@ class ProcessoFacadeTest {
             verify(processoConsultaService).buscarIdsUnidadesComProcessosAtivos(codigoIgnorar);
         }
 
-
         @Test
         @DisplayName("enviarLembrete deve delegar para processoNotificacaoService")
         void enviarLembrete_DeveDelegar() {
@@ -251,7 +250,6 @@ class ProcessoFacadeTest {
 
             Processo resultado = processoFacade.criar(req);
 
-
             assertThat(resultado).isNotNull();
             verify(processoManutencaoService).criar(req);
         }
@@ -292,9 +290,7 @@ class ProcessoFacadeTest {
             when(processoConsultaService.buscarProcessoCodigo(id)).thenReturn(processo);
             when(processoDetalheBuilder.build(eq(processo), any(Usuario.class))).thenReturn(ProcessoDetalheDto.builder().build());
 
-
             var res = processoFacade.obterDetalhes(id, usuario);
-
 
             assertThat(res).isNotNull();
         }
@@ -350,9 +346,7 @@ class ProcessoFacadeTest {
             when(processoConsultaService.unidadesBloqueadasPorTipo(TipoProcesso.MAPEAMENTO))
                     .thenReturn(List.of(1L));
 
-
             List<Long> bloqueadas = processoFacade.listarUnidadesBloqueadasPorTipo("MAPEAMENTO");
-
 
             assertThat(bloqueadas).contains(1L);
         }
@@ -371,9 +365,7 @@ class ProcessoFacadeTest {
             when(processoConsultaService.subprocessosElegiveis(id))
                     .thenReturn(List.of());
 
-
             var res = processoFacade.obterContextoCompleto(id, usuario);
-
 
             assertThat(res)
                     .isNotNull()
@@ -431,9 +423,7 @@ class ProcessoFacadeTest {
                 when(subprocessoService.listarEntidadesPorProcessoEUnidades(100L, List.of(1L, 2L, 3L))).thenReturn(List.of(sp1, sp2, sp3));
                 doReturn(true).when(permissionEvaluator).checkPermission(eq(usuario), any(), eq("DISPONIBILIZAR_MAPA"));
 
-
                 processoFacade.executarAcaoEmBloco(100L, req);
-
 
                 ArgumentCaptor<DisponibilizarMapaRequest> captor =
                         ArgumentCaptor.forClass(DisponibilizarMapaRequest.class);
@@ -479,9 +469,7 @@ class ProcessoFacadeTest {
                         null
                 );
 
-
                 processoFacade.executarAcaoEmBloco(100L, req);
-
 
                 verify(transicaoService).aceitarCadastroEmBloco(List.of(1L, 2L), usuario);
             }
@@ -508,9 +496,7 @@ class ProcessoFacadeTest {
                         null
                 );
 
-
                 processoFacade.executarAcaoEmBloco(100L, req);
-
 
                 verify(transicaoService).aceitarValidacaoEmBloco(List.of(1L), usuario);
             }
@@ -541,9 +527,7 @@ class ProcessoFacadeTest {
                         null
                 );
 
-
                 processoFacade.executarAcaoEmBloco(100L, req);
-
 
                 verify(transicaoService).homologarCadastroEmBloco(List.of(1L), usuario);
             }
@@ -570,9 +554,7 @@ class ProcessoFacadeTest {
                         null
                 );
 
-
                 processoFacade.executarAcaoEmBloco(100L, req);
-
 
                 verify(transicaoService).homologarValidacaoEmBloco(List.of(1L), usuario);
             }

--- a/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServicePbtTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServicePbtTest.java
@@ -63,9 +63,7 @@ class ProcessoManutencaoServicePbtTest {
         when(processoValidador.getMensagemErroUnidadesSemMapa(any())).thenReturn(Optional.empty());
         when(processoRepo.saveAndFlush(any(Processo.class))).thenAnswer(i -> i.getArgument(0));
 
-
         service.criar(req);
-
 
         verify(processoRepo).saveAndFlush(any(Processo.class));
     }

--- a/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageExtraTest.java
@@ -39,7 +39,6 @@ class ProcessoNotificacaoServiceCoverageExtraTest {
         proc.setCodigo(1L);
         proc.setDescricao("Processo 1");
 
-
         Unidade u1 = new Unidade();
         u1.setCodigo(10L);
         u1.setSigla("U1");

--- a/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceTest.java
@@ -161,7 +161,6 @@ class ProcessoNotificacaoServiceTest {
         verify(alertaService).criarAlertasProcessoIniciado(any(), anyList());
     }
 
-
     @Test
     @DisplayName("Deve criar alertas mesmo se não enviar e-mails")
     void deveCriarAlertasMesmoSemEmails() {

--- a/backend/src/test/java/sgc/processo/service/ProcessoValidacaoServiceAcessoTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoValidacaoServiceAcessoTest.java
@@ -132,7 +132,6 @@ class ProcessoValidacaoServiceAcessoTest {
         when(auth.getName()).thenReturn("multi_perfil_user");
         when(auth.getAuthorities()).thenAnswer(m -> List.of(new SimpleGrantedAuthority("ROLE_GESTOR")));
 
-
         // A implementação com bug pegaria apenas o primeiro (1) e negaria o acesso.
         when(usuarioService.buscarPerfisUsuario("multi_perfil_user")).thenReturn(List.of(
                 PerfilDto.builder().unidadeCodigo(1L).build(),
@@ -143,7 +142,6 @@ class ProcessoValidacaoServiceAcessoTest {
         Unidade u200 = UnidadeTestBuilder.umaDe().comCodigo("200").build();
 
         when(unidadeService.todasComHierarquia()).thenReturn(List.of(u100, u200));
-
 
         // Se a lista de IDs conter 200, acesso é permitido. Se tiver apenas 100, negado.
         when(validacaoService.verificarAcessoUnidadeAoProcesso(eq(1L), anyList())).thenAnswer(invocation -> {

--- a/backend/src/test/java/sgc/processo/service/ProcessoWorkflowServicePbtTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoWorkflowServicePbtTest.java
@@ -54,9 +54,7 @@ class ProcessoWorkflowServicePbtTest {
         when(processoValidador.getMensagemErroUnidadesSemMapa(any())).thenReturn(Optional.empty());
         when(processoRepo.findUnidadeCodigosBySituacaoAndUnidadeCodigosIn(any(), any())).thenReturn(List.of());
 
-
         workflowService.iniciar(processo.getCodigo(), codsUnidadesParam, usuario);
-
 
         if (processo.getTipo() == TipoProcesso.MAPEAMENTO) {
             verify(subprocessoService, times(1)).criarParaMapeamento(eq(processo), any(), any(), eq(usuario));

--- a/backend/src/test/java/sgc/relatorio/service/RelatorioFacadeTest.java
+++ b/backend/src/test/java/sgc/relatorio/service/RelatorioFacadeTest.java
@@ -72,7 +72,6 @@ class RelatorioFacadeTest {
         verify(document, atLeastOnce()).add(any());
     }
 
-
     @Test
     @DisplayName("Deve gerar relatório de mapas completo")
     void deveGerarRelatorioMapasCompleto() throws DocumentException {
@@ -143,7 +142,6 @@ class RelatorioFacadeTest {
         verify(document, atLeastOnce()).add(any());
     }
 
-
     @Test
     @DisplayName("Deve processar competência sem atividades")
     void deveProcessarCompetenciaSemAtividades() throws DocumentException {
@@ -201,7 +199,6 @@ class RelatorioFacadeTest {
         verify(document, atLeastOnce()).add(any());
     }
 
-
     @Test
     @DisplayName("Deve cobrir erro ao gerar PDF")
     void deveCobrirErroGerarPdf() throws DocumentException {
@@ -229,6 +226,5 @@ class RelatorioFacadeTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Erro ao gerar PDF");
     }
-
 
 }

--- a/backend/src/test/java/sgc/seguranca/login/GerenciadorJwtTest.java
+++ b/backend/src/test/java/sgc/seguranca/login/GerenciadorJwtTest.java
@@ -154,7 +154,6 @@ class GerenciadorJwtTest {
         // Simular NPE ao acessar o segredo durante a validação
         when(jwtProperties.secret()).thenReturn(null);
 
-
         Optional<GerenciadorJwt.JwtClaims> result = gerenciador.validarToken("any.token");
 
         assertThat(result).isEmpty();

--- a/backend/src/test/java/sgc/seguranca/login/LoginControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/seguranca/login/LoginControllerCoverageTest.java
@@ -41,9 +41,7 @@ class LoginControllerCoverageTest {
         when(loginFacade.autenticar("111111", "senha_errada")).thenReturn(false);
         when(httpRequest.getRemoteAddr()).thenReturn("127.0.0.1");
 
-
         ResponseEntity<Boolean> result = controller.autenticar(request, httpRequest, httpResponse);
-
 
         assertThat(result.getBody()).isFalse();
         verify(httpResponse, never()).addCookie(any()); // Cobertura da linha 64 (branch false)

--- a/backend/src/test/java/sgc/seguranca/login/LoginControllerLogInjectionTest.java
+++ b/backend/src/test/java/sgc/seguranca/login/LoginControllerLogInjectionTest.java
@@ -56,7 +56,6 @@ class LoginControllerLogInjectionTest {
         // O valor original poderia ser algo como: "10.0.0.1\nINFO User logged in as admin"
         String ipMalicioso = "10.0.0.1\nINFO User logged in as admin";
 
-
         AutenticarRequest req = AutenticarRequest.builder()
                 .tituloEleitoral("123")
                 .senha("senha")

--- a/backend/src/test/java/sgc/seguranca/login/dto/AutenticarReqValidationTest.java
+++ b/backend/src/test/java/sgc/seguranca/login/dto/AutenticarReqValidationTest.java
@@ -38,9 +38,7 @@ class AutenticarReqValidationTest {
                 .senha("senha123")
                 .build();
 
-
         Set<ConstraintViolation<AutenticarRequest>> violations = validator.validate(req);
-
 
         assertThat(violations).isEmpty();
     }
@@ -62,9 +60,7 @@ class AutenticarReqValidationTest {
                 .senha(senhaLonga)
                 .build();
 
-
         Set<ConstraintViolation<AutenticarRequest>> violations = validator.validate(req);
-
 
         assertThat(violations).isNotEmpty();
     }

--- a/backend/src/test/java/sgc/subprocesso/dto/MapaAjusteDtoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/dto/MapaAjusteDtoTest.java
@@ -82,7 +82,6 @@ class MapaAjusteDtoTest {
             MapaAjusteDto dto = MapaAjusteDto.of(
                     subprocesso, analise, List.of(comp), List.of(ativ), List.of(con));
 
-
             assertThat(dto.getCompetencias()).hasSize(1);
             CompetenciaAjusteDto compDto = dto.getCompetencias().getFirst();
             assertThat(compDto.getCodCompetencia()).isEqualTo(1L);

--- a/backend/src/test/java/sgc/subprocesso/model/MovimentacaoRepoPerformanceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/MovimentacaoRepoPerformanceTest.java
@@ -74,9 +74,7 @@ class MovimentacaoRepoPerformanceTest {
                 .build();
         movimentacaoRepo.save(m2);
 
-
         List<Movimentacao> result = movimentacaoRepo.findBySubprocessoCodigoOrderByDataHoraDesc(sp.getCodigo());
-
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getDescricao()).isEqualTo("Mov 2");

--- a/backend/src/test/java/sgc/subprocesso/model/MovimentacaoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/MovimentacaoTest.java
@@ -32,5 +32,4 @@ class MovimentacaoTest {
         assertThat(mov.getDataHora()).isEqualTo(agora);
     }
 
-
 }

--- a/backend/src/test/java/sgc/subprocesso/model/SubprocessoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/SubprocessoTest.java
@@ -150,7 +150,6 @@ class SubprocessoTest {
         assertThat(sp.getDataLimiteEtapa1()).isEqualTo(dt);
     }
 
-
     @Test
     @DisplayName("Getters NonNull should return values")
     void gettersNonNull() {

--- a/frontend/src/__tests__/btable-test.spec.ts
+++ b/frontend/src/__tests__/btable-test.spec.ts
@@ -2,12 +2,6 @@ import {describe, it} from "vitest";
 
 describe("BTable experimentation", () => {
     it("checks which prop applies tabindex to tr", () => {
-        
 
-        
-
-        
-
-        
     });
 });

--- a/frontend/src/__tests__/views/HistoricoView.spec.ts
+++ b/frontend/src/__tests__/views/HistoricoView.spec.ts
@@ -27,9 +27,6 @@ vi.mock("vue-router", () => ({
 // Setup components mocks to avoid rendering issues
 // BContainer, BRow, BCol, BCard, BButton are from bootstrap-vue-next
 // Given the errors were "Cannot call vm on an empty VueWrapper", it usually means
-// we tried to find a component that wasn't rendered or wasn't found.
-// The previous test code was trying to find 'TabelaProcessos', but the View code uses a manual table inside BCard.
-// So the test was completely out of sync with the implementation.
 
 describe("HistoricoView.vue", () => {
     const context = setupComponentTest();

--- a/frontend/src/__tests__/views/LoginView.spec.ts
+++ b/frontend/src/__tests__/views/LoginView.spec.ts
@@ -147,7 +147,6 @@ describe("LoginView.vue", () => {
         const wrapper = mount(LoginView, mountOptions());
         const perfilStore = usePerfilStore();
 
-
         perfilStore.loginCompleto = vi.fn().mockResolvedValue(true);
         perfilStore.selecionarPerfilUnidade = vi.fn().mockResolvedValue(true);
         perfilStore.perfisUnidades = MOCK_PERFIS;
@@ -157,7 +156,6 @@ describe("LoginView.vue", () => {
         await wrapper.find('form').trigger('submit');
 
         expect(wrapper.find('[data-testid="sec-login-perfil"]').exists()).toBe(true);
-
 
         // Trigger submit novamente para confirmar seleção
         await wrapper.find('form').trigger('submit');
@@ -253,7 +251,6 @@ describe("LoginView.vue", () => {
         await wrapper.find('[data-testid="inp-login-usuario"]').setValue("123");
         await wrapper.find('[data-testid="inp-login-senha"]').setValue("pass");
         await wrapper.find('form').trigger('submit');
-
 
         expect(wrapper.find('[data-testid="sec-login-perfil"]').exists()).toBe(true);
 

--- a/frontend/src/__tests__/views/PainelViewCoverage.spec.ts
+++ b/frontend/src/__tests__/views/PainelViewCoverage.spec.ts
@@ -69,7 +69,6 @@ describe('PainelView Coverage', () => {
         const processosStore = useProcessosStore(pinia);
         const alertasStore = useAlertasStore(pinia);
 
-        // Wait for onMounted
         await wrapper.vm.$nextTick();
 
         expect(processosStore.buscarProcessosPainel).toHaveBeenCalled();

--- a/frontend/src/components/__tests__/ArvoreUnidadesCoverage.spec.ts
+++ b/frontend/src/components/__tests__/ArvoreUnidadesCoverage.spec.ts
@@ -67,8 +67,5 @@ describe("ArvoreUnidades.vue Coverage", () => {
         // Update modelValue with same values (different reference)
         await wrapper.setProps({modelValue: [1]});
 
-
-        // The test above hit the true case.
-        // This test hits the false case.
     });
 });

--- a/frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts
+++ b/frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts
@@ -39,7 +39,6 @@ const flatten = (nodes: Unidade[]): Unidade[] => {
 describe('ArvoreUnidades Property-Based Tests', () => {
 
     it('should satisfy Monotonicity: Selecting a parent selects all eligible children', () => {
-        // We generate a fixed structure but vary the interactions
         const tree = generateTree(3, 2, 0);
         const allNodes = flatten(tree);
 
@@ -59,9 +58,7 @@ describe('ArvoreUnidades Property-Based Tests', () => {
 
                 const targetNode = allNodes[nodeIndex];
 
-
                 vm.toggle(targetNode, true);
-
 
                 expect(vm.isChecked(targetNode.codigo)).toBe(true);
 
@@ -181,7 +178,6 @@ describe('ArvoreUnidades Property-Based Tests', () => {
 
                     selectedNodes.forEach(node => {
                         expect(node.isElegivel).toBe(true);
-                        // Implicitly checks INTERMEDIARIA is not selected because we forced isElegivel=false for them.
                         expect(node.tipo).not.toBe('INTERMEDIARIA');
                     });
                 }

--- a/frontend/src/components/__tests__/AtividadeItem.spec.ts
+++ b/frontend/src/components/__tests__/AtividadeItem.spec.ts
@@ -29,7 +29,6 @@ describe("AtividadeItem.vue", () => {
         BCol: {template: '<div class="col"><slot /></div>'},
     };
 
-
     it("deve entrar em modo de edição de atividade e salvar", async () => {
         const mountOptions = getCommonMountOptions({}, commonStubs);
         context.wrapper = mount(AtividadeItem, {
@@ -39,7 +38,6 @@ describe("AtividadeItem.vue", () => {
 
         await context.wrapper.find('[data-testid="btn-editar-atividade"]').trigger('click');
 
-        // Check if input appeared (meaning we are in edit mode)
         const input = context.wrapper.find('[data-testid="inp-editar-atividade"]');
         expect(input.exists()).toBe(true);
 

--- a/frontend/src/components/__tests__/DisponibilizarMapaModal.spec.ts
+++ b/frontend/src/components/__tests__/DisponibilizarMapaModal.spec.ts
@@ -166,7 +166,6 @@ describe("DisponibilizarMapaModal.vue", () => {
 
         expect(wrapper.findComponent(BFormInput).props().modelValue).toBe("");
 
-        // Re-find the element to ensure we have the latest state
         const updatedObsTextarea = wrapper.find('[data-testid="inp-disponibilizar-mapa-obs"]');
         expect((updatedObsTextarea.element as HTMLTextAreaElement).value).toBe("");
     });

--- a/frontend/src/components/__tests__/ImportarAtividadesModal.spec.ts
+++ b/frontend/src/components/__tests__/ImportarAtividadesModal.spec.ts
@@ -86,7 +86,6 @@ describe("ImportarAtividadesModal", () => {
         await selects[1].setValue("10");
         await flushPromises();
 
-        // Find and check the checkbox for the activity
         await (wrapper.find('input[type="checkbox"]') as any).setChecked(true);
 
         // Now, the button should be enabled
@@ -115,7 +114,6 @@ describe("ImportarAtividadesModal", () => {
         await wrapper.setProps({mostrar: false});
         await wrapper.setProps({mostrar: true});
 
-        // Check if reset
         expect((wrapper.vm as any).processoSelecionadoId).toBeNull();
     });
 

--- a/frontend/src/components/__tests__/ImportarAtividadesModalCoverage.spec.ts
+++ b/frontend/src/components/__tests__/ImportarAtividadesModalCoverage.spec.ts
@@ -86,7 +86,6 @@ describe("ImportarAtividadesModal Coverage", () => {
 
         vm.unidadeSelecionadaId = 10;
         await flushPromises();
-        // Even if not in list, it might try to find it
         vm.unidadeSelecionadaId = null;
         await flushPromises();
         expect(vm.unidadeSelecionada).toBeNull();

--- a/frontend/src/components/__tests__/MainNavbar.spec.ts
+++ b/frontend/src/components/__tests__/MainNavbar.spec.ts
@@ -75,7 +75,6 @@ describe("MainNavbar.vue", () => {
 
         ctx.wrapper = mount(NavBar, options);
 
-
         // GESTOR vê "Minha unidade" apontando para sua unidade
         checkLink("Minha unidade", "/unidade/456");
     });
@@ -158,7 +157,6 @@ describe("MainNavbar.vue", () => {
         } else {
             await logoutNavItem.trigger("click");
         }
-
 
         expect(mockPush).toHaveBeenCalledWith("/login");
     });

--- a/frontend/src/components/__tests__/ModalAcaoBloco.spec.ts
+++ b/frontend/src/components/__tests__/ModalAcaoBloco.spec.ts
@@ -44,7 +44,6 @@ describe("ModalAcaoBloco.vue", () => {
 
     it("deve inicializar e abrir o modal", async () => {
         const wrapper = createWrapper();
-        // Wait for onMounted
         await wrapper.vm.$nextTick();
 
         (wrapper.vm as any).abrir();

--- a/frontend/src/components/__tests__/TreeTable.spec.ts
+++ b/frontend/src/components/__tests__/TreeTable.spec.ts
@@ -82,7 +82,6 @@ describe("TreeTable.vue", () => {
         const trElements = wrapper.findAll("tbody tr");
         expect(trElements.length).toBeGreaterThan(0);
 
-        // Verify we can find the components
         const treeRows = wrapper.findAllComponents(TreeRowItem);
         expect(treeRows.length).toBeGreaterThan(0);
     });
@@ -124,11 +123,9 @@ describe("TreeTable.vue", () => {
         await wrapper.find("button.btn-outline-primary").trigger("click");
         await wrapper.vm.$nextTick();
 
-        // Verify that more items are now rendered (children are expanded)
         treeRows = wrapper.findAllComponents(TreeRowItem);
         expect(treeRows.length).toBeGreaterThan(initialCount);
 
-        // Verify that the item is expanded
         const expandedItem = (wrapper.vm as any).internalData[0];
         expect(expandedItem.expanded).toBe(true);
     });

--- a/frontend/src/components/comum/InlineEditor.vue
+++ b/frontend/src/components/comum/InlineEditor.vue
@@ -97,7 +97,6 @@ const emit = defineEmits<{
 const isEditing = ref(false);
 const editValue = ref('');
 
-
 function startEdit() {
   editValue.value = props.modelValue;
   isEditing.value = true;

--- a/frontend/src/components/processo/ModalAcaoBloco.vue
+++ b/frontend/src/components/processo/ModalAcaoBloco.vue
@@ -95,7 +95,6 @@ const props = defineProps<{
   mostrarDataLimite?: boolean;
 }>();
 
-
 const emit = defineEmits<{
   'confirmar': [dados: { ids: number[], dataLimite?: string }];
 }>();

--- a/frontend/src/components/processo/SubprocessoCards.stories.ts
+++ b/frontend/src/components/processo/SubprocessoCards.stories.ts
@@ -17,7 +17,6 @@ const meta: Meta<typeof SubprocessoCards> = {
 export default meta;
 type Story = StoryObj<typeof SubprocessoCards>;
 
-
 const mockMapa = {
     codigo: 1,
     descricao: 'Mapa Teste',

--- a/frontend/src/components/processo/SubprocessoCards.vue
+++ b/frontend/src/components/processo/SubprocessoCards.vue
@@ -266,7 +266,6 @@ defineExpose({
   cursor: not-allowed;
 }
 
-/* Ensure hover effect doesn't happen on disabled cards */
 .card-actionable.disabled-card:hover {
   transform: none;
   box-shadow: none;

--- a/frontend/src/router/__tests__/router.spec.ts
+++ b/frontend/src/router/__tests__/router.spec.ts
@@ -22,7 +22,6 @@ vi.mock("@/views/UnidadesView.vue", () => ({default: {name: 'UnidadesView'}}));
 vi.mock("@/views/UnidadeView.vue", () => ({default: {name: 'UnidadeView'}}));
 vi.mock("@/views/AtribuicaoTemporariaView.vue", () => ({default: {name: 'AtribuicaoTemporariaView'}}));
 
-
 vi.mock('@/stores/perfil', () => ({
     usePerfilStore: vi.fn(),
 }));

--- a/frontend/src/services/__tests__/painelService.spec.ts
+++ b/frontend/src/services/__tests__/painelService.spec.ts
@@ -94,7 +94,6 @@ describe("painelService", () => {
             });
         });
 
-
         testErrorHandling(() => service.listarAlertas("123"));
     });
 });

--- a/frontend/src/services/__tests__/subprocessoService.spec.ts
+++ b/frontend/src/services/__tests__/subprocessoService.spec.ts
@@ -30,7 +30,6 @@ describe("subprocessoService", () => {
         expect(apiClient.get).toHaveBeenCalledWith("/subprocessos/1/contexto-edicao");
     });
 
-
     it("validarCadastro chama o endpoint correto", async () => {
         vi.mocked(apiClient.get).mockResolvedValue({data: {}});
         await service.validarCadastro(1);

--- a/frontend/src/services/processoService.ts
+++ b/frontend/src/services/processoService.ts
@@ -37,7 +37,6 @@ export function mapProcessoDetalheDtoToFrontend(dto: ProcessoDetalheDto): Proces
     } as Processo;
 }
 
-
 export async function criarProcesso(
     request: CriarProcessoRequest,
 ): Promise<Processo> {

--- a/frontend/src/services/subprocessoService.ts
+++ b/frontend/src/services/subprocessoService.ts
@@ -19,7 +19,6 @@ interface ImportarAtividadesRequest {
     codigosAtividades?: number[];
 }
 
-
 export async function importarAtividades(
     codSubprocessoDestino: number,
     codSubprocessoOrigem: number,

--- a/frontend/src/services/unidadeService.ts
+++ b/frontend/src/services/unidadeService.ts
@@ -49,7 +49,6 @@ export function mapUnidadesArray(arr: any[] = []): Unidade[] {
     return arr.map(mapUnidade);
 }
 
-
 export async function buscarTodasUnidades() {
     return apiGet("/unidades");
 }

--- a/frontend/src/services/usuarioService.ts
+++ b/frontend/src/services/usuarioService.ts
@@ -115,8 +115,6 @@ export function mapVWUsuariosArray(arr: any[] = []): Usuario[] {
     return arr.map(mapVWUsuarioToUsuario);
 }
 
-
-
 export async function autenticar(
     request: AutenticacaoRequest,
 ): Promise<boolean> {

--- a/frontend/src/stores/__tests__/atribuicoes.spec.ts
+++ b/frontend/src/stores/__tests__/atribuicoes.spec.ts
@@ -115,7 +115,6 @@ describe("useAtribuicaoTemporariaStore", () => {
     });
 
     describe("getters", () => {
-        // Populating store manually for getter tests
         beforeEach(() => {
             context.store.atribuicoes = [
                 {

--- a/frontend/src/stores/__tests__/processos.spec.ts
+++ b/frontend/src/stores/__tests__/processos.spec.ts
@@ -492,7 +492,6 @@ describe("useProcessosStore", () => {
             });
         });
 
-
         describe("executarAcaoBloco", () => {
             const MOCK_PROCESSO_WITH_UNITS = {
                 codigo: 1,

--- a/frontend/src/stores/subprocessos.ts
+++ b/frontend/src/stores/subprocessos.ts
@@ -203,7 +203,6 @@ export const useSubprocessosStore = defineStore("subprocessos", () => {
         );
     }
 
-
     return {
         subprocessoDetalhe,
         lastError,

--- a/frontend/src/test-utils/__tests__/helpers.spec.ts
+++ b/frontend/src/test-utils/__tests__/helpers.spec.ts
@@ -31,7 +31,6 @@ describe("test-utils/helpers", () => {
     it("prepareFreshAtividadesStore deve retornar uma store com dados", async () => {
         const store = await prepareFreshAtividadesStore();
         expect(store).toBeDefined();
-        // Since we populate with ID 1
         expect(store.atividadesPorSubprocesso.get(1)).toBeDefined();
         expect(store.atividadesPorSubprocesso.get(1).length).toBeGreaterThan(0);
     });

--- a/frontend/src/test-utils/mockFactories.ts
+++ b/frontend/src/test-utils/mockFactories.ts
@@ -3,9 +3,6 @@
  */
 import {ProcessoResumo, SituacaoProcesso, TipoProcesso} from '@/types/tipos';
 
-/**
- * Creates a mock ProcessoResumo object with default values
- */
 export function createMockProcessoResumo(overrides: Partial<ProcessoResumo> = {}): ProcessoResumo {
     return {
         codigo: 1,

--- a/frontend/src/types/tipos.ts
+++ b/frontend/src/types/tipos.ts
@@ -271,7 +271,6 @@ export interface UnidadeParticipante {
     filhos: UnidadeParticipante[];
 }
 
-
 export interface PermissoesSubprocesso {
     podeEditarCadastro: boolean;
     podeDisponibilizarCadastro: boolean;
@@ -317,7 +316,6 @@ export interface SubprocessoDetalhe {
     elementosProcesso: any[];
     permissoes: PermissoesSubprocesso;
 }
-
 
 export interface MapaVisualizacao {
     codigo: number;
@@ -391,7 +389,6 @@ export interface SubprocessoElegivel {
     unidadeSigla: string;
     situacao: SituacaoSubprocesso;
 }
-
 
 export interface ErroValidacao {
     tipo: string;

--- a/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
+++ b/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
@@ -115,7 +115,6 @@ function createWrapper(customState = {}, accessOverrides = {}) {
         }
     });
 
-    // Manually set codSubprocesso to ensure buttons depending on it are rendered
     (wrapper.vm as any).codSubprocesso = 123;
 
     return wrapper;

--- a/frontend/src/views/__tests__/CadAtividades.spec.ts
+++ b/frontend/src/views/__tests__/CadAtividades.spec.ts
@@ -229,7 +229,6 @@ describe("CadastroView.vue", () => {
         expect(wrapper.findAllComponents(AtividadeItemStub)).toHaveLength(1);
     });
 
-    // Test case removed/simplified because asserting focus on stubs in VTU/JSDOM is flaky without specific setup
     it("deve adicionar nova atividade", async () => {
         const {wrapper, atividadesStore} = createWrapper();
         await flushPromises();
@@ -245,7 +244,6 @@ describe("CadastroView.vue", () => {
             {descricao: "Nova Atividade"}
         );
 
-        // Check if value was cleared (indicating success flow completed)
         expect(input.element.value).toBe('');
     });
 

--- a/frontend/src/views/__tests__/CadAtividadesCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadAtividadesCoverage.spec.ts
@@ -94,7 +94,6 @@ describe('CadastroView.vue Coverage', () => {
             {codigo: 1, descricao: 'Atividade 1', conhecimentos: []}
         ]);
 
-        // Trigger onMounted manually if needed or just wait
         await flushPromises();
         (wrapper.vm as any).codSubprocesso = 123; // Force set
         await wrapper.vm.$nextTick();

--- a/frontend/src/views/__tests__/CadMapa.spec.ts
+++ b/frontend/src/views/__tests__/CadMapa.spec.ts
@@ -60,7 +60,6 @@ vi.mock("@/services/unidadeService", () => ({
     buscarUnidadePorSigla: vi.fn(),
 }));
 
-
 vi.mock("@/components/mapa/CriarCompetenciaModal.vue", () => ({
     __esModule: true,
     default: {
@@ -167,7 +166,6 @@ const CompetenciaCardStub = {
     `,
     emits: ['editar', 'excluir', 'remover-atividade']
 };
-
 
 describe("MapaView.vue", () => {
     const mockAtividades = [

--- a/frontend/src/views/__tests__/CadProcesso.spec.ts
+++ b/frontend/src/views/__tests__/CadProcesso.spec.ts
@@ -144,7 +144,6 @@ describe('ProcessoCadastroView.vue', () => {
         wrapper.vm.unidadesSelecionadas = [1];
         await nextTick();
 
-        // Still disabled because tipo is null
         expect((salvarBtn.element as HTMLButtonElement).disabled).toBe(true);
 
         // Select type
@@ -476,7 +475,6 @@ describe('ProcessoCadastroView.vue', () => {
         expect(wrapper.vm.fieldErrors.unidades).toBe('');
     });
 
-
     it('shows loading spinner when units are loading', async () => {
         const {wrapper} = createWrapper({
             unidades: {
@@ -489,7 +487,6 @@ describe('ProcessoCadastroView.vue', () => {
 
     it('shows alert with multiple errors', async () => {
         const {wrapper} = createWrapper();
-        // Trigger alert manually or via error handling
         (wrapper.vm as any).mostrarAlerta('danger', 'Titulo', 'Corpo', ['Erro 1', 'Erro 2']);
         await nextTick();
 
@@ -572,9 +569,7 @@ describe('ProcessoCadastroView.vue', () => {
 
         await wrapper.find('[data-testid="btn-processo-salvar"]').trigger('click');
 
-        // Wait for async operations and nextTick inside handleApiErrors
         await flushPromises();
-        // The focus logic is inside a nextTick, so we need to wait for it
         await nextTick();
         await nextTick();
 

--- a/frontend/src/views/__tests__/CadProcessoCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadProcessoCoverage.spec.ts
@@ -136,7 +136,6 @@ describe('ProcessoCadastroView.vue Coverage', () => {
     it('handles error creating process during initiation flow (without existing process)', async () => {
         const {wrapper, processosStore} = createWrapper();
 
-        // Fill form using setValue to ensure reactivity triggers validation
         await wrapper.find('[data-testid="inp-processo-descricao"]').setValue('Teste Inicio');
         wrapper.vm.tipo = 'MAPEAMENTO';
         wrapper.vm.unidadesSelecionadas = [1];

--- a/frontend/src/views/__tests__/HistoricoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/HistoricoViewCoverage.spec.ts
@@ -16,7 +16,6 @@ describe("HistoricoView Coverage", () => {
             ],
         });
 
-        // We mock push but we need the router to be functional for initial render
         const pushSpy = vi.spyOn(router, "push");
 
         const wrapper = mount(HistoricoView, {
@@ -50,7 +49,6 @@ describe("HistoricoView Coverage", () => {
         const store = useProcessosStore();
         expect(store.processosFinalizados).toHaveLength(1);
 
-        // Find the row
         const row = wrapper.find("tbody tr.row-processo-1");
         expect(row.exists()).toBe(true);
         expect(row.text()).toContain("Processo Teste");

--- a/frontend/src/views/__tests__/ProcessoView.spec.ts
+++ b/frontend/src/views/__tests__/ProcessoView.spec.ts
@@ -211,7 +211,6 @@ describe("Processo.vue", () => {
         await nextTick();
         await flushPromises();
 
-        // Check if buttons exist directly as the container class might have changed
         const btnAceitar = wrapper.find("button.btn-success");
         expect(btnAceitar.exists()).toBe(true);
         expect(btnAceitar.text()).toContain("Aceitar em bloco");
@@ -267,7 +266,6 @@ describe("Processo.vue", () => {
         expect(modal.props("titulo")).toBe("Aceitar em Bloco");
     });
 
-
     it("deve executar ação em bloco com sucesso (Aceitar Cadastro)", async () => {
         wrapper = createWrapper();
         perfilStore = usePerfilStore();
@@ -315,7 +313,6 @@ describe("Processo.vue", () => {
         expect(processosStore.executarAcaoBloco).toHaveBeenCalledWith('aceitar', [103], undefined);
     });
 
-
     it("deve executar ação em bloco com sucesso (Homologar Cadastro)", async () => {
         wrapper = createWrapper();
         perfilStore = usePerfilStore();
@@ -353,7 +350,6 @@ describe("Processo.vue", () => {
 
         expect(processosStore.executarAcaoBloco).toHaveBeenCalledWith('homologar', [103], undefined);
     });
-
 
     it("deve executar ação em bloco com sucesso (Disponibilizar)", async () => {
         wrapper = createWrapper();
@@ -518,7 +514,6 @@ describe("Processo.vue", () => {
             }
         });
     });
-
 
     it("deve abrir modal de finalização de processo", async () => {
         wrapper = createWrapper();

--- a/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
@@ -102,7 +102,6 @@ describe("ProcessoViewCoverage.spec.ts", () => {
         }
 
         processosStore = useProcessosStore(pinia) as any;
-        // Ensure action returns promise
         (processosStore.buscarContextoCompleto as any).mockResolvedValue({});
         (processosStore.finalizarProcesso as any).mockResolvedValue({});
         (processosStore.executarAcaoBloco as any).mockResolvedValue({});
@@ -208,7 +207,6 @@ describe("ProcessoViewCoverage.spec.ts", () => {
             params: {codProcesso: "1", siglaUnidade: "U1"}
         }));
     });
-
 
     it("deve lidar com erro na ação em bloco", async () => {
         const wrapper = createWrapper({

--- a/frontend/src/views/__tests__/SubprocessoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/SubprocessoViewCoverage.spec.ts
@@ -147,7 +147,6 @@ describe('SubprocessoView Coverage', () => {
             props: {codProcesso: 1, siglaUnidade: 'TEST'}
         });
 
-        // Trigger manually
         await (wrapper.vm as any).confirmarAlteracaoDataLimite('');
 
         expect(store.alterarDataLimiteSubprocesso).not.toHaveBeenCalled();
@@ -195,9 +194,7 @@ describe('SubprocessoView Coverage', () => {
             props: {codProcesso: 1, siglaUnidade: 'TEST'}
         });
 
-        // Wait for onMounted to set codSubprocesso
         await (wrapper.vm as any).$nextTick();
-
 
         // Call with empty justification
         (wrapper.vm as any).justificativaReabertura = '';

--- a/frontend/src/views/__tests__/UnidadeView.spec.ts
+++ b/frontend/src/views/__tests__/UnidadeView.spec.ts
@@ -102,7 +102,6 @@ describe('UnidadeView.vue', () => {
 
     const mockUnidade = mockUnidadeData;
 
-
     const createWrapper = (initialStateOverride = {}) => {
         context.wrapper = mount(UnidadeView, {
             ...getCommonMountOptions(
@@ -273,7 +272,6 @@ describe('UnidadeView.vue', () => {
 
     it('displays error alert when unidadesStore has error', async () => {
         const {wrapper, unidadesStore} = createWrapper();
-        // Since createTestingPinia is used, we can directly modify state or use patch
         unidadesStore.lastError = {message: 'Erro ao carregar unidade'};
         await wrapper.vm.$nextTick();
 
@@ -331,7 +329,6 @@ describe('UnidadeView.vue', () => {
         expect(emailLink.attributes('aria-label')).toBe('Enviar e-mail para test@example.com');
     });
 
-
     it('handles unit with no children safely', async () => {
         const mockUnidadeSemFilhas = {
             ...mockUnidade,
@@ -345,7 +342,6 @@ describe('UnidadeView.vue', () => {
 
         expect(unidadesStore.unidade.filhas).toHaveLength(0);
 
-        // Access computed property explicitly to ensure coverage
         expect((wrapper.vm).dadosFormatadosSubordinadas).toEqual([]);
 
         // Should check that TreeTable is not rendered or data is empty


### PR DESCRIPTION
Ran a comprehensive cleanup script to remove conversational comments, AI-generated explanations, obvious descriptions, and redundant Javadoc/JSDoc tags from both the backend (Java) and frontend (Vue/TypeScript). Kept important inline logic comments intact. Reverted test files that strictly relied on certain lines to prevent breakages, and cleaned up temporary cleanup scripts.

---
*PR created automatically by Jules for task [17868344546719199408](https://jules.google.com/task/17868344546719199408) started by @lgalvao*