### PR TITLE
Port PR 1301 to main

### DIFF
--- a/backend/src/main/java/sgc/e2e/E2eController.java
+++ b/backend/src/main/java/sgc/e2e/E2eController.java
@@ -175,6 +175,7 @@ public class E2eController {
                         + SQL_SUBPROCESSO_POR_PROCESSO,
                 codigo);
 
+
         if (!mapaIds.isEmpty()) {
             Map<String, Object> params = Map.of("ids", mapaIds);
 
@@ -240,9 +241,14 @@ public class E2eController {
         // Mapa
         Long mapaId = jdbcTemplate.queryForObject("SELECT codigo FROM sgc.mapa WHERE subprocesso_codigo = ?", Long.class, subId);
         
-        // Atividades
+        // Atividades com conhecimentos associados
         jdbcTemplate.update("INSERT INTO sgc.atividade (mapa_codigo, descricao) VALUES (?, ?)", mapaId, "Atividade Origem A - " + procId);
         jdbcTemplate.update("INSERT INTO sgc.atividade (mapa_codigo, descricao) VALUES (?, ?)", mapaId, "Atividade Origem B - " + procId);
+
+        jdbcTemplate.update("INSERT INTO sgc.conhecimento (atividade_codigo, descricao) SELECT codigo, ? FROM sgc.atividade WHERE mapa_codigo = ? AND descricao = ?",
+                "Conhecimento A - " + procId, mapaId, "Atividade Origem A - " + procId);
+        jdbcTemplate.update("INSERT INTO sgc.conhecimento (atividade_codigo, descricao) SELECT codigo, ? FROM sgc.atividade WHERE mapa_codigo = ? AND descricao = ?",
+                "Conhecimento B - " + procId, mapaId, "Atividade Origem B - " + procId);
 
         // Atualizar status para simular finalização
         jdbcTemplate.update("UPDATE sgc.subprocesso SET situacao = 'MAPEAMENTO_MAPA_HOMOLOGADO' WHERE codigo = ?", subId);

--- a/backend/src/main/java/sgc/mapa/service/CopiaMapaService.java
+++ b/backend/src/main/java/sgc/mapa/service/CopiaMapaService.java
@@ -33,7 +33,7 @@ public class CopiaMapaService {
     }
 
     @Transactional
-    public void importarAtividadesDeOutroMapa(Long mapaOrigemId, Long mapaDestinoId, List<Long> codigosAtividades) {
+    public int importarAtividadesDeOutroMapa(Long mapaOrigemId, Long mapaDestinoId, List<Long> codigosAtividades) {
         List<Atividade> atividadesOrigem = atividadeRepo.findWithConhecimentosByMapa_Codigo(mapaOrigemId);
 
         if (codigosAtividades != null && !codigosAtividades.isEmpty()) {
@@ -58,6 +58,7 @@ public class CopiaMapaService {
                 .toList();
 
         if (!atividadesParaSalvar.isEmpty()) atividadeRepo.saveAll(atividadesParaSalvar);
+        return atividadesParaSalvar.size();
     }
 
     private Mapa criarNovoMapa() {

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoService.java
@@ -221,6 +221,7 @@ public class SubprocessoService {
         return (destino != null) ? destino : sp.getUnidade();
     }
 
+
     @Transactional
     public void atualizarParaEmAndamento(Long mapaCodigo) {
         var subprocesso = subprocessoRepo.findByMapa_Codigo(mapaCodigo).orElseThrow();
@@ -435,6 +436,7 @@ public class SubprocessoService {
                 SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO);
         return sp;
     }
+
 
     @Transactional
     public void salvarAjustesMapa(Long codSubprocesso, List<CompetenciaAjusteDto> competencias) {
@@ -692,9 +694,12 @@ public class SubprocessoService {
 
         Long codMapaOrigem = spOrigem.getMapa().getCodigo();
         Long codMapaDestino = spDestino.getMapa().getCodigo();
-        int qtdAtividades = codigosAtividades != null ? codigosAtividades.size() : 0;
-        log.info("Importando {} atividades do mapa #{} para o mapa #{}", qtdAtividades, codMapaOrigem, codMapaDestino);
-        copiaMapaService.importarAtividadesDeOutroMapa(codMapaOrigem, codMapaDestino, codigosAtividades);
+        log.info("Importando {} atividades do mapa #{} para o mapa #{}", codigosAtividades != null ? codigosAtividades.size() : "todas as", codMapaOrigem, codMapaDestino);
+        int importadas = copiaMapaService.importarAtividadesDeOutroMapa(codMapaOrigem, codMapaDestino, codigosAtividades);
+
+        if (importadas == 0 && codigosAtividades != null && !codigosAtividades.isEmpty()) {
+            throw new ErroValidacao("Uma ou mais atividades selecionadas já existentes no cadastro não puderam ser importadas.");
+        }
 
         if (spDestino.getSituacao() == SituacaoSubprocesso.NAO_INICIADO) {
             var tipoProcesso = spDestino.getProcesso().getTipo();
@@ -762,6 +767,7 @@ public class SubprocessoService {
                 .toList();
     }
 
+
     @Transactional(readOnly = true)
     public List<AnaliseHistoricoDto> listarHistoricoCadastro(Long codSubprocesso) {
         return listarAnalisesPorSubprocesso(codSubprocesso).stream()
@@ -792,5 +798,6 @@ public class SubprocessoService {
                 .tipo(analise.getTipo())
                 .build();
     }
+
 
 }

--- a/backend/src/test/java/sgc/e2e/E2eControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/e2e/E2eControllerCoverageTest.java
@@ -25,6 +25,7 @@ class E2eControllerCoverageTest {
 
         when(jdbcTemplate.getDataSource()).thenReturn(null);
 
+
         controller.resetDatabase();
 
         // Assert - Não deve lançar exceção nem fazer nada (cobertura da linha 62)

--- a/backend/src/test/java/sgc/integracao/CDU08IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU08IntegrationTest.java
@@ -51,6 +51,7 @@ class CDU08IntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void setUp() {
 
+
         Unidade raiz = unidadeRepo.findById(1L).orElseThrow();
         Unidade unidadeOrigem = UnidadeFixture.unidadePadrao();
         unidadeOrigem.setCodigo(null);
@@ -65,6 +66,7 @@ class CDU08IntegrationTest extends BaseIntegrationTest {
         unidadeDestino.setNome("Unidade Destino");
         unidadeDestino.setUnidadeSuperior(raiz);
         unidadeDestino = unidadeRepo.save(unidadeDestino);
+
 
         chefe = UsuarioFixture.usuarioPadrao();
         chefe.setTituloEleitoral("888888888888");
@@ -290,6 +292,37 @@ class CDU08IntegrationTest extends BaseIntegrationTest {
             assertThat(atividadesDestino).hasSize(2);
             assertThat(atividadesDestino.stream().map(Atividade::getDescricao).toList())
                     .containsExactlyInAnyOrder("Atividade 1", "Atividade 2");
+        }
+
+        @Test
+        @DisplayName("Deve retornar erro ao importar atividades já existentes no destino (duplicidade)")
+        void deveRetornarErroAoImportarAtividadesJaExistentes() throws Exception {
+            List<Atividade> atividadesOrigem =
+                    atividadeRepo.findByMapa_Codigo(subprocessoOrigem.getMapa().getCodigo());
+
+            Atividade atividadeDuplicada = atividadesOrigem.getFirst();
+
+            Atividade atividadeExistente =
+                    Atividade.builder()
+                            .mapa(subprocessoDestino.getMapa())
+                            .descricao(atividadeDuplicada.getDescricao())
+                            .build();
+            atividadeRepo.save(atividadeExistente);
+
+            ImportarAtividadesRequest request =
+                    new ImportarAtividadesRequest(
+                            subprocessoOrigem.getCodigo(), List.of(atividadeDuplicada.getCodigo()));
+
+            mockMvc.perform(
+                            post(
+                                    "/api/subprocessos/{id}/importar-atividades",
+                                    subprocessoDestino.getCodigo())
+                                    .with(user(chefe))
+                                    .with(csrf())
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnprocessableContent())
+                    .andExpect(jsonPath("$.message", containsString("já existentes no cadastro")));
         }
     }
 }

--- a/backend/src/test/java/sgc/mapa/service/CopiaMapaServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/mapa/service/CopiaMapaServiceCoverageTest.java
@@ -58,7 +58,9 @@ class CopiaMapaServiceCoverageTest {
 
         when(competenciaRepo.findByMapa_Codigo(codMapaOrigem)).thenReturn(List.of(compFonte));
 
+
         service.copiarMapaParaUnidade(codMapaOrigem);
+
 
         verify(competenciaRepo).saveAll(anyList());
     }
@@ -79,7 +81,9 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of()); // Destino vazio
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
+
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, null);
+
 
         verify(atividadeRepo).saveAll(anyList());
     }
@@ -100,7 +104,9 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of());
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
+
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, List.of(10L));
+
 
         verify(atividadeRepo).saveAll(atividadesCaptor.capture());
         assertThat(atividadesCaptor.getValue()).hasSize(1);
@@ -121,8 +127,10 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of());
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
+
         // ID 999 não existe no mapa de origem — deve ser ignorado sem lançar exceção
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, List.of(999L));
+
 
         verify(atividadeRepo, never()).saveAll(anyList());
     }
@@ -141,7 +149,9 @@ class CopiaMapaServiceCoverageTest {
         when(atividadeRepo.findByMapa_Codigo(mapaDestinoId)).thenReturn(List.of(ativDestino));
         when(repo.buscar(Mapa.class, mapaDestinoId)).thenReturn(new Mapa());
 
+
         service.importarAtividadesDeOutroMapa(mapaOrigemId, mapaDestinoId, null);
+
 
         verify(atividadeRepo, never()).saveAll(anyList());
     }


### PR DESCRIPTION
Ported the exact required fixes from PR 1301 which resolved the issue that duplicate activity import silently succeeded instead of returning a 422 error, and added knowledge to fixture for activities. Due to an issue with `.patch` causing massive conflicts via `git cherry-pick` and `git merge`, it was ported in directly. All `cdu08` e2e tests and backend integration tests passed safely.

---
*PR created automatically by Jules for task [2510988922269159787](https://jules.google.com/task/2510988922269159787) started by @lgalvao*