### PR TITLE
chore: remove unnecessary comments

### DIFF
--- a/backend/src/test/java/sgc/e2e/E2eControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/e2e/E2eControllerCoverageTest.java
@@ -28,7 +28,6 @@ class E2eControllerCoverageTest {
 
         controller.resetDatabase();
 
-        // Assert - Não deve lançar exceção nem fazer nada (cobertura da linha 62)
         verify(jdbcTemplate).getDataSource();
     }
 

--- a/backend/src/test/java/sgc/integracao/CDU01IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU01IntegrationTest.java
@@ -43,14 +43,12 @@ class CDU01IntegrationTest extends BaseIntegrationTest {
     @BeforeEach
     void setUp() {
 
-        // Setup Unidade Admin
         unidadeAdmin = UnidadeFixture.unidadePadrao();
         unidadeAdmin.setCodigo(null);
         unidadeAdmin.setSigla("ADM-UNIT-TEST");
         unidadeAdmin.setNome("Unidade Admin Teste");
         unidadeAdmin = unidadeRepo.saveAndFlush(unidadeAdmin);
 
-        // Setup Usuario Admin
         usuarioAdmin = UsuarioFixture.usuarioComPerfil(unidadeAdmin, Perfil.ADMIN);
         usuarioAdmin.setTituloEleitoral("999999990001");
         usuarioAdmin.setNome("Admin User Teste");
@@ -61,14 +59,12 @@ class CDU01IntegrationTest extends BaseIntegrationTest {
                 "INSERT INTO SGC.VW_USUARIO_PERFIL_UNIDADE (usuario_titulo, perfil, unidade_codigo) VALUES (?, ?, ?)",
                 usuarioAdmin.getTituloEleitoral(), "ADMIN", unidadeAdmin.getCodigo());
 
-        // Setup Unidade Gestor
         unidadeGestor = UnidadeFixture.unidadePadrao();
         unidadeGestor.setCodigo(null);
         unidadeGestor.setSigla("GES-UNIT-TEST");
         unidadeGestor.setNome("Unidade Gestor Teste");
         unidadeGestor = unidadeRepo.saveAndFlush(unidadeGestor);
 
-        // Setup Usuario Gestor
         usuarioGestor = UsuarioFixture.usuarioPadrao();
         usuarioGestor.setTituloEleitoral("999999990002");
         usuarioGestor.setNome("Gestor User Teste");

--- a/backend/src/test/java/sgc/integracao/CDU02IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU02IntegrationTest.java
@@ -50,7 +50,6 @@ class CDU02IntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void setup() {
-        // Setup Programático - Não depende do data.sql
 
         // Raiz
         unidadeRaiz = UnidadeFixture.unidadePadrao();

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceContextoIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceContextoIntegrationTest.java
@@ -161,7 +161,6 @@ class SubprocessoServiceContextoIntegrationTest extends BaseIntegrationTest {
     @DisplayName("obterPermissoesUI: Deve testar visualização de impacto em REVISAO")
     void obterPermissoesUI_VisualizarImpacto() {
         // Unidade 8 established in data.sql has a mapping in UNIDADE_MAPA (mapa_vigente_codigo=1)
-        // This should make temMapaVigente=true
         
         admin.setPerfilAtivo(Perfil.ADMIN);
         subprocesso.setSituacaoForcada(SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA);

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceEmailIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceEmailIntegrationTest.java
@@ -56,7 +56,6 @@ class SubprocessoServiceEmailIntegrationTest extends BaseIntegrationTest {
 
         admin = usuarioRepo.findById("111111111111").orElseThrow();
 
-        // Setup Responsabilidade for units using JDBC to bypass Hibernate @Immutable / null identifier issues
         jdbcTemplate.update(
                 "INSERT INTO sgc.vw_responsabilidade (unidade_codigo, usuario_titulo, usuario_matricula, tipo, data_inicio) VALUES (?, ?, ?, ?, ?)",
                 unidade.getCodigo(), admin.getTituloEleitoral(), admin.getMatricula(), "TITULAR", LocalDateTime.now()

--- a/backend/src/test/java/sgc/mapa/MapaControllerTest.java
+++ b/backend/src/test/java/sgc/mapa/MapaControllerTest.java
@@ -101,7 +101,6 @@ class MapaControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(mapa)))
                 .andExpect(status().isCreated())
-                // Assert suffix instead of exact match to ignore host/port differences
                 .andExpect(header().string("Location", org.hamcrest.Matchers.endsWith(API_MAPAS_1)));
     }
 

--- a/backend/src/test/java/sgc/organizacao/UnidadeControllerTest.java
+++ b/backend/src/test/java/sgc/organizacao/UnidadeControllerTest.java
@@ -76,7 +76,6 @@ class UnidadeControllerTest {
 
         when(hierarquiaService.buscarArvoreHierarquica()).thenReturn(Collections.emptyList());
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
@@ -93,7 +92,6 @@ class UnidadeControllerTest {
         when(hierarquiaService.buscarArvoreComElegibilidade(anyBoolean(), any()))
                 .thenReturn(Collections.emptyList());
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/arvore-com-elegibilidade")
                         .param("tipoProcesso", "MAPEAMENTO"))
                 .andExpect(status().isOk());
@@ -106,7 +104,6 @@ class UnidadeControllerTest {
 
         when(unidadeService.verificarMapaVigente(1L)).thenReturn(true);
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/1/mapa-vigente"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.temMapaVigente").value(true));
@@ -124,7 +121,6 @@ class UnidadeControllerTest {
                 .build();
         when(usuarioServiceBean.buscarPorUnidadeLotacao(1L)).thenReturn(List.of(usuario));
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/1/usuarios")).andExpect(status().isOk());
     }
 
@@ -138,7 +134,6 @@ class UnidadeControllerTest {
         u.setTipo(TipoUnidade.OPERACIONAL);
         when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(u);
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/sigla/SIGLA")).andExpect(status().isOk());
     }
 
@@ -152,7 +147,6 @@ class UnidadeControllerTest {
         un.setTipo(TipoUnidade.OPERACIONAL);
         when(unidadeService.buscarPorId(1L)).thenReturn(un);
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/1")).andExpect(status().isOk());
     }
 
@@ -163,7 +157,6 @@ class UnidadeControllerTest {
 
         when(hierarquiaService.buscarArvore(1L)).thenReturn(UnidadeDto.builder().build());
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/1/arvore"))
                 .andExpect(status().isOk());
     }
@@ -175,7 +168,6 @@ class UnidadeControllerTest {
 
         when(hierarquiaService.buscarSiglasSubordinadas("SIGLA")).thenReturn(List.of("SIGLA", "FILHA"));
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/sigla/SIGLA/subordinadas"))
                 .andExpect(status().isOk());
     }
@@ -187,7 +179,6 @@ class UnidadeControllerTest {
 
         when(hierarquiaService.buscarSiglaSuperior("FILHA")).thenReturn(Optional.of("SIGLA"));
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/sigla/FILHA/superior"))
                 .andExpect(status().isOk());
     }
@@ -199,7 +190,6 @@ class UnidadeControllerTest {
 
         when(hierarquiaService.buscarSiglaSuperior("RAIZ")).thenReturn(Optional.empty());
 
-        // Act & Assert
         mockMvc.perform(get("/api/unidades/sigla/RAIZ/superior"))
                 .andExpect(status().isNoContent());
     }

--- a/backend/src/test/java/sgc/processo/model/ProcessoTest.java
+++ b/backend/src/test/java/sgc/processo/model/ProcessoTest.java
@@ -224,7 +224,6 @@ class ProcessoTest {
         @Test
         @DisplayName("Deve permitir todas as situações válidas")
         void devePermitirTodasAsSituacoesValidas() {
-            // Arrange & Act & Assert
             for (SituacaoProcesso situacao : SituacaoProcesso.values()) {
                 processo.setSituacao(situacao);
                 assertThat(processo.getSituacao()).isEqualTo(situacao);
@@ -234,7 +233,6 @@ class ProcessoTest {
         @Test
         @DisplayName("Deve permitir todos os tipos válidos")
         void devePermitirTodosOsTiposValidos() {
-            // Arrange & Act & Assert
             for (TipoProcesso tipo : TipoProcesso.values()) {
                 processo.setTipo(tipo);
                 assertThat(processo.getTipo()).isEqualTo(tipo);

--- a/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServicePbtTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoManutencaoServicePbtTest.java
@@ -36,7 +36,6 @@ class ProcessoManutencaoServicePbtTest {
         });
         when(processoValidador.getMensagemErroUnidadesSemMapa(any())).thenReturn(Optional.of("Erro: Unidade sem mapa"));
 
-        // Act & Assert
         assertThatThrownBy(() -> service.criar(req))
                 .isInstanceOf(ErroValidacao.class)
                 .hasMessage("Erro: Unidade sem mapa");
@@ -86,7 +85,6 @@ class ProcessoManutencaoServicePbtTest {
 
         when(processoConsultaService.buscarProcessoCodigo(anyLong())).thenReturn(processo);
 
-        // Act & Assert
         assertThatThrownBy(() -> service.atualizar(1L, req))
                 .isInstanceOf(ErroValidacao.class)
                 .hasMessage("Apenas processos na situação 'CRIADO' podem ser editados.");
@@ -109,7 +107,6 @@ class ProcessoManutencaoServicePbtTest {
 
         when(processoConsultaService.buscarProcessoCodigo(anyLong())).thenReturn(processo);
 
-        // Act & Assert
         assertThatThrownBy(() -> service.apagar(1L))
                 .isInstanceOf(ErroValidacao.class)
                 .hasMessage("Apenas processos na situação 'CRIADO' podem ser removidos.");

--- a/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoNotificacaoServiceCoverageTest.java
@@ -126,7 +126,6 @@ class ProcessoNotificacaoServiceCoverageTest {
         sub.setSituacao(SituacaoUnidade.ATIVA);
         sub.setUnidadeSuperior(inter);
 
-        // Setup para processarFinalizacaoProcesso
         p.adicionarParticipantes(Set.of(inter, sub));
 
         when(processoRepo.findByIdComParticipantes(codProcesso)).thenReturn(Optional.of(p));
@@ -156,7 +155,6 @@ class ProcessoNotificacaoServiceCoverageTest {
         inter.setTipo(TipoUnidade.INTERMEDIARIA);
         inter.setSituacao(SituacaoUnidade.ATIVA);
 
-        // Setup para processarFinalizacaoProcesso
         p.adicionarParticipantes(Set.of(inter));
 
         when(processoRepo.findByIdComParticipantes(codProcesso)).thenReturn(Optional.of(p));

--- a/backend/src/test/java/sgc/subprocesso/dto/MapaAjusteDtoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/dto/MapaAjusteDtoTest.java
@@ -76,7 +76,6 @@ class MapaAjusteDtoTest {
             comp.setDescricao("Comp 1");
             comp.setAtividades(Set.of(ativ));
 
-            // Execute
             Analise analise = new Analise();
             analise.setObservacoes("");
             MapaAjusteDto dto = MapaAjusteDto.of(

--- a/backend/src/test/java/sgc/subprocesso/model/SituacaoSubprocessoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/SituacaoSubprocessoTest.java
@@ -83,11 +83,8 @@ class SituacaoSubprocessoTest {
     @Test
     @DisplayName("Deve testar ramos da verificação de prefixo (MAPEAMENTO)")
     void testRamosPrefixoMapeamento() {
-        // this != NAO_INICIADO && nova != NAO_INICIADO
-        // this.name().startsWith("MAPEAMENTO") && !nova.name().startsWith("MAPEAMENTO") -> false
         assertThat(MAPEAMENTO_CADASTRO_EM_ANDAMENTO.podeTransicionarPara(REVISAO_CADASTRO_EM_ANDAMENTO, TipoProcesso.MAPEAMENTO)).isFalse();
 
-        // this.name().startsWith("MAPEAMENTO") && nova.name().startsWith("MAPEAMENTO") -> prossegue para switch
         assertThat(MAPEAMENTO_CADASTRO_EM_ANDAMENTO.podeTransicionarPara(MAPEAMENTO_CADASTRO_DISPONIBILIZADO, TipoProcesso.MAPEAMENTO)).isTrue();
     }
 

--- a/e2e/helpers/helpers-atividades.ts
+++ b/e2e/helpers/helpers-atividades.ts
@@ -60,7 +60,6 @@ export async function removerAtividade(page: Page, descricao: string) {
     await row.hover();
     await card.getByTestId('btn-remover-atividade').click({force: true});
 
-    // Confirmar no modal
     await page.getByTestId('btn-modal-confirmacao-confirmar').click();
 
     await expect(page.getByText(descricao)).toBeHidden();
@@ -87,7 +86,6 @@ export async function removerConhecimento(page: Page, atividadeDescricao: string
     await linhaConhecimento.hover();
     await linhaConhecimento.getByTestId('btn-remover-conhecimento').click({force: true});
 
-    // Confirmar no modal
     await page.getByTestId('btn-modal-confirmacao-confirmar').click();
 
     await expect(card.getByText(conhecimento)).toBeHidden();

--- a/e2e/setup/fixtures.ts
+++ b/e2e/setup/fixtures.ts
@@ -1,5 +1,4 @@
 import {test as base} from '@playwright/test';
-// Note: import uses .js extension because tests run with Node's ESM resolution (nodenext)
 import logger from '../../frontend/src/utils/logger.js';
 
 // Extend base test to automatically log console messages

--- a/frontend/src/__tests__/views/HistoricoView.spec.ts
+++ b/frontend/src/__tests__/views/HistoricoView.spec.ts
@@ -24,7 +24,6 @@ vi.mock("vue-router", () => ({
     createMemoryHistory: vi.fn(),
 }));
 
-// Setup components mocks to avoid rendering issues
 // BContainer, BRow, BCol, BCard, BButton are from bootstrap-vue-next
 // Given the errors were "Cannot call vm on an empty VueWrapper", it usually means
 
@@ -85,7 +84,6 @@ describe("HistoricoView.vue", () => {
         await flushPromises();
 
         const rows = context.wrapper.findAll('tbody tr');
-        // We have 2 processes mocked in initial state.
         expect(rows.length).toBe(2);
         expect(rows[0].text()).toContain("Proc B");
         expect(rows[1].text()).toContain("Proc A");

--- a/frontend/src/__tests__/views/LoginView.spec.ts
+++ b/frontend/src/__tests__/views/LoginView.spec.ts
@@ -145,7 +145,6 @@ describe("LoginView.vue", () => {
 
         expect(wrapper.find('[data-testid="sec-login-perfil"]').exists()).toBe(true);
 
-        // Trigger submit novamente para confirmar seleção
         await wrapper.find('form').trigger('submit');
 
         expect(perfilStore.selecionarPerfilUnidade).toHaveBeenCalledWith("123", MOCK_PERFIS[0]);

--- a/frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts
+++ b/frontend/src/components/__tests__/ArvoreUnidadesPbt.spec.ts
@@ -130,7 +130,6 @@ describe('ArvoreUnidades Property-Based Tests', () => {
         const treeStructure = generateTree(3, 2, 0); // ~14 nodes
         const allNodesStructure = flatten(treeStructure);
 
-        // We need as many random properties as nodes
         const numNodes = allNodesStructure.length;
 
         fc.assert(
@@ -173,7 +172,6 @@ describe('ArvoreUnidades Property-Based Tests', () => {
                         vm.toggle(node, !isSelected);
                     });
 
-                    // Assert Invariant: All selected units must be eligible
                     const selectedNodes = allNodes.filter(n => vm.isChecked(n.codigo));
 
                     selectedNodes.forEach(node => {

--- a/frontend/src/components/__tests__/AtividadeItem.spec.ts
+++ b/frontend/src/components/__tests__/AtividadeItem.spec.ts
@@ -62,7 +62,6 @@ describe("AtividadeItem.vue", () => {
         expect(input.exists()).toBe(true);
         await input.setValue('Novo Conhecimento');
 
-        // Trigger submit on the form directly
         await context.wrapper.find('[data-testid="form-novo-conhecimento"]').trigger('submit');
 
         expect(context.wrapper!.emitted('adicionar-conhecimento')).toBeTruthy();

--- a/frontend/src/components/__tests__/ImportarAtividadesModal.spec.ts
+++ b/frontend/src/components/__tests__/ImportarAtividadesModal.spec.ts
@@ -118,7 +118,6 @@ describe("ImportarAtividadesModal", () => {
     });
 
     it("deve lidar com erro na importação", async () => {
-        // Setup selection
         const selects = wrapper.findAllComponents(BFormSelect as any);
         await selects[0].setValue("1");
         await flushPromises();

--- a/frontend/src/components/__tests__/ImportarAtividadesModalCoverage.spec.ts
+++ b/frontend/src/components/__tests__/ImportarAtividadesModalCoverage.spec.ts
@@ -130,13 +130,11 @@ describe("ImportarAtividadesModal Coverage", () => {
 
         const vm = wrapper.vm as any;
 
-        // Trigger processoSelecionadoId watch via select
         const selects = wrapper.findAll('select');
         await selects[0].setValue(1);
         await flushPromises();
         expect(vm.processoSelecionado).toEqual(mockProcesso);
 
-        // Trigger unidadeSelecionadaId watch via select
         await selects[1].setValue(10);
         await flushPromises();
         expect(vm.unidadeSelecionada).toEqual(mockUnidade);

--- a/frontend/src/components/__tests__/MainNavbar.spec.ts
+++ b/frontend/src/components/__tests__/MainNavbar.spec.ts
@@ -27,7 +27,6 @@ vi.mock("vue-router", () => ({
 }));
 
 describe("MainNavbar.vue", () => {
-    // Setup cleanup
     const ctx = setupComponentTest();
 
     beforeEach(() => {

--- a/frontend/src/components/__tests__/MainNavbarCoverage.spec.ts
+++ b/frontend/src/components/__tests__/MainNavbarCoverage.spec.ts
@@ -27,7 +27,6 @@ vi.mock("vue-router", () => ({
 }));
 
 describe("MainNavbar.vue Coverage", () => {
-    // Setup default mock for usePerfil
     vi.mocked(usePerfil).mockReturnValue({
         perfilSelecionado: ref("GESTOR"),
         unidadeSelecionada: ref("Unidade Teste"),

--- a/frontend/src/components/__tests__/TabelaProcessosCoverage.spec.ts
+++ b/frontend/src/components/__tests__/TabelaProcessosCoverage.spec.ts
@@ -50,7 +50,6 @@ describe('TabelaProcessos Coverage', () => {
         });
 
         const row = wrapper.find('tr');
-        // Trigger space key
         await row.trigger('keydown', {key: ' '});
 
         expect(wrapper.emitted('selecionarProcesso')).toBeTruthy();

--- a/frontend/src/router/__tests__/router.spec.ts
+++ b/frontend/src/router/__tests__/router.spec.ts
@@ -41,7 +41,6 @@ describe('Router Guards', () => {
     beforeEach(() => {
         vi.clearAllMocks();
 
-        // Setup Store Mock
         perfilStoreMock = {
             usuarioCodigo: null,
             perfisUnidades: [],

--- a/frontend/src/stores/__tests__/alertas.spec.ts
+++ b/frontend/src/stores/__tests__/alertas.spec.ts
@@ -104,7 +104,6 @@ describe("useAlertasStore", () => {
 
         describe("marcarAlertaComoLido", () => {
             it("deve realizar update otimista e chamar alertaService sem recarregar tudo", async () => {
-                // Setup initial state
                 context.store.alertas = [structuredClone(mockAlerta)];
                 alertaService.marcarComoLido.mockResolvedValue();
 
@@ -120,7 +119,6 @@ describe("useAlertasStore", () => {
             });
 
             it("deve reverter estado em caso de falha do serviço", async () => {
-                // Setup initial state
                 context.store.alertas = [structuredClone(mockAlerta)];
 
                 alertaService.marcarComoLido.mockRejectedValue(

--- a/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
+++ b/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
@@ -165,7 +165,6 @@ describe("CadastroView.vue", () => {
         await wrapper.find('[data-testid="btn-cad-atividades-disponibilizar"]').trigger("click");
         await flushPromises();
 
-        // Confirm in modal
         const modal = wrapper.findComponent(ConfirmacaoDisponibilizacaoModal);
         await modal.vm.$emit('confirmar');
 

--- a/frontend/src/views/__tests__/CadAtividades.spec.ts
+++ b/frontend/src/views/__tests__/CadAtividades.spec.ts
@@ -99,7 +99,6 @@ describe("CadastroView.vue", () => {
     const createWrapper = (isRevisao = false, atividades = mockAtividades) => {
         mocks.mockRoute.query = {};
 
-        // Setup Pinia with Stubs
         const pinia = createTestingPinia({
             createSpy: vi.fn,
             initialState: {

--- a/frontend/src/views/__tests__/CadAtividadesCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadAtividadesCoverage.spec.ts
@@ -97,13 +97,11 @@ describe('CadastroView.vue Coverage', () => {
         (wrapper.vm as any).codSubprocesso = 123; // Force set
         await wrapper.vm.$nextTick();
 
-        // Trigger removal via stub
         await wrapper.find('.btn-rem-at').trigger('click');
 
         expect((wrapper.vm as any).dadosRemocao).toEqual({tipo: 'atividade', index: 0});
         expect((wrapper.vm as any).mostrarModalConfirmacaoRemocao).toBe(true);
 
-        // Confirm removal
         const spy = vi.spyOn(atividadesStore, 'removerAtividade').mockResolvedValue({} as any);
         await wrapper.find('.btn-conf').trigger('click');
 
@@ -125,7 +123,6 @@ describe('CadastroView.vue Coverage', () => {
         (wrapper.vm as any).codSubprocesso = 123;
         await wrapper.vm.$nextTick();
 
-        // Trigger removal of knowledge
         await wrapper.find('.btn-rem-con').trigger('click');
 
         expect((wrapper.vm as any).dadosRemocao).toEqual({tipo: 'conhecimento', index: 0, conhecimentoCodigo: 100});

--- a/frontend/src/views/__tests__/CadMapa.spec.ts
+++ b/frontend/src/views/__tests__/CadMapa.spec.ts
@@ -369,7 +369,6 @@ describe("MapaView.vue", () => {
     });
 
     afterEach(() => {
-        // cleanup
     });
 
     it("deve carregar dados no mount", async () => {

--- a/frontend/src/views/__tests__/CadMapaCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadMapaCoverage.spec.ts
@@ -83,7 +83,6 @@ describe('MapaView Coverage', () => {
 
         await wrapper.vm.$nextTick(); // Wait for mount
 
-        // Trigger
         await (wrapper.vm as any).abrirModalImpacto();
 
         expect(mapasStore.buscarImpactoMapa).not.toHaveBeenCalled();
@@ -108,7 +107,6 @@ describe('MapaView Coverage', () => {
         (mapasStore.buscarImpactoMapa as any).mockResolvedValue(undefined);
         (wrapper.vm as any).codSubprocesso = 456;
 
-        // Trigger
         await (wrapper.vm as any).abrirModalImpacto();
 
         expect(mapasStore.buscarImpactoMapa).toHaveBeenCalledWith(456);

--- a/frontend/src/views/__tests__/CadProcessoCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadProcessoCoverage.spec.ts
@@ -107,7 +107,6 @@ describe('ProcessoCadastroView.vue Coverage', () => {
     it('handles mixed errors (field + generic) correctly in handleApiErrors', async () => {
         const {wrapper, processosStore} = createWrapper();
 
-        // Setup state for error
         processosStore.criarProcesso.mockImplementation(async () => {
             processosStore.lastError = {
                 message: 'Erro misto',
@@ -148,7 +147,6 @@ describe('ProcessoCadastroView.vue Coverage', () => {
         processosStore.criarProcesso.mockRejectedValue(new Error('Create Error'));
         processosStore.lastError = {message: 'Failed to create'};
 
-        // Confirm initiation
         const modal = wrapper.findComponent({name: 'ModalConfirmacao'});
         await modal.vm.$emit('confirmar');
         await flushPromises();
@@ -189,7 +187,6 @@ describe('ProcessoCadastroView.vue Coverage', () => {
     it('opens and confirms removal modal', async () => {
         const {wrapper, processosStore} = createWrapper();
 
-        // Setup process being edited
         (wrapper.vm).processoEditando = {codigo: 123, descricao: 'Processo Teste'};
         await nextTick();
 
@@ -197,7 +194,6 @@ describe('ProcessoCadastroView.vue Coverage', () => {
         await (wrapper.vm).abrirModalRemocao();
         expect((wrapper.vm).mostrarModalRemocao).toBe(true);
 
-        // Confirm removal
         processosStore.removerProcesso.mockResolvedValue(undefined);
 
         await (wrapper.vm).confirmarRemocao();

--- a/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
@@ -218,7 +218,6 @@ describe("ProcessoViewCoverage.spec.ts", () => {
 
         const modal = wrapper.findComponent({name: 'ModalAcaoBloco'});
 
-        // Trigger action
         (wrapper.vm as any).acaoBlocoAtual = 'aceitar';
         (processosStore.executarAcaoBloco as any).mockRejectedValue(new Error("Erro bloco"));
 

--- a/frontend/src/views/__tests__/Relatorios.spec.ts
+++ b/frontend/src/views/__tests__/Relatorios.spec.ts
@@ -70,7 +70,6 @@ describe("Relatorios.vue", () => {
         wrapper = createWrapper(initialState);
         processosStore = useProcessosStore();
 
-        // Trigger onMounted
         await flushPromises();
 
         expect(processosStore.buscarProcessosPainel).toHaveBeenCalled();

--- a/frontend/src/views/__tests__/SubprocessoView.spec.ts
+++ b/frontend/src/views/__tests__/SubprocessoView.spec.ts
@@ -216,7 +216,6 @@ describe('SubprocessoView.vue', () => {
         (wrapper.vm as any).modals.open('alterarDataLimite');
         await (wrapper.vm as any).$nextTick();
 
-        // Confirm
         const modal = wrapper.findComponent(SubprocessoModalStub);
         await modal.vm.$emit('confirmar-alteracao', '2024-01-01');
 
@@ -243,7 +242,6 @@ describe('SubprocessoView.vue', () => {
         const {wrapper, store} = mountComponent();
         await flushPromises();
 
-        // Trigger Reabertura
         await wrapper.find('[data-testid="btn-reabrir-cadastro"]').trigger('click');
         await (wrapper.vm as any).$nextTick();
 
@@ -254,7 +252,6 @@ describe('SubprocessoView.vue', () => {
         const textarea = wrapper.find('textarea');
         await textarea.setValue('Erro no preenchimento');
 
-        // Confirmar
         const btn = wrapper.find('[data-testid="btn-confirmar-reabrir"]');
         await btn.trigger('click');
         await flushPromises();

--- a/frontend/src/views/__tests__/UnidadeView.spec.ts
+++ b/frontend/src/views/__tests__/UnidadeView.spec.ts
@@ -299,7 +299,6 @@ describe('UnidadeView.vue', () => {
     });
 
     it('renders clickable contact links for titular', async () => {
-        // Setup mock user with contact info
         const mockUserWithContact = {
             ...mockUsuario,
             ramal: '1234',

--- a/frontend/src/views/__tests__/VisAtividades.spec.ts
+++ b/frontend/src/views/__tests__/VisAtividades.spec.ts
@@ -201,7 +201,6 @@ describe("CadastroVisualizacaoView.vue Coverage", () => {
         // Force open validation modal state
         (wrapper.vm as any).mostrarModalValidar = true;
 
-        // Trigger validation
         try {
             await (wrapper.vm as any).confirmarValidacao();
         } catch {

--- a/frontend/src/views/__tests__/VisAtividadesCoverage.spec.ts
+++ b/frontend/src/views/__tests__/VisAtividadesCoverage.spec.ts
@@ -201,7 +201,6 @@ describe("CadastroVisualizacaoView.vue Coverage", () => {
         // Force open validation modal state
         (wrapper.vm as any).mostrarModalValidar = true;
 
-        // Trigger validation
         try {
             await (wrapper.vm as any).confirmarValidacao();
         } catch {


### PR DESCRIPTION
Removes unnecessary visual separator lines, obvious testing comments, conversational comments, and obvious param/return javadocs/jsdocs.

---
*PR created automatically by Jules for task [11168301331477525227](https://jules.google.com/task/11168301331477525227) started by @lgalvao*