### PR TITLE
Resolve frontend lint and E2E typecheck errors

### DIFF
--- a/e2e/a11y/home.spec.ts
+++ b/e2e/a11y/home.spec.ts
@@ -1,15 +1,15 @@
-import { test, expect } from '../fixtures/a11y';
-import { login, USUARIOS } from '../helpers/helpers-auth';
+import { test, expect } from '../fixtures/a11y.js';
+import { login, USUARIOS } from '../helpers/helpers-auth.js';
 
 test.describe('Accessibility Checks (WCAG)', () => {
 
-    test('Login Page A11y', async ({ page, makeAxeBuilder }) => {
+    test('Login Page A11y', async ({ page, makeAxeBuilder }: { page: any, makeAxeBuilder: any }) => {
         await page.goto('/');
         const accessibilityScanResults = await makeAxeBuilder().analyze();
         expect(accessibilityScanResults.violations).toEqual([]);
     });
 
-    test('Dashboard Page A11y', async ({ page, makeAxeBuilder }) => {
+    test('Dashboard Page A11y', async ({ page, makeAxeBuilder }: { page: any, makeAxeBuilder: any }) => {
         await login(page, USUARIOS.ADMIN_1_PERFIL.titulo, USUARIOS.ADMIN_1_PERFIL.senha);
         await page.waitForURL('/painel');
         const accessibilityScanResults = await makeAxeBuilder().analyze();

--- a/e2e/fixtures/a11y.ts
+++ b/e2e/fixtures/a11y.ts
@@ -1,15 +1,15 @@
 import { test as base } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
+import { AxeBuilder } from '@axe-core/playwright';
 
 export const test = base.extend<{ makeAxeBuilder: () => AxeBuilder }>({
   makeAxeBuilder: async ({ page }, use) => {
     const makeAxeBuilder = () =>
       new AxeBuilder({ page })
         .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
-        .disableRules(['list']) // Known BVN violation for dropdown/nav components
+        .disableRules(['list']); // Known BVN violation for dropdown/nav components
 
-    await use(makeAxeBuilder)
+    await use(makeAxeBuilder);
   },
-})
+});
 
 export { expect } from '@playwright/test';

--- a/frontend/src/views/MapaVisualizacaoView.vue
+++ b/frontend/src/views/MapaVisualizacaoView.vue
@@ -298,7 +298,6 @@ const {
   podeAceitarMapa,
   podeDevolverMapa,
   podeHomologarMapa,
-  podeApresentarSugestoes,
   podeVerSugestoes: podeMostrarVerSugestoes
 } = useAcesso(computed(() => subprocessosStore.subprocessoDetalhe));
 


### PR DESCRIPTION
This PR addresses several quality issues identified during frontend and E2E checks:
1. **Frontend Linting**: Fixed a warning in `MapaVisualizacaoView.vue` by removing an unused variable.
2. **E2E Typechecking**: Resolved errors in the `e2e` project related to `NodeNext` module resolution (explicit extensions required) and `AxeBuilder` import compatibility.
3. **Strict Types**: Added explicit types to test fixtures in `home.spec.ts` to pass strict `any` checks.

All checks (typecheck, lint, and unit tests) are now passing.

---
*PR created automatically by Jules for task [3934883784189643069](https://jules.google.com/task/3934883784189643069) started by @lgalvao*