### PR TITLE
Fix Frontend Quality Check Issues

### DIFF
--- a/e2e/cdu-12.spec.ts
+++ b/e2e/cdu-12.spec.ts
@@ -1,5 +1,5 @@
 import {expect, test} from './fixtures/complete-fixtures.js';
-import {USUARIOS} from './helpers/helpers-auth.js';
+import {login, USUARIOS} from './helpers/helpers-auth.js';
 import {criarProcessoFinalizadoFixture, criarProcessoFixture} from './fixtures/fixtures-processos.js';
 import {
     abrirModalImpactoEdicao,

--- a/e2e/fixtures/base.ts
+++ b/e2e/fixtures/base.ts
@@ -1,6 +1,7 @@
 import {test as base} from '@playwright/test';
 // Use the project's centralized logger for consistent formatting
 import logger from '../../frontend/src/utils/logger.js';
+import {useProcessoCleanup} from '../hooks/hooks-limpeza.js';
 
 function obterBaseUrlWorker(_workerIndex: number): string {
     const portaFrontend = Number.parseInt(process.env.E2E_FRONTEND_PORT || '5173', 10);
@@ -26,7 +27,9 @@ function ehRuidoAutenticacaoEmDetalhes(url: string, status?: number, method?: st
         && /\/api\/processos\/\d+\/detalhes$/.test(url);
 }
 
-export const test = base.extend({
+export const test = base.extend<{
+    cleanupAutomatico: ReturnType<typeof useProcessoCleanup>;
+}>({
     context: async ({browser}, use, testInfo) => {
         const baseURL = obterBaseUrlWorker(testInfo.parallelIndex);
         const context = await browser.newContext({
@@ -161,6 +164,12 @@ export const test = base.extend({
         });
 
         await use(page);
+    },
+
+    cleanupAutomatico: async ({request}, use) => {
+        const cleanup = useProcessoCleanup();
+        await use(cleanup);
+        await cleanup.limpar(request);
     },
 });
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -20,9 +20,9 @@ declare global {
         __pinia__: ReturnType<typeof createPinia>;
     }
 
-    let pinia: ReturnType<typeof createPinia>;
+    var pinia: ReturnType<typeof createPinia>;
 
-    let __pinia__: ReturnType<typeof createPinia>;
+    var __pinia__: ReturnType<typeof createPinia>;
 }
 
 const app = createApp(App);


### PR DESCRIPTION
This PR addresses several issues identified during a frontend quality check.

Key changes:
1.  **TypeScript Global Scope Fix**: In `frontend/src/main.ts`, updated `declare global` to use `var` for `pinia` and `__pinia__`. This correctly attaches them to the global object and fixes `tsc` errors.
2.  **E2E Fixture Improvement**: Integrated `cleanupAutomatico` into the base E2E fixture (`e2e/fixtures/base.ts`). This ensures the fixture is available across all tests using the base extension and properly handles automated cleanup of processes.
3.  **Missing Imports**: Fixed a missing `login` import in `e2e/cdu-12.spec.ts` that was causing a type error.
4.  **Verification**: Ran `npm run typecheck`, `npm run lint`, and `npm run test:unit` to ensure the codebase is clean and regressions were not introduced.

---
*PR created automatically by Jules for task [10545855244300973024](https://jules.google.com/task/10545855244300973024) started by @lgalvao*