### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/views/ProcessoDetalheView.vue
+++ b/frontend/src/views/ProcessoDetalheView.vue
@@ -128,17 +128,6 @@ import {logger} from "@/utils";
 
 type ContextoBloco = "cadastro" | "validacao" | "misto";
 
-function flattenUnidades(unidades: any[]): any[] {
-  let result: any[] = [];
-  for (const u of unidades) {
-    result.push(u);
-    if (u.filhos && u.filhos.length > 0) {
-      result = result.concat(flattenUnidades(u.filhos));
-    }
-  }
-  return result;
-}
-
 const route = useRoute();
 const router = useRouter();
 const processosStore = useProcessosStore();

--- a/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
@@ -208,11 +208,14 @@ describe("ProcessoViewCoverage.spec.ts", () => {
     it("deve lidar com erro na ação em bloco", async () => {
         const wrapper = createWrapper({
             processos: {
-                processoDetalhe: {
-                    unidades: [
-                        {codUnidade: 1, sigla: "A", situacaoSubprocesso: "QUALQUER"}
-                    ]
-                }
+                subprocessosElegiveis: [
+                    {
+                        unidadeCodigo: 1,
+                        unidadeSigla: "A",
+                        unidadeNome: "Unidade A",
+                        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO
+                    }
+                ]
             }
         });
 
@@ -233,12 +236,20 @@ describe("ProcessoViewCoverage.spec.ts", () => {
     it("deve calcular unidades elegíveis para Disponibilizar", async () => {
         const wrapper = createWrapper({
             processos: {
-                processoDetalhe: {
-                    unidades: [
-                        {codUnidade: 1, sigla: "A", situacaoSubprocesso: SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO}, // Eligible
-                        {codUnidade: 2, sigla: "B", situacaoSubprocesso: "OUTRO"}
-                    ]
-                }
+                subprocessosElegiveis: [
+                    {
+                        unidadeCodigo: 1,
+                        unidadeSigla: "A",
+                        unidadeNome: "Unidade A",
+                        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO
+                    }, // Eligible
+                    {
+                        unidadeCodigo: 2,
+                        unidadeSigla: "B",
+                        unidadeNome: "Unidade B",
+                        situacao: "OUTRO"
+                    }
+                ]
             }
         });
         (wrapper.vm as any).acaoBlocoAtual = 'disponibilizar';
@@ -249,16 +260,20 @@ describe("ProcessoViewCoverage.spec.ts", () => {
     it("deve calcular unidades elegíveis para Homologar", async () => {
         const wrapper = createWrapper({
             processos: {
-                processoDetalhe: {
-                    unidades: [
-                        {
-                            codUnidade: 1,
-                            sigla: "A",
-                            situacaoSubprocesso: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO
-                        }, // Eligible
-                        {codUnidade: 2, sigla: "B", situacaoSubprocesso: "OUTRO"}
-                    ]
-                }
+                subprocessosElegiveis: [
+                    {
+                        unidadeCodigo: 1,
+                        unidadeSigla: "A",
+                        unidadeNome: "Unidade A",
+                        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO
+                    }, // Eligible
+                    {
+                        unidadeCodigo: 2,
+                        unidadeSigla: "B",
+                        unidadeNome: "Unidade B",
+                        situacao: "OUTRO"
+                    }
+                ]
             }
         });
         (wrapper.vm as any).acaoBlocoAtual = 'homologar';
@@ -268,16 +283,20 @@ describe("ProcessoViewCoverage.spec.ts", () => {
     it("deve calcular unidades elegíveis para Aceitar (incluindo REVISAO_DISPONIBILIZADA)", async () => {
         const wrapper = createWrapper({
             processos: {
-                processoDetalhe: {
-                    unidades: [
-                        {
-                            codUnidade: 1,
-                            sigla: "A",
-                            situacaoSubprocesso: SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA
-                        }, // Eligible
-                        {codUnidade: 2, sigla: "B", situacaoSubprocesso: "OUTRO"}
-                    ]
-                }
+                subprocessosElegiveis: [
+                    {
+                        unidadeCodigo: 1,
+                        unidadeSigla: "A",
+                        unidadeNome: "Unidade A",
+                        situacao: SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA
+                    }, // Eligible
+                    {
+                        unidadeCodigo: 2,
+                        unidadeSigla: "B",
+                        unidadeNome: "Unidade B",
+                        situacao: "OUTRO"
+                    }
+                ]
             }
         });
         (wrapper.vm as any).acaoBlocoAtual = 'aceitar';


### PR DESCRIPTION
This change addresses quality check issues in the frontend. It removes an unused function in `ProcessoDetalheView.vue` that was causing a lint warning. Additionally, it fixes three failing unit tests in `ProcessoViewCoverage.spec.ts` by updating the test data to align with the current implementation of the processes store and component logic. All quality checks (typecheck, lint, and unit tests) now pass successfully.

---
*PR created automatically by Jules for task [4376776482535553175](https://jules.google.com/task/4376776482535553175) started by @lgalvao*