### PR TITLE
docs: create simplification suggestions tracking document

### DIFF
--- a/simplification-suggestions.md
+++ b/simplification-suggestions.md
@@ -1,0 +1,40 @@
+# Simplification Suggestions for SGC
+
+This document outlines strategies for simplifying the SGC codebase, reducing overengineering, and minimizing fragmentation. These recommendations are specifically tailored for a small-scale intranet application expected to handle at most 5-10 simultaneous users. Guidelines typically applied to highly-scalable, multilayered, or super-modularized systems are intentionally avoided to prioritize maintainability, readability, and development speed.
+
+## Architectural Priorities
+
+1. **Monolithic Architecture**: Maintain a cohesive monolith. Avoid splitting the application into microservices or fragmented Gradle subprojects.
+2. **Procedural Services**: Favor procedural code in Services over complex design patterns (e.g., Strategy, Command, Visitor) unless the complexity is strictly necessary for the business logic.
+3. **Concrete Classes**: Avoid single-implementation interfaces. If an interface is only implemented by one class, remove the interface and use the concrete class directly.
+4. **Direct Controller-to-Service Communication**: Remove redundant intermediary layers.
+
+## Backend Simplifications
+
+1. **Remove Redundant Facades**:
+   - Facade classes (e.g., `OrganizacaoFacade`, `ProcessoFacade`, `SubprocessoFacade`, `MapaFacade`, `AtividadeFacade`, `UsuarioFacade`, `AlertaFacade`, `RelatorioFacade`, `LoginFacade`, `PainelFacade`) that merely delegate calls from Controllers to Services add unnecessary boilerplate.
+   - **Action**: Inject Services directly into Controllers.
+
+2. **Consolidate Business Logic**:
+   - Move business validations and logic out of Controllers.
+   - **Action**: Controllers should be thin, focusing solely on HTTP request/response handling, routing, and basic input validation (via annotations). All business rules and complex validations must reside in the Service layer.
+
+3. **Simplify DTO Mapping**:
+   - Avoid creating separate DTOs for simple read operations where the entity structure is sufficient and does not expose sensitive information.
+   - **Action**: Return entities directly for simple queries, minimizing the need for mapping boilerplate. Only use DTOs when necessary to shape the response for specific UI needs, aggregate data, or hide sensitive fields.
+
+## Frontend Simplifications
+
+1. **Minimize Pinia State Management**:
+   - Many Pinia stores currently act as unnecessary pass-throughs, merely caching API data without managing complex global state. Examples include `mapas.ts`, `atividades.ts`, `subprocessos.ts`, `processos.ts`, and `usuarios.ts`.
+   - **Action**: Remove these pass-through stores. Replace them with standard Vue `refs` or composables that call Services directly.
+   - **Action**: Reserve Pinia exclusively for true global state (e.g., user authentication, session data, UI notifications/toasts).
+
+2. **Eliminate Redundant Wrapper Components**:
+   - Avoid creating frontend components that only proxy props and events to underlying components (e.g., wrapping a simple BootstrapVueNext component without adding substantial value or specific logic).
+   - **Action**: Use the base components directly or consolidate the logic into fewer, more meaningful components.
+
+## Development Practices
+
+- **Avoid Overengineering**: Always evaluate if a pattern or abstraction is necessary for the current scale and requirements. If it only serves "future-proofing" for scenarios unlikely to occur in this specific intranet context, remove it.
+- **Code Cleanliness**: Remove conversational AI artifacts, obvious comments that just repeat code logic, redundant Javadoc/JSDoc tags, and visual separator lines. The code should be self-documenting as much as possible.


### PR DESCRIPTION
Created the `simplification-suggestions.md` file as requested, establishing strong project principles against overengineering. The guidelines specify monolithic maintenance, removal of unnecessary layers like `OrganizacaoFacade`, directly injecting services to thin controllers, keeping Pinia state strictly for global data and avoiding pass-through stores like `mapas.ts`.

---
*PR created automatically by Jules for task [15673040835290427293](https://jules.google.com/task/15673040835290427293) started by @lgalvao*