### PR TITLE
Fix frontend quality check warnings

### DIFF
--- a/frontend/src/components/comum/InputData.vue
+++ b/frontend/src/components/comum/InputData.vue
@@ -1,8 +1,8 @@
 <template>
   <BInputGroup>
     <BFormInput
-        ref="inputRef"
         :id="id"
+        ref="inputRef"
         :model-value="modelValue"
         :state="state"
         :data-testid="dataTestid"

--- a/frontend/src/components/processo/ProcessoFormFields.vue
+++ b/frontend/src/components/processo/ProcessoFormFields.vue
@@ -105,9 +105,7 @@ import {
   BFormInput,
   BFormInvalidFeedback,
   BFormSelect,
-  BFormSelectOption,
-  BInputGroup,
-  BInputGroupText
+  BFormSelectOption
 } from "bootstrap-vue-next";
 import {nextTick, ref, watch} from "vue";
 import ArvoreUnidades from "@/components/unidade/ArvoreUnidades.vue";
@@ -159,17 +157,6 @@ function updateField<K extends keyof ProcessoFormData>(field: K, value: Processo
     ...props.modelValue,
     [field]: value
   });
-}
-
-function abrirCalendario() {
-  if (inputDataLimiteRef.value?.$el) {
-    const input = inputDataLimiteRef.value.$el as HTMLInputElement;
-    if (typeof input.showPicker === 'function') {
-      input.showPicker();
-    } else {
-      input.focus();
-    }
-  }
 }
 
 function focarPrimeiroErro() {

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -198,7 +198,6 @@ import {
 import logger from "@/utils/logger";
 import {formatSituacaoSubprocesso} from "@/utils/formatters";
 import * as atividadeService from "@/services/atividadeService";
-import * as subprocessoService from "@/services/subprocessoService";
 import {listarAnalisesCadastro} from "@/services/analiseService";
 import {useErrorHandler} from "@/composables/useErrorHandler";
 


### PR DESCRIPTION
Performed a quality check on the frontend, including typechecking, linting, and unit tests. Fixed identified lint warnings by removing unused imports and functions in `ProcessoFormFields.vue` and `CadastroView.vue`. Verified that all quality checks now pass successfully.

---
*PR created automatically by Jules for task [14422521747223065955](https://jules.google.com/task/14422521747223065955) started by @lgalvao*