### PR TITLE
chore: clean up unnecessary comments

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -91,7 +91,6 @@ tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
     val env = (project.findProperty("ENV") ?: System.getProperty("spring.profiles.active"))?.toString() ?: "test"
     val envFile = rootProject.file(".env.$env")
 
-    // Define o perfil Spring automaticamente baseado no ENV
     systemProperty("spring.profiles.active", env)
     println("Perfil Spring ativado: $env")
 

--- a/backend/src/main/java/sgc/processo/service/ProcessoDetalheBuilder.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoDetalheBuilder.java
@@ -24,7 +24,6 @@ public class ProcessoDetalheBuilder {
     private final SubprocessoValidacaoService subprocessoValidacaoService;
     private final UnidadeRepo unidadeRepo;
     private final SubprocessoService subprocessoService;
-        //teste
     @Transactional(readOnly = true)
     public ProcessoDetalheDto build(Processo processo, Usuario usuario) {
         List<Subprocesso> subprocessos = subprocessoRepo.findByProcessoCodigoWithUnidade(processo.getCodigo());

--- a/backend/src/test/java/sgc/integracao/mocks/TestLoginHelper.java
+++ b/backend/src/test/java/sgc/integracao/mocks/TestLoginHelper.java
@@ -39,7 +39,6 @@ public class TestLoginHelper {
             throw new IllegalStateException("Cookie de pré-autenticação não encontrado");
         }
 
-        // 2. Autorizar (não precisa do resultado, mas faz parte do fluxo)
         AutorizarRequest autorizarRequest = new AutorizarRequest(titulo);
         mockMvc.perform(post("/api/usuarios/autorizar")
                         .cookie(preAuthCookie)

--- a/e2e/cdu-01.spec.ts
+++ b/e2e/cdu-01.spec.ts
@@ -12,7 +12,6 @@ test.describe('CDU-01 - Realizar login e exibir estrutura das telas', () => {
     });
 
     test('Deve realizar login com sucesso (Perfil Único)', async ({page}) => {
-        // Usuário 222222 (GESTOR_COORD_11) tem apenas um perfil
         await autenticar(page, USUARIOS.GESTOR_COORD.titulo, USUARIOS.GESTOR_COORD.senha);
 
         await expect(page.getByText('GESTOR - COORD_11')).toBeVisible();

--- a/frontend/src/components/comum/__tests__/AppAlert.spec.ts
+++ b/frontend/src/components/comum/__tests__/AppAlert.spec.ts
@@ -42,7 +42,6 @@ describe('AppAlert.vue', () => {
       }
     });
 
-    // import.meta.env.DEV in vitest is usually true by default
     expect(wrapper.text()).toContain('Mostrar detalhes técnicos');
 
     // Múltiplos buttons podem existir se fosse notificação estruturada, mas é modo simples

--- a/frontend/src/components/processo/SubprocessoModal.vue
+++ b/frontend/src/components/processo/SubprocessoModal.vue
@@ -86,7 +86,6 @@ const isDataValida = computed(() => {
   return isDateValidAndFuture(parseDate(novaDataLimite.value));
 });
 
-// Watch para mostrarModal e inicializar quando abrir
 watch(
     () => props.mostrarModal,
     (novoValor: boolean) => {


### PR DESCRIPTION
This commit automates and applies the cleanup of various kinds of conversational and redundant comments from the codebase. It targets known AI outputs, empty `@param` tags that just repeat names with no text, and single-line obvious remarks, while safely avoiding destruction of E2E test traceability step headers.

---
*PR created automatically by Jules for task [11134802968287435981](https://jules.google.com/task/11134802968287435981) started by @lgalvao*