### PR TITLE
Clean up unnecessary and redundant comments

### DIFF
--- a/e2e/captura.spec.ts
+++ b/e2e/captura.spec.ts
@@ -502,15 +502,12 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await expect(page.getByTestId('btn-processo-salvar')).toBeDisabled();
             await capturarTela(page, '03-processo', '10-botoes-desativados-form-vazio');
 
-            // Preencher descrição
             await page.getByTestId('inp-processo-descricao').fill(descricao);
             await expect(page.getByTestId('btn-processo-salvar')).toBeDisabled();
             await capturarTela(page, '03-processo', '11-botoes-desativados-falta-data-unidade');
 
-            // Selecionar tipo
             await page.getByTestId('sel-processo-tipo').selectOption('MAPEAMENTO');
 
-            // Preencher data
             const dataLimite = new Date();
             dataLimite.setDate(dataLimite.getDate() + 30);
             await page.getByTestId('inp-processo-data-limite').fill(dataLimite.toISOString().split('T')[0]);
@@ -1049,7 +1046,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await capturarTela(page, '11-unidades', '04-modal-criar-atribuicao');
             await page.getByRole('button', {name: /Cancelar/i}).click();
 
-            // 2. Histórico
             const linkHistorico = page.getByRole('link', {name: /Histórico/i});
             await expect(linkHistorico).toBeVisible();
             await linkHistorico.click();
@@ -1081,7 +1077,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await capturarTela(page, '13-configuracoes', '04-modal-adicionar-administrador');
             await page.getByRole('button', {name: /Cancelar/i}).click();
 
-            // 4. Relatórios
             const linkRelatorios = page.getByRole('link', {name: /Relatórios/i});
             await expect(linkRelatorios).toBeVisible();
             await linkRelatorios.click();

--- a/e2e/lifecycle.js
+++ b/e2e/lifecycle.js
@@ -226,7 +226,6 @@ function startSmtpServer() {
         authOptional: true,
         onData(stream, _session, callback) {
             stream.on('data', () => {
-                // Consumir dados
             });
             stream.on('end', () => {
                 callback();

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -14,7 +14,6 @@ function parseStringDate(s: string): Date | null {
         const ddmmyyyy = parse(trimmed, "dd/MM/yyyy", new Date());
         if (isValid(ddmmyyyy)) return ddmmyyyy;
     } catch {
-        // ignore
     }
 
     if (/^\d{10,}$/.test(trimmed)) {


### PR DESCRIPTION
Removed unneeded conversational/AI comments using provided scripts. The scripts target explicit markers and multiline blocks. Validated that e2e test files correctly cleaned up obvious step descriptions, while preserving necessary ESLint directives and ignoring empty catch block guidelines.

---
*PR created automatically by Jules for task [1352636443994955264](https://jules.google.com/task/1352636443994955264) started by @lgalvao*