### PR TITLE
docs: update simplification suggestions for architecture

### DIFF
--- a/simplification-suggestions.md
+++ b/simplification-suggestions.md
@@ -2,40 +2,42 @@
 
 Given the context of an intranet application for 5-10 simultaneous users, the current architecture presents several areas of overengineering. Following the strict project guidelines, we must prioritize simple, direct code, avoid unnecessary layers/patterns, minimize DTO mapping, maintain a cohesive monolith, and simplify the frontend state management.
 
-Here are the key suggestions to reduce complexity and fragmentation:
+Here are the key suggestions to reduce complexity and fragmentation, updated based on the current state of the codebase:
 
 ## 1. Backend: Direct repository access from Controllers for CRUD
 
-**Issue:** Many controllers delegate simple CRUD operations to Facades and Services, adding unnecessary boilerplate. For example, `UnidadeController` likely uses `UnidadeService` or a Facade just to call `UnidadeRepo.findAll()`. The `ProcessoController` heavily relies on `ProcessoFacade` which then calls multiple services (`ProcessoConsultaService`, `ProcessoManutencaoService`, etc.).
+**Issue:** Many controllers delegate simple CRUD operations to Facades and Services, adding unnecessary boilerplate.
 
 **Suggestion:** For simple reads and basic CRUD operations without complex business logic, Controllers should inject Spring Data Repositories directly.
 *   **Action:** Review controllers like `UnidadeController`, `ProcessoController` and remove intermediary Facade/Service layers for methods that simply proxy to `Repo.findById()` or `Repo.findAll()`.
-*   **Action:** Refactor `ProcessoFacade`. It currently acts as a massive proxy. Methods like `listarAtivos()` that just call `processoConsultaService.processosAndamento()` should be handled directly in the Controller or a single, cohesive Service if logic is needed.
 
-## 2. Backend: Consolidation of Fragmented services
+## 2. Backend: Consolidation of Fragmented services and elimination of Facades
 
-**Issue:** Domain logic is fragmented into many small services. For example, the `Processo` domain is split into `ProcessoWorkflowService`, `ProcessoManutencaoService`, `ProcessoConsultaService`, `ProcessoValidacaoService`, and `ProcessoNotificacaoService`. While this follows Single responsibility to an extreme, it makes the codebase harder to navigate and understand for a small application.
+**Current State & Issue:** The domain logic was previously fragmented, and complex Facades were used to orchestrate logic.
+*   **Resolved:** The fragmentation in the `Processo` domain (e.g., `ProcessoWorkflowService`, `ProcessoManutencaoService`, etc.) and the `ProcessoFacade` have already been successfully consolidated into a single, cohesive `ProcessoService.java`.
+*   **Remaining Issue:** Other domains still employ unnecessary Facades that add indirection without substantial business value for a small application. For instance, `PainelFacade` and `UsuarioFacade`.
 
-**Suggestion:** Consolidate these micro-services back into a single, cohesive `ProcessoService`.
-*   **Action:** Merge `ProcessoWorkflowService`, `ProcessoManutencaoService`, `ProcessoConsultaService`, and `ProcessoValidacaoService` into a single `ProcessoService`. The logic is procedural and tightly coupled to the `Processo` entity.
-*   **Action:** Evaluate other domains (e.g., `Mapa`, `Organizacao`) for similar fragmentation and consolidate their services.
+**Suggestion:** Eliminate remaining Facade classes and consolidate logic into cohesive domain services or handle simple orchestration directly in controllers.
+*   **Action:** Refactor `PainelFacade` (in `sgc.processo.painel`) into a simpler `PainelService` or move its logic directly to `PainelController`.
+*   **Action:** Refactor `UsuarioFacade` (in `sgc.organizacao`) by moving its logic into `UsuarioService` or `UsuarioController` directly.
 
 ## 3. Backend: Minimize DTO Mapping
 
-**Issue:** The system uses DTOs even when entities could be returned directly for reads, leading to boilerplate mapping code. For instance, `ProcessoDetalheDto` and its nested `UnidadeParticipanteDto`.
+**Issue:** The system uses DTOs even when entities could be returned directly for reads, leading to boilerplate mapping code.
 
 **Suggestion:** Return JPA entities directly from Controllers for simple read operations where the API consumer needs the full object.
 *   **Action:** Use `@JsonView` (which is already present in some places like `ProcessoViews.Publica`) to control serialization instead of creating dedicated DTOs for every view.
 *   **Action:** Remove DTOs that have a 1:1 mapping with entities unless they are strictly necessary to hide sensitive data or aggregate complex data not easily achieved via projections.
+*   **Action:** The `ProcessoDetalheBuilder` was previously flagged for removal. Its logic should be verified to ensure it is handled procedurally within `ProcessoService`.
 
 ## 4. Frontend: Removal of Pass-through Pinia stores
 
-**Issue:** The frontend uses Pinia stores (`processos.ts`, `mapas.ts`, `subprocessos.ts`) largely as pass-throughs to cache API data fetched by Services. This adds boilerplate and complexity without significant benefit, especially since the user base is small and data fetching is fast.
+**Issue:** The frontend uses Pinia stores (`processos.ts`, `mapas.ts`, `subprocessos.ts` in `frontend/src/stores/`) largely as pass-throughs to cache API data fetched by Services. This adds boilerplate and complexity without significant benefit, especially since the user base is small and data fetching is fast.
 
 **Suggestion:** Eliminate pinia stores that only proxy Service calls. Use vue composables or simple `ref` variables in components to hold data fetched directly from Services.
-*   **Action:** Deprecate and remove `useProcessosStore`, `useMapasStore`, etc.
-*   **Action:** Refactor components that rely on these stores to import the corresponding Service functions (e.g., `processoService.obterDetalhesProcesso`) and manage state locally using `ref` or a custom Composable like `useFetchProcesso`.
-*   **Action:** Restrict pinia usage strictly to global application state, such as Authentication (User session), UI Notifications (`toast.ts`), and potentially global configuration.
+*   **Action:** Deprecate and remove `useProcessosStore`, `useMapasStore`, and `useSubprocessosStore`.
+*   **Action:** Refactor components that rely on these stores to import the corresponding Service functions directly or use local Composables (e.g., `useProcessos.ts` as outlined in `plano-simplificacao.md`).
+*   **Action:** Restrict pinia usage strictly to global application state, such as Authentication (User session), UI Notifications (`feedback.ts` / `toast.ts`), and potentially global configuration.
 
 ## 5. Frontend: Simplify wrapper components
 
@@ -46,8 +48,7 @@ Here are the key suggestions to reduce complexity and fragmentation:
 
 ## 6. General: Procedural logic over Design patterns
 
-**Issue:** The use of Factories (e.g., `PdfFactory`), Builders (`ProcessoDetalheBuilder`), and complex Facades (`ProcessoFacade`, `PainelFacade`) suggests an enterprise-level architecture that is overkill for a 5-10 user intranet app.
+**Issue:** The use of Factories, Builders, and complex Facades suggests an enterprise-level architecture that is overkill for a 5-10 user intranet app.
 
 **Suggestion:** Favor direct, procedural code in Services over complex object-oriented design patterns.
-*   **Action:** Refactor `ProcessoDetalheBuilder` into a procedural method within the consolidated `ProcessoService`.
-*   **Action:** Simplify or remove `Facade` classes. If a controller needs to orchestrate a few operations, it can do so directly, or a central Service can handle the orchestration procedurally.
+*   **Action:** Ensure that new features avoid Builders and Factories for simple objects.


### PR DESCRIPTION
This PR updates `simplification-suggestions.md` to accurately reflect the current state of the codebase and provide concrete action items for reducing overengineering.

- Acknowledges that `ProcessoFacade` and multiple process services have already been successfully consolidated into `ProcessoService.java`.
- Identifies `PainelFacade` and `UsuarioFacade` as remaining unnecessary indirection layers that should be refactored into services or handled in controllers.
- Explicitly lists `processos.ts`, `mapas.ts`, and `subprocessos.ts` as redundant pass-through Pinia stores that should be replaced with direct service calls or Composables (`useProcessos.ts`).
- Reiterates the need to avoid `ProcessoDetalheBuilder` and excessive DTO mappings.
- No application code was altered; tests confirm existing logic remains intact.

---
*PR created automatically by Jules for task [5525601669257487691](https://jules.google.com/task/5525601669257487691) started by @lgalvao*