### PR TITLE
chore: clean up unnecessary comments across the codebase

### DIFF
--- a/backend/src/main/java/sgc/processo/service/ProcessoService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoService.java
@@ -55,7 +55,6 @@ public class ProcessoService {
     private final SgcPermissionEvaluator permissionEvaluator;
     private final SubprocessoTransicaoService transicaoService;
 
-    // --- CONSULTAS (Baseadas em ProcessoConsultaService e ProcessoDetalheBuilder) ---
 
     @Transactional(readOnly = true)
     public Processo buscarPorCodigo(Long codigo) {
@@ -139,7 +138,6 @@ public class ProcessoService {
                 .toList();
     }
 
-    // --- MANUTENÇÃO (Baseada em ProcessoManutencaoService) ---
 
     public Processo criar(CriarProcessoRequest req) {
         List<Long> codigosUnidades = new ArrayList<>(req.unidades());
@@ -191,7 +189,6 @@ public class ProcessoService {
         log.info("Processo {} removido.", codigo);
     }
 
-    // --- WORKFLOW (Baseado em ProcessoWorkflowService) ---
 
     public List<String> iniciar(Long codigo, List<Long> codsUnidadesParam, Usuario usuario) {
         Processo processo = buscarPorCodigo(codigo);
@@ -253,7 +250,6 @@ public class ProcessoService {
         log.info("Processo {} finalizado", codigo);
     }
 
-    // --- AÇÕES EM BLOCO (Baseado em ProcessoFacade) ---
 
     public void executarAcaoEmBloco(Long codProcesso, AcaoEmBlocoRequest req) {
         Usuario usuario = usuarioService.usuarioAutenticado();
@@ -274,7 +270,6 @@ public class ProcessoService {
         processarAcoesBlocoAceiteHomologacao(req, usuario, subprocessos);
     }
 
-    // --- BUILDING DTO (Baseado em ProcessoDetalheBuilder) ---
 
     @Transactional(readOnly = true)
     public ProcessoDetalheDto obterDetalhesCompleto(Long codProcesso, Usuario usuario, boolean incluirElegiveis) {
@@ -307,7 +302,6 @@ public class ProcessoService {
         return dto;
     }
 
-    // --- NOTIFICAÇÕES (Baseado em ProcessoNotificacaoService) ---
 
     public void enviarLembrete(Long codProcesso, Long unidadeCodigo) {
         Processo processo = buscarPorCodigoComParticipantes(codProcesso);
@@ -329,7 +323,6 @@ public class ProcessoService {
         servicoAlertas.criarAlertaAdmin(processo, unidade, "Lembrete: Prazo encerra em " + dataLimiteText);
     }
 
-    // --- MÉTODOS PRIVADOS / AUXILIARES ---
 
     private List<Long> buscarCodigosAcesso(Usuario usuario) {
         Long root = usuario.getUnidadeAtivaCodigo();

--- a/e2e/captura.spec.ts
+++ b/e2e/captura.spec.ts
@@ -502,15 +502,12 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await expect(page.getByTestId('btn-processo-salvar')).toBeDisabled();
             await capturarTela(page, '03-processo', '10-botoes-desativados-form-vazio');
 
-            // Preencher descrição
             await page.getByTestId('inp-processo-descricao').fill(descricao);
             await expect(page.getByTestId('btn-processo-salvar')).toBeDisabled();
             await capturarTela(page, '03-processo', '11-botoes-desativados-falta-data-unidade');
 
-            // Selecionar tipo
             await page.getByTestId('sel-processo-tipo').selectOption('MAPEAMENTO');
 
-            // Preencher data
             const dataLimite = new Date();
             dataLimite.setDate(dataLimite.getDate() + 30);
             await page.getByTestId('inp-processo-data-limite').fill(dataLimite.toISOString().split('T')[0]);
@@ -1049,7 +1046,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await capturarTela(page, '11-unidades', '04-modal-criar-atribuicao');
             await page.getByRole('button', {name: /Cancelar/i}).click();
 
-            // 2. Histórico
             const linkHistorico = page.getByRole('link', {name: /Histórico/i});
             await expect(linkHistorico).toBeVisible();
             await linkHistorico.click();
@@ -1081,7 +1077,6 @@ test.describe('Captura de Telas - Sistema SGC', () => {
             await capturarTela(page, '13-configuracoes', '04-modal-adicionar-administrador');
             await page.getByRole('button', {name: /Cancelar/i}).click();
 
-            // 4. Relatórios
             const linkRelatorios = page.getByRole('link', {name: /Relatórios/i});
             await expect(linkRelatorios).toBeVisible();
             await linkRelatorios.click();

--- a/frontend/src/components/__tests__/ModalAcaoBloco.spec.ts
+++ b/frontend/src/components/__tests__/ModalAcaoBloco.spec.ts
@@ -140,4 +140,3 @@ describe("ModalAcaoBloco.vue", () => {
     });
 });
 
-

--- a/frontend/src/composables/useProcessos.ts
+++ b/frontend/src/composables/useProcessos.ts
@@ -49,7 +49,6 @@ export function useProcessos() {
     } = store;
 
     return {
-        // Estado
         carregando,
         processosPainel,
         processosPainelPage,
@@ -59,7 +58,6 @@ export function useProcessos() {
         subprocessosElegiveis,
         lastError,
         
-        // Ações
         clearError,
         buscarProcessosPainel,
         buscarProcessosFinalizados,


### PR DESCRIPTION
Cleaned up unnecessary comments (conversational AI blocks, redundant/obvious line comments, empty JSDocs, and visual separators) using the project's utility scripts, while preserving required linting ignore blocks.

---
*PR created automatically by Jules for task [5497561288646628089](https://jules.google.com/task/5497561288646628089) started by @lgalvao*