### PR TITLE
Resolve frontend linting and typecheck errors

### DIFF
--- a/frontend/etc/scripts/analisar-mensagens.cjs
+++ b/frontend/etc/scripts/analisar-mensagens.cjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * analisar-mensagens.cjs
  *
@@ -170,7 +171,7 @@ function gerarRelatorio(dados) {
 
     const agrupadas = agruparPorTexto(todasMensagens);
     const duplicatasExatas = [...agrupadas.entries()]
-        .filter(([_, grupo]) => grupo.length > 1)
+        .filter(([, grupo]) => grupo.length > 1)
         .sort((a, b) => b[1].length - a[1].length);
 
     if (duplicatasExatas.length === 0) {

--- a/frontend/etc/scripts/extrair-mensagens.cjs
+++ b/frontend/etc/scripts/extrair-mensagens.cjs
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * extrair-mensagens.cjs
  *
@@ -22,7 +23,6 @@ const RAIZ = path.join(__dirname, '../../..');
 const BACKEND_SRC = path.join(RAIZ, 'backend/src/main/java/sgc');
 const BACKEND_TEST = path.join(RAIZ, 'backend/src/test/java/sgc');
 const FRONTEND_SRC = path.join(RAIZ, 'frontend/src');
-const FRONTEND_TEST = path.join(RAIZ, 'frontend/src');
 const E2E_DIR = path.join(RAIZ, 'e2e');
 const OUTPUT_FILE = path.join(RAIZ, 'mensagens-extraidas.json');
 
@@ -104,7 +104,6 @@ function extrairMensagensValidacaoDto(arquivos) {
  */
 function extrairMensagensExcecoes(arquivos) {
     const mensagens = [];
-    const PATTERN = /throw\s+new\s+Erro\w+\(\s*"([^"]+)"/g;
 
     for (const arquivo of arquivos) {
         const conteudo = fs.readFileSync(arquivo, 'utf-8');
@@ -173,7 +172,6 @@ function extrairMensagensTeste(arquivos) {
  */
 function extrairMensagensToast(arquivos) {
     const mensagens = [];
-    const PATTERN = /setPending\(\s*["'`]([^"'`]+)["'`]\s*\)/g;
 
     for (const arquivo of arquivos) {
         const conteudo = fs.readFileSync(arquivo, 'utf-8');

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -14,6 +14,7 @@ function parseStringDate(s: string): Date | null {
         const ddmmyyyy = parse(trimmed, "dd/MM/yyyy", new Date());
         if (isValid(ddmmyyyy)) return ddmmyyyy;
     } catch {
+        // ignore
     }
 
     if (/^\d{10,}$/.test(trimmed)) {


### PR DESCRIPTION
This change addresses the linting and typechecking errors identified during a quality check of the frontend and root project. The fixes include adding necessary comments to empty catch blocks, suppressing inappropriate lint rules for CommonJS scripts, and removing dead code (unused variables/constants). All tests and typechecks now pass successfully.

---
*PR created automatically by Jules for task [1704065397778576442](https://jules.google.com/task/1704065397778576442) started by @lgalvao*