### PR TITLE
Increase Backend Test Coverage for Processo Domain

### DIFF
--- a/backend/src/test/java/sgc/processo/ProcessoControllerTest.java
+++ b/backend/src/test/java/sgc/processo/ProcessoControllerTest.java
@@ -307,6 +307,48 @@ class ProcessoControllerTest {
     class NovasListagens {
         @Test
         @WithMockUser(roles = "ADMIN")
+        @DisplayName("listarParaImportacao deve retornar lista de processos para importacao")
+        void deveListarParaImportacao() throws Exception {
+            when(processoService.listarParaImportacao())
+                    .thenReturn(List.of(Processo.builder().codigo(1L).build()));
+
+            mockMvc.perform(get("/api/processos/para-importacao"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$[0].codigo").value(1L));
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
+        @DisplayName("listarUnidadesParaImportacao deve retornar lista de participantes quando finalizado")
+        void deveListarUnidadesParaImportacaoQuandoFinalizado() throws Exception {
+            Processo processo = Processo.builder()
+                .codigo(1L)
+                .situacao(SituacaoProcesso.FINALIZADO)
+                .build();
+
+            Unidade unidade = Unidade.builder().codigo(10L).sigla("U1").nome("Unidade 1").situacao(SituacaoUnidade.ATIVA).build();
+            processo.adicionarParticipantes(Set.of(unidade));
+
+            when(processoService.buscarPorCodigoComParticipantes(1L)).thenReturn(processo);
+
+            Subprocesso sub = Subprocesso.builder()
+                .codigo(100L)
+                .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO)
+                .unidade(unidade)
+                .dataLimiteEtapa1(LocalDateTime.now())
+                .build();
+            when(subprocessoService.listarEntidadesPorProcesso(1L)).thenReturn(List.of(sub));
+
+            mockMvc.perform(get("/api/processos/1/unidades-importacao"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$[0].codUnidade").value(10L))
+                    .andExpect(jsonPath("$[0].codSubprocesso").value(100L));
+        }
+
+        @Test
+        @WithMockUser(roles = "ADMIN")
         @DisplayName("obterStatusUnidades deve retornar unidades desabilitadas")
         void deveObterStatusUnidades() throws Exception {
             when(processoService.listarUnidadesBloqueadasPorTipo(TipoProcesso.MAPEAMENTO)).thenReturn(List.of(1L, 2L));
@@ -383,6 +425,28 @@ class ProcessoControllerTest {
     @Nested
     @DisplayName("Cobertura extra")
     class CoberturaExtra {
+        @Test
+        @DisplayName("listarUnidadesParaImportacao deve lancar ErroValidacao quando nao finalizado")
+        void deveLancarErroValidacaoQuandoListarUnidadesParaImportacaoNaoFinalizado() {
+            Processo processo = Processo.builder()
+                .codigo(1L)
+                .situacao(SituacaoProcesso.EM_ANDAMENTO)
+                .build();
+            when(processoServiceMock.buscarPorCodigoComParticipantes(1L)).thenReturn(processo);
+
+            ErroValidacao ex = assertThrows(ErroValidacao.class, () -> controller.listarUnidadesParaImportacao(1L));
+            assertEquals(sgc.comum.MsgValidacao.PROCESSO_DEVE_ESTAR_FINALIZADO, ex.getMessage());
+        }
+
+        @Test
+        @DisplayName("excluir chama servico e retorna 204")
+        void excluir_RetornaNoContent() {
+            Long codigo = 1L;
+            ResponseEntity<Void> response = controller.excluir(codigo);
+            verify(processoServiceMock).apagar(codigo);
+            assertEquals(204, response.getStatusCode().value());
+        }
+
         // Usar mocks manuais para testes isolados
         private ProcessoController controller;
         private ProcessoService processoServiceMock;

--- a/backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java
@@ -236,6 +236,77 @@ class ProcessoServiceTest {
     @DisplayName("Consultas e Detalhes")
     class Consultas {
         @Test
+        @DisplayName("Deve listar para importacao")
+        void deveListarParaImportacao() {
+            Processo p = new Processo();
+            when(processoRepo.listarPorSituacaoComParticipantes(SituacaoProcesso.FINALIZADO)).thenReturn(List.of(p));
+
+            List<Processo> res = processoService.listarParaImportacao();
+            assertThat(res).containsExactly(p);
+            verify(processoRepo).listarPorSituacaoComParticipantes(SituacaoProcesso.FINALIZADO);
+        }
+
+        @Test
+        @DisplayName("Deve listar ativos para ADMIN")
+        void deveListarAtivosParaAdmin() {
+            Usuario admin = new Usuario();
+            admin.setPerfilAtivo(Perfil.ADMIN);
+            when(usuarioService.usuarioAutenticado()).thenReturn(admin);
+
+            Processo p = new Processo();
+            when(processoRepo.listarPorSituacao(SituacaoProcesso.EM_ANDAMENTO)).thenReturn(List.of(p));
+
+            List<Processo> res = processoService.listarAtivos();
+            assertThat(res).containsExactly(p);
+            verify(processoRepo).listarPorSituacao(SituacaoProcesso.EM_ANDAMENTO);
+            verify(processoRepo, never()).listarPorSituacaoEUnidadeCodigos(any(), any());
+        }
+
+        @Test
+        @DisplayName("Deve listar ativos para usuario normal")
+        void deveListarAtivosParaUsuarioNormal() {
+            Usuario gestor = new Usuario();
+            gestor.setPerfilAtivo(Perfil.GESTOR);
+            Unidade u = new Unidade();
+            u.setCodigo(1L);
+            gestor.setUnidadeAtivaCodigo(1L);
+            when(usuarioService.usuarioAutenticado()).thenReturn(gestor);
+            when(unidadeService.todasComHierarquia()).thenReturn(List.of(u));
+
+            Processo p = new Processo();
+            when(processoRepo.listarPorSituacaoEUnidadeCodigos(eq(SituacaoProcesso.EM_ANDAMENTO), anyList())).thenReturn(List.of(p));
+
+            List<Processo> res = processoService.listarAtivos();
+            assertThat(res).containsExactly(p);
+            verify(processoRepo).listarPorSituacaoEUnidadeCodigos(eq(SituacaoProcesso.EM_ANDAMENTO), anyList());
+            verify(processoRepo, never()).listarPorSituacao(any());
+        }
+
+        @Test
+        @DisplayName("Deve listar iniciados por participantes")
+        void deveListarIniciadosPorParticipantes() {
+            Pageable pageable = Pageable.unpaged();
+            Processo p = new Processo();
+            when(processoRepo.listarPorParticipantesESituacaoDiferente(anyList(), eq(SituacaoProcesso.CRIADO), eq(pageable)))
+                    .thenReturn(new PageImpl<>(List.of(p)));
+
+            Page<Processo> res = processoService.listarIniciadosPorParticipantes(List.of(1L), pageable);
+            assertThat(res.getContent()).containsExactly(p);
+            verify(processoRepo).listarPorParticipantesESituacaoDiferente(List.of(1L), SituacaoProcesso.CRIADO, pageable);
+        }
+
+        @Test
+        @DisplayName("Deve listar unidades bloqueadas por tipo")
+        void deveListarUnidadesBloqueadasPorTipo() {
+            when(processoRepo.listarUnidadesBloqueadasPorSituacaoETipo(SituacaoProcesso.EM_ANDAMENTO, TipoProcesso.MAPEAMENTO))
+                    .thenReturn(List.of(1L, 2L));
+
+            List<Long> res = processoService.listarUnidadesBloqueadasPorTipo(TipoProcesso.MAPEAMENTO);
+            assertThat(res).containsExactly(1L, 2L);
+            verify(processoRepo).listarUnidadesBloqueadasPorSituacaoETipo(SituacaoProcesso.EM_ANDAMENTO, TipoProcesso.MAPEAMENTO);
+        }
+
+        @Test
         @DisplayName("Deve buscar entidade por ID")
         void deveBuscarEntidadePorId() {
             Long id = 100L;


### PR DESCRIPTION
This commit significantly improves the test coverage in the `Processo` domain (specifically `ProcessoController` and `ProcessoService`), aiming to satisfy the project's quality thresholds.

Testing strategies implemented:
- Added MockMvc calls expecting success/failure status and exact json payload matches for `ProcessoController`.
- Stubs matching business rules (ADMIN vs GESTOR) logic implemented in `ProcessoService` repository delegations.
- Re-run global suite to verify 0 regressions.

---
*PR created automatically by Jules for task [15649271718400055958](https://jules.google.com/task/15649271718400055958) started by @lgalvao*