### PR TITLE
docs: update simplification suggestions for limited-scale intranet system

### DIFF
--- a/simplification-suggestions.md
+++ b/simplification-suggestions.md
@@ -1,39 +1,46 @@
 # Simplification & De-overengineering Suggestions
 
-Based on the constraint that this is an intranet application for at most 5-10 simultaneous users, many patterns suited for highly-scalable, multi-layered, and super-modularized enterprise applications are unnecessary and represent overengineering. Below are suggestions to simplify the codebase, reduce fragmentation, and improve maintainability.
+**CRITICAL SYSTEM DESIGN CONSTRAINT:** This system is an intranet tool designed to be used by **at most 5-10 simultaneous users**.
+
+Because of this extremely limited scale, many architectural guidelines accrued from training on highly-scalable, multi-layered, super-modularized enterprise applications **DO NOT APPLY HERE**. Applying such patterns introduces excessive complexity, fragmentation, and overhead without any tangible benefit to this specific project.
+
+Below are concrete suggestions to simplify the codebase, reduce fragmentation, and improve maintainability by removing overengineered solutions.
 
 ## 1. Backend: Eliminate Facade Layers
-**Issue:** The project currently uses Facades (`PainelFacade`, `UsuarioFacade`, `AlertaFacade`, `RelatorioFacade`, `LoginFacade`, `AtividadeFacade`) as an intermediary layer between Controllers and Services.
+**Issue:** The project currently uses Facades (`PainelFacade`, `UsuarioFacade`, `AlertaFacade`, `RelatorioFacade`, `LoginFacade`, `AtividadeFacade`) as an unnecessary intermediary layer between Controllers and Services. In a system of this size, this is pure overengineering.
 **Suggestion:**
 - Remove the Facade layer entirely. Domain logic should be consolidated directly into Services (e.g., `ProcessoService`, `PainelService`, `UsuarioService`).
-- Controllers can call Services directly, or for simple CRUD operations, Controllers should be allowed to inject and call Spring Data Repositories directly. This eliminates boilerplate and pass-through code.
+- Controllers MUST call Services directly.
+- **For simple CRUD operations, Controllers are strictly allowed to inject and call Spring Data Repositories directly.** This eliminates boilerplate pass-through code.
 
 ## 2. Frontend: Remove Pass-Through Pinia Stores
-**Issue:** Several Pinia stores (`mapas.ts`, `processos.ts`, `subprocessos.ts`, `atividades.ts`, `usuarios.ts`, `configuracoes.ts`) act as unnecessary pass-throughs that merely fetch and cache API data for single views.
+**Issue:** Several Pinia stores (`mapas.ts`, `processos.ts`, `subprocessos.ts`, `configuracoes.ts`) act as unnecessary pass-throughs that merely fetch and cache API data for single views, introducing unwanted state-synchronization complexity.
 **Suggestion:**
 - Remove these stores. Use standard Vue `ref`s, `reactive`, or composables (like `useAsyncAction`) directly within components to hold page-level state and call `services/` directly.
-- Reserve Pinia strictly for true global state that is shared across the entire application, such as Authentication/Profile (`perfil.ts`) and UI Feedback/Notifications (`feedback.ts`, `toast.ts`).
+- Reserve Pinia strictly for true global state that is shared across the entire application, such as Authentication/Profile (`perfil.ts`) and UI Feedback/Notifications (`toast.ts`, `feedback.ts`).
 
 ## 3. Backend: Reduce Service Fragmentation
 **Issue:** Domain logic is heavily fragmented into micro-services within the monolith. For example:
 - `Subprocesso` has `SubprocessoService`, `SubprocessoTransicaoService`, `SubprocessoValidacaoService`, `SubprocessoNotificacaoService`.
 - `Mapa` has `MapaVisualizacaoService`, `MapaSalvamentoService`, `ImpactoMapaService`, `MapaManutencaoService`, `CopiaMapaService`.
 **Suggestion:**
-- Consolidate these fragmented classes into cohesive, domain-centric services (e.g., a single `SubprocessoService` and a single `MapaService`). Given the application's scale, procedural code in a single service is easier to trace and maintain than navigating through multiple dispersed classes and injected dependencies.
+- Consolidate these fragmented classes into cohesive, domain-centric services (e.g., a single `SubprocessoService` and a single `MapaService`). Given the application's scale, procedural code in a single service is easier to trace, understand, and maintain than navigating through multiple dispersed classes and injected dependencies.
 
 ## 4. Backend: Minimize DTO Mapping for Simple Reads
 **Issue:** There is a proliferation of DTOs for simple read operations where the data closely matches the underlying entity.
 **Suggestion:**
-- Return JPA entities directly from Controllers for simple read operations. Eliminate DTOs (and their mapping boilerplate) unless there is a strict need to hide sensitive fields, prevent recursive serialization (e.g., bidirectional relationships), or aggregate data from multiple entities that cannot be simply solved by Jackson annotations (like `@JsonIgnore` or `@JsonView`).
+- Return JPA entities directly from Controllers for simple read operations.
+- Eliminate DTOs (and their mapping boilerplate) unless there is a strict need to hide sensitive fields, prevent recursive serialization (e.g., bidirectional relationships), or aggregate data from multiple entities that cannot be simply solved by Jackson annotations (like `@JsonIgnore` or `@JsonView`).
 
 ## 5. Frontend: Eliminate Unnecessary Wrapper Components
 **Issue:** Applying strict modularization often leads to creating wrapper components that do nothing but proxy props and events down to a library component.
 **Suggestion:**
 - Avoid creating Vue components that only wrap base UI components (like BootstrapVueNext components) without adding substantial domain logic or distinct visual structure. Use the base components directly to avoid prop-drilling and event-bubbling overhead.
 
-## 6. General Architectural Philosophy
-- **Interfaces:** Avoid single-implementation interfaces. If an interface only has an `Impl` class, remove the interface and use the concrete class directly.
-- **Patterns:** Avoid complex design patterns (Builders for simple objects, Factories, Hexagonal/Onion architectures). Use Spring Boot and Hibernate features directly and simply.
+## 6. General Architectural Philosophy for this Scale
+- **No Complex Architectures:** Avoid Hexagonal Architecture, Onion Architecture, CQRS, or strict Clean Architecture boundaries. Use JPA annotations directly on domain models.
+- **Interfaces:** Avoid single-implementation interfaces (e.g., `IService` and `ServiceImpl`). If an interface only has an `Impl` class, remove the interface and use the concrete class directly.
+- **Patterns:** Avoid complex design patterns (Builders for simple objects, Factories). Use Spring Boot and Hibernate features directly and simply. Keep the monolithic structure cohesive (no microservices or fragmented Gradle subprojects).
 
 ## 7. Active Simplification Efforts
 **Current Status:** There are active efforts to implement these simplifications, as documented in `plano-simplificacao.md`.


### PR DESCRIPTION
Updated `simplification-suggestions.md` to reflect the constraint that the system is an intranet tool for at most 5-10 users.

I explicitly emphasized that high-scalability, super-modular enterprise patterns do not apply and highlighted concrete areas in the codebase where overengineering should be simplified (e.g., Facade classes in the backend, pass-through Pinia stores in the frontend). I also provided specific rules like allowing simple repository injections directly into controllers and avoiding single-implementation interfaces. Tests were run and remain green.

---
*PR created automatically by Jules for task [8883728795703420484](https://jules.google.com/task/8883728795703420484) started by @lgalvao*