### PR TITLE
chore: clean up unnecessary comments

### DIFF
--- a/backend/src/main/java/sgc/e2e/E2eController.java
+++ b/backend/src/main/java/sgc/e2e/E2eController.java
@@ -378,7 +378,6 @@ public class E2eController {
         int diasLimite = request.diasLimite() != null ? request.diasLimite() : 30;
         Unidade unidade = unidadeService.buscarPorSigla(request.unidadeSigla());
 
-        // 1. Criar processo de mapeamento base e tornar seu mapa vigente na unidade
         ProcessoFixtureRequest requestMapeamento = new ProcessoFixtureRequest(
                 "Mapa base fixture " + System.currentTimeMillis(), request.unidadeSigla(), true, diasLimite);
         Processo processoMapeamento = criarProcessoFixture(requestMapeamento, TipoProcesso.MAPEAMENTO);
@@ -399,7 +398,6 @@ public class E2eController {
         jdbcTemplate.update("INSERT INTO sgc.unidade_mapa (unidade_codigo, mapa_vigente_codigo) VALUES (?, ?)",
                 unidade.getCodigo(), codMapaVigente);
 
-        // 2. Criar processo de revisão e definir situação como REVISAO_CADASTRO_DISPONIBILIZADA
         ProcessoFixtureRequest requestRevisao = new ProcessoFixtureRequest(
                 request.descricao(), request.unidadeSigla(), true, diasLimite);
         Processo processoRevisao = criarProcessoFixture(requestRevisao, TipoProcesso.REVISAO);

--- a/e2e/captura.spec.ts
+++ b/e2e/captura.spec.ts
@@ -36,7 +36,6 @@ import * as fs from 'node:fs';
  * para refinamento de UI. Funciona tambem como um bom teste 'smoke'
  */
 
-// Interface para metadados das capturas (Padrão Captus)
 interface CaptureMetadata {
     file: string;
     url: string;

--- a/e2e/helpers/helpers-atividades.ts
+++ b/e2e/helpers/helpers-atividades.ts
@@ -281,7 +281,6 @@ export async function importarAtividadesComAvisoDuplicidade(page: Page, processo
     const modal = page.getByRole('dialog');
     await modal.getByTestId('btn-importar').click();
 
-    // O modal deve fechar (sem erro) mesmo quando todas as atividades são duplicatas
     await expect(modal).toBeHidden();
 }
 

--- a/etc/scripts/clean_comments.py
+++ b/etc/scripts/clean_comments.py
@@ -100,7 +100,7 @@ def process_file(filepath):
 modified_files = []
 
 for root, dirs, files in os.walk('.'):
-    if 'node_modules' in root or '.git' in root or 'build' in root or 'dist' in root or 'test' in root or '__tests__' in root or 'stories' in root:
+    if 'node_modules' in root or '.git' in root or 'build' in root or 'dist' in root:
         continue
     for file in files:
         if file.endswith(('.ts', '.js', '.vue', '.java')):

--- a/frontend/src/__tests__/views/LoginView.spec.ts
+++ b/frontend/src/__tests__/views/LoginView.spec.ts
@@ -34,7 +34,7 @@ describe("LoginView.vue", () => {
                 createTestingPinia({
                     createSpy: vi.fn,
                     initialState: initialState,
-                    stubActions: false, // We want to call actions to test logic inside them or mock them explicitly
+                    stubActions: false,
                 }),
             ],
             // Stubs for bootstrap components to simplify testing


### PR DESCRIPTION
Cleaned up unnecessary comments:
- Executed `clean-ai-comments.mjs` to remove multiline conversational comments added by AI agents
- Executed `clean_comments.py` to strip obvious Javadoc/JSDoc parameters and returns, and other obvious descriptive comments
- Fixed `clean_comments.py` to also process test and `e2e` directories.
- Addressed minor remaining AI conversational comments inside test spec files manually.

---
*PR created automatically by Jules for task [14654778225643739571](https://jules.google.com/task/14654778225643739571) started by @lgalvao*