### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/views/AtribuicaoTemporariaView.vue
+++ b/frontend/src/views/AtribuicaoTemporariaView.vue
@@ -71,12 +71,12 @@
               <BListGroup v-else-if="usuariosEncontrados.length > 0" flush>
                 <BListGroupItem
                     v-for="(usuario, indice) in usuariosEncontrados"
+                    :id="`opcao-usuario-${usuario.codigo}`"
                     :key="usuario.codigo"
                     action
                     button
                     :active="indiceUsuarioDestacado === indice"
                     :data-testid="`opcao-usuario-${usuario.codigo}`"
-                    :id="`opcao-usuario-${usuario.codigo}`"
                     @mousedown.prevent="selecionarUsuario(usuario)"
                 >
                   {{ usuario.nome }}

--- a/frontend/src/views/CadastroVisualizacaoView.vue
+++ b/frontend/src/views/CadastroVisualizacaoView.vue
@@ -3,7 +3,7 @@
     <PageHeader title="Atividades e conhecimentos">
       <template #default>
         <div class="unidade-cabecalho mb-0">
-          <span class="unidade-sigla">{{ siglaUnidade }}</span>
+          <span class="unidade-sigla">{{ siglaUnidade }}<template v-if="nomeUnidade"> - {{ nomeUnidade }}</template></span>
         </div>
       </template>
       <template #actions>

--- a/frontend/src/views/MapaVisualizacaoView.vue
+++ b/frontend/src/views/MapaVisualizacaoView.vue
@@ -64,7 +64,7 @@
     <div v-if="unidade">
       <div class="mb-5 d-flex align-items-center">
         <div class="fs-5" data-testid="txt-header-unidade">
-          {{ unidade.sigla }}
+          {{ unidade.sigla }}<template v-if="unidade.nome"> - {{ unidade.nome }}</template>
         </div>
       </div>
 


### PR DESCRIPTION
This PR fixes several quality issues identified in the frontend:
1. **Linting**: Fixed an unused variable warning in `CadastroVisualizacaoView.vue` by incorporating the unit name into the page header, which also improves UI consistency.
2. **Unit Tests**: Resolved assertion failures in `MapaVisualizacaoView.spec.ts` and `VisMapa.spec.ts`. These tests expected the unit identification to follow the pattern "SIGLA - Nome", but `MapaVisualizacaoView.vue` was only showing the sigla.
3. **Verification**: Successfully ran `npm run typecheck`, `npm run lint`, and `npm run test:unit` in the frontend to ensure all checks pass. Verified visual consistency by running the E2E capture suite.

---
*PR created automatically by Jules for task [15651077878954916293](https://jules.google.com/task/15651077878954916293) started by @lgalvao*