### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/views/__tests__/CadastroViewPermissoes.spec.ts
+++ b/frontend/src/views/__tests__/CadastroViewPermissoes.spec.ts
@@ -4,6 +4,7 @@ import {beforeEach, describe, expect, it, vi} from "vitest";
 import {ref} from "vue";
 import * as usePerfilModule from "@/composables/usePerfil";
 import * as subprocessoService from "@/services/subprocessoService";
+import * as processoService from "@/services/processoService";
 import CadastroView from "@/views/CadastroView.vue";
 import {Perfil, SituacaoSubprocesso, TipoProcesso} from "@/types/tipos";
 
@@ -20,6 +21,10 @@ vi.mock("@/services/subprocessoService", () => ({
     buscarContextoEdicao: vi.fn(),
     validarCadastro: vi.fn(),
     listarAtividades: vi.fn(),
+}));
+
+vi.mock("@/services/processoService", () => ({
+    obterDetalhesProcesso: vi.fn(),
 }));
 
 const stubs = {
@@ -49,6 +54,10 @@ describe("CadastroView - permissões no carregamento", () => {
             isChefe: ref(true),
         } as any);
 
+        vi.mocked(processoService.obterDetalhesProcesso).mockResolvedValue({
+            codigo: 1,
+            unidades: []
+        } as any);
         vi.mocked(subprocessoService.buscarSubprocessoPorProcessoEUnidade).mockResolvedValue({codigo: 123} as any);
         vi.mocked(subprocessoService.buscarContextoEdicao).mockResolvedValue({
             detalhes: {


### PR DESCRIPTION
I performed a quality check on the frontend, including type-checking, linting, and unit tests.

During the unit tests, I identified an unhandled `AxiosError: Network Error` in `frontend/src/views/__tests__/CadastroViewPermissoes.spec.ts`. This was caused by the `CadastroView.vue` component calling `processosStore.buscarProcessoDetalhe` on mount, which in turn calls the real `processoService.obterDetalhesProcesso` because the service was not mocked in that specific test file.

I fixed this by:
1. Mocking `@/services/processoService` in the test file.
2. Providing a default resolved value for `obterDetalhesProcesso` in the `beforeEach` block.

After the fix, all 1089 frontend unit tests passed without unhandled errors. Type-checking and linting also passed for both the root and frontend projects.

---
*PR created automatically by Jules for task [1019898172660204878](https://jules.google.com/task/1019898172660204878) started by @lgalvao*