### PR TITLE
fix: resolve lint and typecheck errors in e2e and frontend

### DIFF
--- a/e2e/captura.spec.ts
+++ b/e2e/captura.spec.ts
@@ -86,12 +86,12 @@ async function capturarTela(page: Page, categoria: string, nome: string, opcoes?
     const viewport = page.viewportSize() || { width: 0, height: 0 };
     
     // Extrair rota da URL (ex: /painel)
-    let route = '/';
+    let routePath;
     try {
         const urlObj = new URL(url);
-        route = urlObj.pathname + urlObj.search;
+        routePath = urlObj.pathname + urlObj.search;
     } catch {
-        route = url;
+        routePath = url;
     }
 
     // Injetar banner com a URL no RODAPÉ
@@ -142,7 +142,7 @@ async function capturarTela(page: Page, categoria: string, nome: string, opcoes?
     capturasMetadata.push({
         file: nomeArquivo,
         url,
-        route,
+        route: routePath,
         viewport,
         timestamp: new Date().toISOString(),
         tags: [...(opcoes?.tags ?? []), categoria],
@@ -168,12 +168,12 @@ async function capturarComponente(elemento: Locator, categoria: string, nome: st
     const viewport = page.viewportSize() || { width: 0, height: 0 };
     
     // Extrair rota
-    let route = '/';
+    let routePath;
     try {
         const urlObj = new URL(url);
-        route = urlObj.pathname + urlObj.search;
+        routePath = urlObj.pathname + urlObj.search;
     } catch {
-        route = url;
+        routePath = url;
     }
 
     // Para componentes, adicionamos um selo discreto no final
@@ -204,7 +204,7 @@ async function capturarComponente(elemento: Locator, categoria: string, nome: st
     capturasMetadata.push({
         file: nomeArquivo,
         url,
-        route,
+        route: routePath,
         viewport,
         timestamp: new Date().toISOString(),
         tags: [...(tags ?? []), categoria, 'componente'],

--- a/frontend/src/composables/useSubprocessos.ts
+++ b/frontend/src/composables/useSubprocessos.ts
@@ -117,7 +117,7 @@ function atualizarStatusLocal(status: {
     };
 }
 
-export function useSubprocessos(_pinia?: unknown) {
+export function useSubprocessos() {
     return {
         get subprocessoDetalhe() {
             return subprocessoDetalhe.value;


### PR DESCRIPTION
This submission fixes minor static analysis errors discovered during a general quality check. It resolves unused variable assignments in the E2E capture script and an unused parameter violation in a Vue composable. All tests (backend and frontend), linting, and typechecking now pass.

---
*PR created automatically by Jules for task [6554211586520620289](https://jules.google.com/task/6554211586520620289) started by @lgalvao*