### PR TITLE
Fix Frontend Quality Check Failures

### DIFF
--- a/frontend/src/views/__tests__/ProcessoView.spec.ts
+++ b/frontend/src/views/__tests__/ProcessoView.spec.ts
@@ -86,19 +86,22 @@ const mockElegiveis = [
         unidadeCodigo: 101,
         unidadeSigla: "UNI1",
         unidadeNome: "Unidade 1",
-        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO
+        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO,
+        localizacaoCodigo: 999
     },
     {
         unidadeCodigo: 103,
         unidadeSigla: "UNI3",
         unidadeNome: "Unidade 3",
-        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO
+        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO,
+        localizacaoCodigo: 999
     },
     {
         unidadeCodigo: 104,
         unidadeSigla: "UNI4",
         unidadeNome: "Unidade 4",
-        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO
+        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO,
+        localizacaoCodigo: 999
     }
 ];
 
@@ -175,7 +178,7 @@ describe("Processo.vue", () => {
                     ProcessoInfo: ProcessoInfoStub,
                     BAlert: BAlertStub,
                     BSpinner: BSpinnerStub,
-                    BButton: {template: "<button><slot></slot></button>"}
+                    BButton: {template: '<button @click="$emit(\'click\', $event)"><slot /></button>'}
                 }
             }
         });

--- a/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts
@@ -249,13 +249,15 @@ describe("ProcessoViewCoverage.spec.ts", () => {
                         unidadeCodigo: 1,
                         unidadeSigla: "A",
                         unidadeNome: "Unidade A",
-                        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO
+                        situacao: SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO,
+                        localizacaoCodigo: 100
                     }, // Eligible
                     {
                         unidadeCodigo: 2,
                         unidadeSigla: "B",
                         unidadeNome: "Unidade B",
-                        situacao: "OUTRO"
+                        situacao: "OUTRO",
+                        localizacaoCodigo: 100
                     }
                 ]
             }
@@ -273,13 +275,15 @@ describe("ProcessoViewCoverage.spec.ts", () => {
                         unidadeCodigo: 1,
                         unidadeSigla: "A",
                         unidadeNome: "Unidade A",
-                        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO
+                        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO,
+                        localizacaoCodigo: 100
                     }, // Eligible
                     {
                         unidadeCodigo: 2,
                         unidadeSigla: "B",
                         unidadeNome: "Unidade B",
-                        situacao: "OUTRO"
+                        situacao: "OUTRO",
+                        localizacaoCodigo: 100
                     }
                 ]
             }
@@ -296,13 +300,15 @@ describe("ProcessoViewCoverage.spec.ts", () => {
                         unidadeCodigo: 1,
                         unidadeSigla: "A",
                         unidadeNome: "Unidade A",
-                        situacao: SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA
+                        situacao: SituacaoSubprocesso.REVISAO_CADASTRO_DISPONIBILIZADA,
+                        localizacaoCodigo: 100
                     }, // Eligible
                     {
                         unidadeCodigo: 2,
                         unidadeSigla: "B",
                         unidadeNome: "Unidade B",
-                        situacao: "OUTRO"
+                        situacao: "OUTRO",
+                        localizacaoCodigo: 100
                     }
                 ]
             }


### PR DESCRIPTION
This PR fixes failing unit tests in the frontend discovered during a quality check. The failures were primarily due to outdated mock data (missing `localizacaoCodigo` required for filtering) and a non-functional `BButton` stub that prevented event handlers from being triggered. Type checking and linting were also verified and are passing.

---
*PR created automatically by Jules for task [13992345392332034938](https://jules.google.com/task/13992345392332034938) started by @lgalvao*