### PR TITLE
Fix frontend quality check and type errors

### DIFF
--- a/frontend/src/constants/textos.ts
+++ b/frontend/src/constants/textos.ts
@@ -178,6 +178,8 @@ export const TEXTOS = {
     SUCESSO_LEMBRETE_ENVIADO: "Lembrete enviado",
     ERRO_LEMBRETE_ENVIADO: "Não foi possível enviar o lembrete",
     CARREGANDO: "Carregando informações da unidade...",
+    NAO_ENCONTRADO_TITULO: "Subprocesso não iniciado",
+    NAO_ENCONTRADO_DESC: "Este subprocesso ainda não foi iniciado ou a unidade não participa deste processo.",
     REABRIR_CADASTRO_TITULO: "Reabrir cadastro",
     REABRIR_REVISAO_TITULO: "Reabrir revisão",
     BOTAO_CONFIRMAR_REABERTURA: "Confirmar reabertura",

--- a/frontend/src/views/SubprocessoView.vue
+++ b/frontend/src/views/SubprocessoView.vue
@@ -161,8 +161,8 @@
     </div>
     <div v-else-if="erroNaoEncontrado" class="text-center py-5">
       <i class="bi bi-exclamation-triangle fs-1 text-warning mb-3 d-block"></i>
-      <h3>{{ TEXTOS.subprocesso.NAO_ENCONTRADO_TITULO || 'Subprocesso não iniciado' }}</h3>
-      <p class="text-muted">{{ TEXTOS.subprocesso.NAO_ENCONTRADO_DESC || 'Este subprocesso ainda não foi iniciado ou a unidade não participa deste processo.' }}</p>
+      <h3>{{ TEXTOS.subprocesso.NAO_ENCONTRADO_TITULO }}</h3>
+      <p class="text-muted">{{ TEXTOS.subprocesso.NAO_ENCONTRADO_DESC }}</p>
       <BButton to="/painel" variant="primary" class="mt-3">Voltar para o Painel</BButton>
     </div>
     <div v-else class="text-center py-5">


### PR DESCRIPTION
Performed a comprehensive quality check on the frontend and root project.
1. Ran `npm run typecheck` from the root, which identified missing properties in `TEXTOS.subprocesso` used in `SubprocessoView.vue`.
2. Added `NAO_ENCONTRADO_TITULO` and `NAO_ENCONTRADO_DESC` to `frontend/src/constants/textos.ts` under the `subprocesso` section to centralize all UI strings.
3. Updated `frontend/src/views/SubprocessoView.vue` to use these new constants and removed hardcoded fallback strings.
4. Verified that `npm run typecheck`, `npm run lint --prefix frontend`, and `npm run test:unit --prefix frontend` all pass successfully.
5. Ran `npm run quality:all --prefix frontend` to ensure coverage and all checks remain green.

---
*PR created automatically by Jules for task [3722655504389077218](https://jules.google.com/task/3722655504389077218) started by @lgalvao*