### PR TITLE
Fix frontend quality check warnings

### DIFF
--- a/e2e/cdu-01.spec.ts
+++ b/e2e/cdu-01.spec.ts
@@ -9,6 +9,7 @@ test.describe('CDU-01 - Realizar login e exibir estrutura das telas', () => {
 
     test('Deve exibir a tela de login com campos obrigatórios', async ({page}) => {
         await verificarTelaLogin(page);
+        await expect(page).toHaveURL(/\/login/);
     });
 
     test('Deve exibir erro com credenciais inválidas', async ({page}) => {

--- a/frontend/src/components/processo/ProcessoFormFields.vue
+++ b/frontend/src/components/processo/ProcessoFormFields.vue
@@ -150,7 +150,7 @@ const inputDescricaoRef = ref<InstanceType<typeof BFormInput> | null>(null);
 const selectTipoRef = ref<any>(null);
 const inputDataLimiteRef = ref<InstanceType<typeof InputData> | null>(null);
 const containerUnidadesRef = ref<HTMLElement | null>(null);
-const {obterPrimeiroCampoComErro, possuiErros} = useValidacao();
+const {obterPrimeiroCampoComErro} = useValidacao();
 
 const tipoOptions = [
   {value: TipoProcesso.MAPEAMENTO, text: 'Mapeamento'},


### PR DESCRIPTION
I performed a quality check on the frontend and root project, addressing linting warnings found in both.

Specifically:
- In `frontend/src/components/processo/ProcessoFormFields.vue`, I removed the unused `possuiErros` variable destructuring from the `useValidacao` composable.
- In `e2e/cdu-01.spec.ts`, I added an explicit `expect(page).toHaveURL(/\/login/)` assertion to the 'Deve exibir a tela de login com campos obrigatórios' test to satisfy the `playwright/expect-expect` ESLint rule, which requires tests to have direct assertions even when calling verification helpers.

All typechecks, lint checks, and unit tests are now passing without warnings or errors.

---
*PR created automatically by Jules for task [8454095379276249732](https://jules.google.com/task/8454095379276249732) started by @lgalvao*