### PR TITLE
Correção ao clicar no card de cadastro no front end e aprimoramento nos testes

### DIFF
--- a/frontend/src/components/processo/SubprocessoCards.vue
+++ b/frontend/src/components/processo/SubprocessoCards.vue
@@ -186,7 +186,13 @@ const processos = useProcessos();
 
 const subprocesso = computed(() => props.subprocesso ?? subprocessosStore.subprocessoDetalhe);
 
-const isProcessoFinalizado = computed(() => processos.processoDetalhe.value?.situacao === SituacaoProcesso.FINALIZADO);
+const isProcessoFinalizado = computed(() => {
+  const processoDetalhe = processos.processoDetalhe.value;
+  if (!processoDetalhe || processoDetalhe.codigo !== props.codProcesso) {
+    return false;
+  }
+  return processoDetalhe.situacao === SituacaoProcesso.FINALIZADO;
+});
 
 const {podeEditarCadastro, podeEditarMapa, habilitarAcessoCadastro, habilitarAcessoMapa} = useAcesso(subprocesso);
 

--- a/frontend/src/components/processo/__tests__/SubprocessoCards.spec.ts
+++ b/frontend/src/components/processo/__tests__/SubprocessoCards.spec.ts
@@ -7,6 +7,9 @@ import {ref} from "vue";
 import * as useAcessoModule from "@/composables/useAcesso";
 
 const {pushMock} = vi.hoisted(() => ({ pushMock: vi.fn() }));
+const processosMock = {
+    processoDetalhe: {value: {codigo: 1, situacao: SituacaoProcesso.EM_ANDAMENTO}}
+};
 
 vi.mock("vue-router", () => ({
     useRouter: () => ({
@@ -21,14 +24,13 @@ vi.mock("@/composables/useSubprocessos", () => ({
 }));
 
 vi.mock("@/composables/useProcessos", () => ({
-    useProcessos: () => ({
-        processoDetalhe: { value: { situacao: SituacaoProcesso.EM_ANDAMENTO } }
-    })
+    useProcessos: () => processosMock
 }));
 
 describe("SubprocessoCards.vue", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        processosMock.processoDetalhe.value = {codigo: 1, situacao: SituacaoProcesso.EM_ANDAMENTO};
     });
 
     function createWrapper(props: any, access: any = {}) {
@@ -260,5 +262,28 @@ describe("SubprocessoCards.vue", () => {
         pushMock.mockClear();
         await card.trigger("keydown", { key: "Escape" });
         expect(pushMock).not.toHaveBeenCalled();
+    });
+
+    it("não deve tratar processo finalizado de outro código como finalizado do card atual", async () => {
+        processosMock.processoDetalhe.value = {
+            codigo: 999,
+            situacao: SituacaoProcesso.FINALIZADO
+        } as any;
+
+        const wrapper = createWrapper({
+            tipoProcesso: TipoProcesso.REVISAO,
+            mapa: null,
+            codSubprocesso: 1,
+            codProcesso: 1,
+            siglaUnidade: "U1"
+        }, {
+            habilitarAcessoCadastro: true,
+            podeEditarCadastro: true
+        });
+
+        const cardCadastro = wrapper.find('[data-testid="card-subprocesso-atividades"]');
+        expect(cardCadastro.exists()).toBe(true);
+        await cardCadastro.trigger("click");
+        expect(pushMock).toHaveBeenCalledWith(expect.objectContaining({name: "SubprocessoCadastro"}));
     });
 });


### PR DESCRIPTION
Ao clicar no card de cadastro de atividades, ele redirecionava para a pagina errada informado na issue #1381 