### PR TITLE
Correção no front end relacionado ao formulario que criar um processo e sua árvore de unidades, tambem foi corrigídos alguns testes

### DIFF
--- a/frontend/src/components/__tests__/ArvoreUnidades.spec.ts
+++ b/frontend/src/components/__tests__/ArvoreUnidades.spec.ts
@@ -299,7 +299,7 @@ describe("ArvoreUnidades.vue", () => {
     it("deve atualizar unidadesSelecionadasLocal quando modelValue muda", async () => {
         const wrapper = createWrapper({modelValue: [10]});
         await wrapper.setProps({modelValue: [20]});
-        expect((wrapper.vm as any).unidadesSelecionadasLocal).toContain(20);
+        expect((wrapper.vm as any).unidadesSelecionadasLocal).toEqual([]);
     });
 
     it("deve atualizar expandedUnits quando unidades muda", async () => {
@@ -361,6 +361,54 @@ describe("ArvoreUnidades.vue", () => {
         const wrapper = createWrapper({modelValue: [10]});
         await wrapper.setProps({modelValue: [10]});
         expect((wrapper.vm as any).unidadesSelecionadasLocal).toEqual([10]);
+    });
+
+    it("deve remover seleção inelegível quando unidades muda", async () => {
+        const wrapper = createWrapper({modelValue: [10, 21]});
+        const unidadesAtualizadas: Unidade[] = [
+            {
+                codigo: 1,
+                sigla: "ROOT",
+                nome: "Raiz",
+                isElegivel: false,
+                tipo: "ADMINISTRATIVA",
+                filhas: [
+                    {
+                        codigo: 10,
+                        sigla: "FILHA1",
+                        nome: "Filha 1",
+                        isElegivel: false,
+                        filhas: [],
+                        tipo: "OPERACIONAL"
+                    },
+                    {
+                        codigo: 20,
+                        sigla: "FILHA2",
+                        nome: "Filha 2",
+                        isElegivel: false,
+                        filhas: [
+                            {
+                                codigo: 21,
+                                sigla: "NETA1",
+                                nome: "Neta 1",
+                                isElegivel: true,
+                                filhas: [],
+                                tipo: "OPERACIONAL"
+                            }
+                        ],
+                        tipo: "INTERMEDIARIA"
+                    }
+                ]
+            }
+        ];
+
+        await wrapper.setProps({unidades: unidadesAtualizadas});
+        await wrapper.vm.$nextTick();
+
+        const emissoes = wrapper.emitted("update:modelValue");
+        expect(emissoes).toBeTruthy();
+        const ultimaEmissao = emissoes![emissoes!.length - 1][0] as number[];
+        expect(ultimaEmissao).toEqual([21]);
     });
 
     it("deve lidar com unidades sem propriedade filhas", async () => {

--- a/frontend/src/components/__tests__/ArvoreUnidadesCoverage.spec.ts
+++ b/frontend/src/components/__tests__/ArvoreUnidadesCoverage.spec.ts
@@ -31,7 +31,7 @@ describe("ArvoreUnidades.vue Coverage", () => {
     it("deve atualizar unidadesSelecionadasLocal quando modelValue muda externamente", async () => {
         const wrapper = mount(ArvoreUnidades, {
             props: {
-                unidades: [{codigo: 1, sigla: "A", nome: "A", filhas: []}],
+                unidades: [{codigo: 1, sigla: "A", nome: "A", isElegivel: true, filhas: []}],
                 modelValue: []
             },
             global: {

--- a/frontend/src/components/unidade/ArvoreUnidades.vue
+++ b/frontend/src/components/unidade/ArvoreUnidades.vue
@@ -105,6 +105,25 @@ function getTodasSubunidades(unidade: Unidade): Unidade[] {
   return result;
 }
 
+function coletarCodigosElegiveis(unidades: Unidade[]): Set<number> {
+  const codigosElegiveis = new Set<number>();
+
+  const visitar = (unidade: Unidade) => {
+    if (unidade.isElegivel === true) {
+      codigosElegiveis.add(unidade.codigo);
+    }
+    (unidade.filhas ?? []).forEach(visitar);
+  };
+
+  unidades.forEach(visitar);
+  return codigosElegiveis;
+}
+
+function filtrarSelecaoPorElegibilidade(selecao: number[]): number[] {
+  const codigosElegiveis = coletarCodigosElegiveis(props.unidades);
+  return selecao.filter(codigo => codigosElegiveis.has(codigo));
+}
+
 function isChecked(codigo: number): boolean {
   if (!props.modoSelecao) return false;
   return unidadesSelecionadasLocal.value.includes(codigo);
@@ -218,11 +237,12 @@ function deselecionarTodas() {
 watch(
     () => props.modelValue,
     (novoValor) => {
-      const sortedNew = [...novoValor].sort();
+      const novoValorFiltrado = filtrarSelecaoPorElegibilidade(novoValor);
+      const sortedNew = [...novoValorFiltrado].sort();
       const sortedLocal = [...unidadesSelecionadasLocal.value].sort();
 
       if (JSON.stringify(sortedNew) !== JSON.stringify(sortedLocal)) {
-        unidadesSelecionadasLocal.value = [...novoValor];
+        unidadesSelecionadasLocal.value = [...novoValorFiltrado];
       }
     },
     {deep: true},
@@ -231,6 +251,11 @@ watch(
 const expandedUnits = ref<Set<number>>(new Set());
 
 watch(() => props.unidades, (newUnidades) => {
+  const selecaoFiltrada = filtrarSelecaoPorElegibilidade(unidadesSelecionadasLocal.value);
+  if (selecaoFiltrada.length !== unidadesSelecionadasLocal.value.length) {
+    unidadesSelecionadasLocal.value = selecaoFiltrada;
+  }
+
   if (newUnidades && newUnidades.length > 0) {
     expandedUnits.value = new Set(newUnidades.map(u => u.codigo));
   }

--- a/frontend/src/views/ProcessoCadastroView.vue
+++ b/frontend/src/views/ProcessoCadastroView.vue
@@ -168,11 +168,38 @@ const {notificacao, notify, notifyStructured, clear} = useNotification();
 const unidades = ref<Unidade[]>([]);
 const isLoadingUnidades = ref(false);
 
+function coletarCodigosElegiveis(unidadesArvore: Unidade[]): Set<number> {
+  const codigosElegiveis = new Set<number>();
+
+  const visitar = (unidade: Unidade) => {
+    if (unidade.isElegivel === true) {
+      codigosElegiveis.add(unidade.codigo);
+    }
+    (unidade.filhas ?? []).forEach(visitar);
+  };
+
+  unidadesArvore.forEach(visitar);
+  return codigosElegiveis;
+}
+
+function sincronizarUnidadesSelecionadasElegiveis(unidadesArvore: Unidade[]) {
+  const codigosElegiveis = coletarCodigosElegiveis(unidadesArvore);
+  const selecionadasFiltradas = unidadesSelecionadas.value.filter(codigo =>
+      codigosElegiveis.has(codigo),
+  );
+
+  if (selecionadasFiltradas.length !== unidadesSelecionadas.value.length) {
+    unidadesSelecionadas.value = selecionadasFiltradas;
+  }
+}
+
 async function buscarUnidadesParaProcesso(tipoProcesso: string, codProcesso?: number) {
   isLoadingUnidades.value = true;
   try {
     const response = await buscarArvoreComElegibilidade(tipoProcesso, codProcesso);
-    unidades.value = mapUnidadesArray(response as any);
+    const unidadesMapeadas = mapUnidadesArray(response as any);
+    unidades.value = unidadesMapeadas;
+    sincronizarUnidadesSelecionadasElegiveis(unidadesMapeadas);
   } catch (err: any) {
     logger.error("Erro ao buscar unidades:", err);
   } finally {

--- a/frontend/src/views/__tests__/CadProcesso.spec.ts
+++ b/frontend/src/views/__tests__/CadProcesso.spec.ts
@@ -236,6 +236,10 @@ describe('ProcessoCadastroView.vue', () => {
     });
 
     it('updates an existing process', async () => {
+        vi.mocked(unidadeService.buscarArvoreComElegibilidade).mockResolvedValue([
+            {codigo: 1, sigla: 'U1', nome: 'Unidade 1', isElegivel: true, filhas: []}
+        ] as any);
+
         const {wrapper, processosStore} = createWrapper();
 
         wrapper.vm.processoEditando = {codigo: 123};
@@ -259,6 +263,10 @@ describe('ProcessoCadastroView.vue', () => {
     });
 
     it('initiates a process (confirmation flow)', async () => {
+        vi.mocked(unidadeService.buscarArvoreComElegibilidade).mockResolvedValue([
+            {codigo: 1, sigla: 'U1', nome: 'Unidade 1', isElegivel: true, filhas: []}
+        ] as any);
+
         const {wrapper, processosStore} = createWrapper();
 
         wrapper.vm.descricao = 'Iniciar teste';
@@ -281,6 +289,10 @@ describe('ProcessoCadastroView.vue', () => {
     });
 
     it('initiates an existing process', async () => {
+        vi.mocked(unidadeService.buscarArvoreComElegibilidade).mockResolvedValue([
+            {codigo: 1, sigla: 'U1', nome: 'Unidade 1', isElegivel: true, filhas: []}
+        ] as any);
+
         const {wrapper, processosStore} = createWrapper();
 
         wrapper.vm.processoEditando = {codigo: 123};
@@ -319,6 +331,36 @@ describe('ProcessoCadastroView.vue', () => {
         wrapper.vm.tipo = 'REVISAO';
         await nextTick();
         expect(unidadeService.buscarArvoreComElegibilidade).toHaveBeenCalledWith('REVISAO', undefined);
+    });
+
+    it('remove unidades selecionadas inelegíveis ao trocar tipo para revisão', async () => {
+        vi.mocked(unidadeService.buscarArvoreComElegibilidade).mockImplementation(async (tipoProcesso: string) => {
+            if (tipoProcesso === 'MAPEAMENTO') {
+                return [
+                    {codigo: 1, sigla: 'ASSESSORIA_11', nome: 'A11', isElegivel: true, filhas: []},
+                    {codigo: 2, sigla: 'ASSESSORIA_12', nome: 'A12', isElegivel: true, filhas: []}
+                ] as any;
+            }
+            return [
+                {codigo: 1, sigla: 'ASSESSORIA_11', nome: 'A11', isElegivel: false, filhas: []},
+                {codigo: 2, sigla: 'ASSESSORIA_12', nome: 'A12', isElegivel: true, filhas: []}
+            ] as any;
+        });
+
+        const {wrapper} = createWrapper();
+
+        wrapper.vm.tipo = 'MAPEAMENTO';
+        await nextTick();
+        await flushPromises();
+
+        wrapper.vm.unidadesSelecionadas = [1, 2];
+        await nextTick();
+
+        wrapper.vm.tipo = 'REVISAO';
+        await nextTick();
+        await flushPromises();
+
+        expect(wrapper.vm.unidadesSelecionadas).toEqual([2]);
     });
 
     it('handles error when starting a new process (creation fail)', async () => {

--- a/frontend/src/views/__tests__/CadProcessoCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadProcessoCoverage.spec.ts
@@ -170,6 +170,10 @@ describe('ProcessoCadastroView.vue Coverage', () => {
     });
 
     it('handles error starting process during initiation flow', async () => {
+        vi.mocked(unidadeService.buscarArvoreComElegibilidade).mockResolvedValue([
+            {codigo: 1, sigla: 'U1', nome: 'Unidade 1', isElegivel: true, filhas: []}
+        ] as any);
+
         const {wrapper, processosStore} = createWrapper();
 
         await wrapper.find('[data-testid="inp-processo-descricao"]').setValue('Teste inicio');
@@ -260,6 +264,11 @@ describe('ProcessoCadastroView.vue Coverage', () => {
 
     it('populates fields when loading an existing process', async () => {
         mockRoute.query = {codProcesso: '123'};
+        vi.mocked(unidadeService.buscarArvoreComElegibilidade).mockResolvedValue([
+            {codigo: 1, sigla: 'U1', nome: 'Unidade 1', isElegivel: true, filhas: []},
+            {codigo: 2, sigla: 'U2', nome: 'Unidade 2', isElegivel: true, filhas: []}
+        ] as any);
+
         const mockProcesso = {
             codigo: 123,
             descricao: 'Processo existente',


### PR DESCRIPTION
Em ArvoreUnidades.vue foi feito o ajuste na árvore de unidades para não manter seleção de unidades que deixaram de ser elegíveis quando a lista de unidades é recarregada ou quando o modelValue
muda. 
Já em ProcessoCadasroView.vue foi feita a melhoria na sincronização com as unidades realmente elegíveis.
O problema é relacionado a issue #1420