### PR TITLE
test(e2e): reforçar alinhamento de modais em bloco e reabertura (CDU-22/23/24/25/33)

### DIFF
--- a/e2e/cdu-22.spec.ts
+++ b/e2e/cdu-22.spec.ts
@@ -55,6 +55,8 @@ test.describe.serial('CDU-22 - Aceitar cadastros em bloco', () => {
         await expect(modal.getByText(TEXTOS.acaoBloco.aceitar.TITULO_CADASTRO)).toBeVisible();
         await expect(modal.getByText(TEXTOS.acaoBloco.aceitar.TEXTO_CADASTRO)).toBeVisible();
         await expect(modal.locator('table')).toBeVisible();
+        await expect(modal.getByRole('button', {name: /Cancelar/i})).toBeVisible();
+        await expect(modal.getByRole('button', {name: TEXTOS.acaoBloco.aceitar.BOTAO})).toBeVisible();
         await modal.getByRole('button', {name: /Cancelar/i}).click();
 
         await expect(modal).not.toHaveClass(/show/);

--- a/e2e/cdu-23.spec.ts
+++ b/e2e/cdu-23.spec.ts
@@ -72,6 +72,8 @@ test.describe.serial('CDU-23 - Homologar cadastros em bloco', () => {
         await expect(modal.getByText(TEXTOS.acaoBloco.homologar.TITULO_CADASTRO)).toBeVisible();
         await expect(modal.getByText(TEXTOS.acaoBloco.homologar.TEXTO_CADASTRO)).toBeVisible();
         await expect(modal.locator('table')).toBeVisible();
+        await expect(modal.getByRole('button', {name: /Cancelar/i})).toBeVisible();
+        await expect(modal.getByRole('button', {name: TEXTOS.acaoBloco.homologar.BOTAO})).toBeVisible();
         await modal.getByRole('button', {name: /Cancelar/i}).click();
 
         await expect(modal).not.toHaveClass(/show/);

--- a/e2e/cdu-24.spec.ts
+++ b/e2e/cdu-24.spec.ts
@@ -47,6 +47,25 @@ test.describe.serial('CDU-24 - Disponibilizar mapas em bloco', () => {
         await expect(btnDisponibilizarMapa).toBeDisabled();
     });
 
+    test('ADMIN abre modal de disponibilização em bloco e cancela operação', async ({_resetAutomatico, page, _autenticadoComoAdmin}) => {
+        await acessarDetalhesProcesso(page, descProcesso);
+
+        const btnDisponibilizar = page.getByRole('button', {name: TEXTOS.acaoBloco.disponibilizar.ROTULO}).first();
+        await expect(btnDisponibilizar).toBeEnabled();
+        await btnDisponibilizar.click();
+
+        const modal = page.locator('#modal-acao-bloco');
+        await expect(modal.getByText(TEXTOS.acaoBloco.disponibilizar.TITULO)).toBeVisible();
+        await expect(modal.getByText(TEXTOS.acaoBloco.disponibilizar.TEXTO)).toBeVisible();
+        await expect(modal.getByRole('button', {name: /Cancelar/i})).toBeVisible();
+        await expect(modal.getByRole('button', {name: TEXTOS.acaoBloco.disponibilizar.BOTAO})).toBeVisible();
+
+        await modal.getByRole('button', {name: /Cancelar/i}).click();
+        await expect(modal).not.toHaveClass(/show/);
+        await expect(page.getByRole('heading', {name: /Unidades participantes/i})).toBeVisible();
+    });
+
+
     test('ADMIN disponibiliza mapas em bloco após associar todas as atividades', async ({_resetAutomatico, page, _autenticadoComoAdmin}) => {
         await acessarDetalhesProcesso(page, descProcesso);
         await navegarParaSubprocesso(page, UNIDADE_1);

--- a/e2e/cdu-25.spec.ts
+++ b/e2e/cdu-25.spec.ts
@@ -40,6 +40,9 @@ test.describe.serial('CDU-25 - Aceitar validação de mapas em bloco', () => {
 
             const modal = page.getByRole('dialog');
             await expect(modal).toBeVisible();
+            await expect(modal.getByText(TEXTOS.acaoBloco.aceitar.TITULO_VALIDACAO)).toBeVisible();
+            await expect(modal.getByRole('button', {name: /Cancelar/i})).toBeVisible();
+            await expect(modal.getByRole('button', {name: TEXTOS.acaoBloco.aceitar.BOTAO})).toBeVisible();
             await modal.getByRole('button', {name: /Cancelar/i}).click();
             
             await expect(modal).toBeHidden();

--- a/e2e/cdu-33.spec.ts
+++ b/e2e/cdu-33.spec.ts
@@ -70,6 +70,9 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
         const modal = page.getByRole('dialog');
         await expect(modal).toBeVisible();
         await expect(modal.getByRole('heading', {name: /Reabrir revisão/i})).toBeVisible();
+        await expect(page.getByTestId('inp-justificativa-reabrir')).toBeVisible();
+        await expect(modal.getByRole('button', {name: /Cancelar/i})).toBeVisible();
+        await expect(page.getByTestId('btn-confirmar-reabrir')).toHaveText(/Reabrir/i);
 
         await expect(page.getByTestId('btn-confirmar-reabrir')).toBeDisabled();
         await modal.getByRole('button', {name: /Cancelar/i}).click();

--- a/etc/reqs/pendencias.md
+++ b/etc/reqs/pendencias.md
@@ -1,5 +1,19 @@
 # Pendências consolidadas da reanálise CDU x E2E (rodada 2)
 
+## Andamento da execução (2026-03-27 - lote CDU-22, CDU-23, CDU-24, CDU-25 e CDU-33)
+- ✅ **CDU-22 (Aceitar cadastros em bloco)** reforçado com validação explícita dos botões do modal (`Cancelar` e `Registrar aceite`) no fluxo de cancelamento, mantendo evidência direta dos controles de ação do requisito.
+- ✅ **CDU-23 (Homologar cadastros em bloco)** ampliado com asserção explícita dos botões do modal (`Cancelar` e `Homologar`) antes do cancelamento, reduzindo risco de falso positivo de abertura sem controles corretos.
+- ✅ **CDU-24 (Disponibilizar mapas em bloco)** ganhou cenário dedicado de cancelamento da modal com validação de título, texto orientativo e botões obrigatórios, além de retorno para tela de detalhes do processo.
+- ✅ **CDU-25 (Aceitar validação de mapas em bloco)** passou a validar de forma explícita o título de modal e os botões de decisão (`Cancelar` e `Registrar aceite`) no cenário de interrupção da operação.
+- ✅ **CDU-33 (Reabrir revisão de cadastro)** recebeu reforço na evidência de UI da modal (campo de justificativa e botões de cancelar/confirmar) antes da confirmação da reabertura.
+- ✅ Regressão direcionada executada com sucesso para os 5 arquivos impactados em execução sequencial (`--workers=1`) conforme regra de depuração sem mistura de variáveis.
+- 🔄 Próximo passo sugerido: avançar para pendências de histórico de análise (CDU-09 e CDU-19) e itens de árvore/seleção no CDU-03 com foco em regras de habilitação/desabilitação por hierarquia.
+
+## Novos aprendizados (lote 2026-03-27)
+- Em ações em bloco, validar apenas a presença da modal não garante aderência ao requisito; é importante comprovar também os botões de decisão que materializam o fluxo (`Cancelar` e botão de confirmação específico).
+- Cenários de cancelamento continuam valiosos mesmo quando o fluxo de sucesso já está coberto, pois asseguram a regra funcional de permanência na tela de detalhes sem efeito colateral indevido.
+- Em requisitos com “solicitação de justificativa” (CDU-33), assertar o campo dedicado e o estado inicial do botão de confirmação melhora a rastreabilidade da regra de negócio no E2E.
+
 Esta versão substitui a rodada anterior e consolida pendências após segunda varredura com leitura de specs e helpers.
 
 ## Andamento da execução (2026-03-26 - continuidade CDU-28)


### PR DESCRIPTION
### Motivation
- Alinhar os specs E2E aos requisitos documentados em `etc/reqs/pendencias.md` garantindo que aberturas de modal não sejam validadas apenas por presença, mas também pelos controles de decisão obrigatórios (botões e campos de justificativa). 
- Reduzir falsos-positivos em cancelamentos de ações em bloco e aumentar evidência de UX/fluxo antes de confirmar ações sistêmicas.

### Description
- Adicionei assertivas explícitas de UI em cinco specs E2E para validar títulos, textos e botões de decisão nas modais de ação em bloco e reabertura: `e2e/cdu-22.spec.ts`, `e2e/cdu-23.spec.ts`, `e2e/cdu-24.spec.ts`, `e2e/cdu-25.spec.ts` e `e2e/cdu-33.spec.ts`.
- Incluí um novo cenário em `e2e/cdu-24.spec.ts` para abrir e cancelar a modal de disponibilização em bloco, verificando retorno à tela de detalhes.
- Ajustei o assert do rótulo do botão de confirmação na modal de reabertura (`CDU-33`) para aceitar o texto real renderizado e adicionei verificações do campo de justificativa e do botão de cancelar.
- Atualizei `etc/reqs/pendencias.md` com a seção de progresso (2026-03-27), aprendizados e próximos passos para manter rastreabilidade do trabalho.

### Testing
- Executado o lote de testes E2E com: `npx playwright test e2e/cdu-22.spec.ts e2e/cdu-23.spec.ts e2e/cdu-24.spec.ts e2e/cdu-25.spec.ts e2e/cdu-33.spec.ts --workers=1`, que inicialmente falhou por ausência dos binários do Playwright no ambiente; identificado e documentado como evidência no PR.
- Preparado o ambiente com: `npx playwright install --with-deps --only-shell`, que foi executado com sucesso para provisionar os navegadores necessários.
- Reexecução do lote indicou uma falha pontual de asserção no `CDU-33`, que foi corrigida ajustando o matcher do botão de confirmação; após correção, o teste isolado passou com: `npx playwright test e2e/cdu-33.spec.ts --workers=1`.
- Regime de regressão direcionada: os cinco arquivos modificados foram executados em sequência (`--workers=1`) durante a validação, com asserções ajustadas e evidências registradas em `etc/reqs/pendencias.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c652716728832bbf3403ea617e570a)