### PR TITLE
feat(qa-dashboard): adiciona página web para visualizar snapshot de QA

### DIFF
--- a/etc/qa-dashboard/README.md
+++ b/etc/qa-dashboard/README.md
@@ -13,6 +13,7 @@ ferramentas.
 - `runs/`: snapshots gerados por execucao. Ignorado no Git.
 - `latest/`: atalhos para os artefatos consolidados mais recentes. Ignorado no Git.
 - `tmp/`: arquivos auxiliares temporarios. Ignorado no Git.
+- `dashboard.html`, `dashboard.js`, `dashboard.css`: interface visual do dashboard a partir de `latest/ultimo-snapshot.json`.
 
 ## Contrato
 
@@ -27,6 +28,24 @@ Os adaptadores podem consumir:
 - saidas dos comandos de QA
 
 Mas esses artefatos nao sao a fonte de verdade do dashboard.
+
+## Como coletar e visualizar
+
+1. Gere um snapshot de QA (exemplo perfil rapido):
+
+   ```bash
+   node etc/qa-dashboard/scripts/coletar-snapshot.mjs --perfil rapido
+   ```
+
+2. Sirva a raiz do repositorio com qualquer servidor HTTP simples e abra `etc/qa-dashboard/dashboard.html`.
+
+   Exemplo:
+
+   ```bash
+   npx http-server .
+   ```
+
+   Depois acesse `http://localhost:8080/etc/qa-dashboard/dashboard.html`.
 
 ## Documento principal
 

--- a/etc/qa-dashboard/dashboard.css
+++ b/etc/qa-dashboard/dashboard.css
@@ -1,0 +1,145 @@
+:root {
+    color-scheme: light;
+    --cor-fundo: #f6f8fa;
+    --cor-superficie: #ffffff;
+    --cor-texto: #1f2937;
+    --cor-borda: #d1d5db;
+    --cor-verde: #15803d;
+    --cor-amarelo: #b45309;
+    --cor-vermelho: #b91c1c;
+    --cor-azul: #2563eb;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: Inter, Arial, sans-serif;
+    background: var(--cor-fundo);
+    color: var(--cor-texto);
+}
+
+.pagina {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.25rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.cabecalho {
+    background: var(--cor-superficie);
+    border: 1px solid var(--cor-borda);
+    border-radius: 0.75rem;
+    padding: 1rem;
+}
+
+.cabecalho h1 {
+    margin: 0 0 0.25rem;
+}
+
+.grade-resumo {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+}
+
+.card {
+    background: var(--cor-superficie);
+    border: 1px solid var(--cor-borda);
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+}
+
+.card h3 {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #6b7280;
+}
+
+.card strong {
+    display: block;
+    margin-top: 0.25rem;
+    font-size: 1.4rem;
+}
+
+.bloco {
+    background: var(--cor-superficie);
+    border: 1px solid var(--cor-borda);
+    border-radius: 0.75rem;
+    padding: 1rem;
+}
+
+.grade-dupla {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.tabela-container {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th,
+td {
+    border-bottom: 1px solid var(--cor-borda);
+    padding: 0.5rem;
+    text-align: left;
+    vertical-align: top;
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 0.2rem 0.5rem;
+    color: #fff;
+    font-size: 0.75rem;
+}
+
+.status.sucesso,
+.status.verde {
+    background: var(--cor-verde);
+}
+
+.status.alerta,
+.status.amarelo {
+    background: var(--cor-amarelo);
+}
+
+.status.falha,
+.status.vermelho {
+    background: var(--cor-vermelho);
+}
+
+.barra {
+    background: #e5e7eb;
+    border-radius: 999px;
+    height: 0.6rem;
+    overflow: hidden;
+    margin-top: 0.35rem;
+}
+
+.barra > span {
+    display: block;
+    height: 100%;
+    background: var(--cor-azul);
+}
+
+.lista-hotspots {
+    margin: 0;
+    padding-left: 1rem;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.lista-hotspots li {
+    line-height: 1.35;
+}

--- a/etc/qa-dashboard/dashboard.html
+++ b/etc/qa-dashboard/dashboard.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SGC - Dashboard de QA</title>
+    <link rel="stylesheet" href="./dashboard.css">
+</head>
+<body>
+<main class="pagina">
+    <header class="cabecalho">
+        <h1>Dashboard de QA - SGC</h1>
+        <p id="metadadosResumo">Carregando snapshot...</p>
+    </header>
+
+    <section class="grade-resumo" id="resumoCards"></section>
+
+    <section class="bloco">
+        <h2>Verificacoes da execucao</h2>
+        <div class="tabela-container">
+            <table>
+                <thead>
+                <tr>
+                    <th>Nome</th>
+                    <th>Status</th>
+                    <th>Duracao</th>
+                    <th>Sumario</th>
+                </tr>
+                </thead>
+                <tbody id="tabelaVerificacoes"></tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="bloco grade-dupla">
+        <article>
+            <h2>Cobertura consolidada</h2>
+            <div id="coberturaMetricas"></div>
+        </article>
+        <article>
+            <h2>Qualidade e confiabilidade</h2>
+            <div id="qualidadeMetricas"></div>
+        </article>
+    </section>
+
+    <section class="bloco">
+        <h2>Hotspots de risco</h2>
+        <ul id="listaHotspots" class="lista-hotspots"></ul>
+    </section>
+</main>
+
+<script type="module" src="./dashboard.js"></script>
+</body>
+</html>

--- a/etc/qa-dashboard/dashboard.js
+++ b/etc/qa-dashboard/dashboard.js
@@ -1,0 +1,187 @@
+function formatarNumero(valor, casas = 2) {
+    if (typeof valor !== "number" || Number.isNaN(valor)) {
+        return "-";
+    }
+
+    return valor.toLocaleString("pt-BR", {
+        minimumFractionDigits: casas,
+        maximumFractionDigits: casas
+    });
+}
+
+function formatarDuracao(ms) {
+    if (typeof ms !== "number") {
+        return "-";
+    }
+
+    const segundos = Math.round(ms / 1000);
+    if (segundos < 60) {
+        return `${segundos}s`;
+    }
+
+    const minutos = Math.floor(segundos / 60);
+    const resto = segundos % 60;
+    return `${minutos}m ${resto}s`;
+}
+
+function criarCard(titulo, valor, classe = "") {
+    const artigo = document.createElement("article");
+    artigo.className = "card";
+    artigo.innerHTML = `<h3>${titulo}</h3><strong class="${classe}">${valor}</strong>`;
+    return artigo;
+}
+
+function criarStatus(status) {
+    return `<span class="status ${status}">${status}</span>`;
+}
+
+function criarBarra(percentual) {
+    const valorNormalizado = Math.max(0, Math.min(100, Number(percentual ?? 0)));
+    return `<div class="barra"><span style="width:${valorNormalizado}%"></span></div>`;
+}
+
+function renderizarResumo(snapshot) {
+    const container = document.getElementById("resumoCards");
+    const resumo = snapshot.resumo ?? {};
+    const totais = resumo.totais ?? {};
+
+    container.append(
+        criarCard("Status geral", criarStatus(resumo.statusGeral ?? "-")),
+        criarCard("Indice de saude", `${formatarNumero(resumo.indiceSaude)}%`),
+        criarCard("Verificacoes", `${totais.verificacoes ?? 0}`),
+        criarCard("Sucessos", `${totais.sucesso ?? 0}`),
+        criarCard("Alertas", `${totais.alerta ?? 0}`),
+        criarCard("Falhas", `${totais.falha ?? 0}`)
+    );
+
+    const git = snapshot.metadados?.git ?? {};
+    const texto = [
+        `Gerado em ${new Date(snapshot.metadados?.geradoEm ?? Date.now()).toLocaleString("pt-BR")}`,
+        `Perfil: ${snapshot.metadados?.perfilExecucao ?? "-"}`,
+        `Branch: ${git.branch ?? "-"}`,
+        `Commit: ${git.commitCurto ?? git.commit ?? "-"}`
+    ].join(" | ");
+
+    document.getElementById("metadadosResumo").textContent = texto;
+}
+
+function renderizarVerificacoes(snapshot) {
+    const corpoTabela = document.getElementById("tabelaVerificacoes");
+    const verificacoes = snapshot.verificacoes ?? [];
+
+    for (const verificacao of verificacoes) {
+        const linha = document.createElement("tr");
+        linha.innerHTML = `
+            <td>${verificacao.nome}</td>
+            <td>${criarStatus(verificacao.status)}</td>
+            <td>${formatarDuracao(verificacao.duracaoMs)}</td>
+            <td>${verificacao.sumario ?? "-"}</td>
+        `;
+        corpoTabela.append(linha);
+    }
+}
+
+function renderizarCobertura(snapshot) {
+    const bloco = document.getElementById("coberturaMetricas");
+    const cobertura = snapshot.cobertura ?? {};
+    const backend = cobertura.backend ?? {};
+    const frontend = cobertura.frontend ?? {};
+
+    const metricas = [
+        {titulo: "Backend - linhas", valor: backend.linhas?.percentual},
+        {titulo: "Backend - branches", valor: backend.branches?.percentual},
+        {titulo: "Frontend - linhas", valor: frontend.lines?.percentual},
+        {titulo: "Frontend - branches", valor: frontend.branches?.percentual},
+        {titulo: "Frontend - funcoes", valor: frontend.functions?.percentual},
+        {titulo: "Frontend - statements", valor: frontend.statements?.percentual}
+    ];
+
+    const lista = document.createElement("ul");
+
+    for (const metrica of metricas) {
+        const item = document.createElement("li");
+        const percentual = Number(metrica.valor ?? 0);
+        item.innerHTML = `${metrica.titulo}: <strong>${formatarNumero(percentual)}%</strong>${criarBarra(percentual)}`;
+        lista.append(item);
+    }
+
+    bloco.append(lista);
+}
+
+function renderizarQualidade(snapshot) {
+    const bloco = document.getElementById("qualidadeMetricas");
+    const qualidade = snapshot.qualidade ?? {};
+    const confiabilidade = snapshot.confiabilidade ?? {};
+
+    const lista = document.createElement("ul");
+    lista.innerHTML = `
+        <li>Erros de lint: <strong>${qualidade.lint?.erros ?? 0}</strong></li>
+        <li>Avisos de lint: <strong>${qualidade.lint?.avisos ?? 0}</strong></li>
+        <li>Erros de typecheck: <strong>${qualidade.typecheck?.erros ?? 0}</strong></li>
+        <li>Testes ignorados: <strong>${confiabilidade.testesIgnorados ?? 0}</strong></li>
+        <li>Testes flaky: <strong>${confiabilidade.testesFlaky ?? 0}</strong></li>
+    `;
+
+    bloco.append(lista);
+
+    const suites = document.createElement("div");
+    suites.innerHTML = "<h3>Suites mais lentas</h3>";
+    const listaSuites = document.createElement("ol");
+
+    for (const suite of confiabilidade.suitesLentas ?? []) {
+        const item = document.createElement("li");
+        item.textContent = `${suite.nome}: ${formatarDuracao(suite.duracaoMs)}`;
+        listaSuites.append(item);
+    }
+
+    suites.append(listaSuites);
+    bloco.append(suites);
+}
+
+function renderizarHotspots(snapshot) {
+    const lista = document.getElementById("listaHotspots");
+    const hotspots = snapshot.hotspots ?? [];
+
+    if (hotspots.length === 0) {
+        lista.innerHTML = "<li>Nenhum hotspot calculado.</li>";
+        return;
+    }
+
+    for (const hotspot of hotspots) {
+        const item = document.createElement("li");
+        const motivos = (hotspot.motivos ?? []).join("; ");
+        item.innerHTML = `<strong>${hotspot.nome}</strong> - risco ${formatarNumero(hotspot.risco)}. ${motivos}`;
+        lista.append(item);
+    }
+}
+
+function renderizarErro(mensagem) {
+    const elemento = document.getElementById("metadadosResumo");
+    elemento.textContent = mensagem;
+    elemento.style.color = "#b91c1c";
+}
+
+async function carregarSnapshot() {
+    const resposta = await fetch("./latest/ultimo-snapshot.json", {cache: "no-store"});
+
+    if (!resposta.ok) {
+        throw new Error(`Falha ao carregar snapshot: HTTP ${resposta.status}`);
+    }
+
+    return resposta.json();
+}
+
+async function inicializarDashboard() {
+    try {
+        const snapshot = await carregarSnapshot();
+        renderizarResumo(snapshot);
+        renderizarVerificacoes(snapshot);
+        renderizarCobertura(snapshot);
+        renderizarQualidade(snapshot);
+        renderizarHotspots(snapshot);
+    } catch (erro) {
+        renderizarErro(`Nao foi possivel carregar os dados do dashboard. ${erro.message}`);
+    }
+}
+
+inicializarDashboard();


### PR DESCRIPTION
### Motivation
- Fornecer uma interface visual simples e estática para consultar os snapshots consolidados gerados pelo coletor de QA. 
- Facilitar a inspeção rápida de métricas (status geral, índice de saúde, cobertura, lint/typecheck, suites lentas e hotspots) sem precisar abrir arquivos JSON manualmente.

### Description
- Adiciona `etc/qa-dashboard/dashboard.html` com estrutura responsiva para mostrar resumo executivo, tabela de verificações, cobertura, qualidade/confiabilidade e hotspots. 
- Adiciona `etc/qa-dashboard/dashboard.js` que carrega `latest/ultimo-snapshot.json`, renderiza as seções do dashboard e trata erros de carregamento. 
- Adiciona `etc/qa-dashboard/dashboard.css` com estilos para cards, badges de status, tabela e barras de cobertura. 
- Atualiza `etc/qa-dashboard/README.md` com instruções para gerar o snapshot (`coletar-snapshot.mjs`) e servir o repositório por HTTP para visualizar `dashboard.html`.

### Testing
- Executado o coletor de snapshots com `node etc/qa-dashboard/scripts/coletar-snapshot.mjs --perfil backend` e o snapshot foi gerado com sucesso. 
- Validado a sintaxe dos scripts com `node --check etc/qa-dashboard/dashboard.js` e `node --check etc/qa-dashboard/scripts/coletar-snapshot.mjs`, ambos concluíram sem erros. 
- A página é estática e depende de `latest/ultimo-snapshot.json`, devendo ser aberta servindo o repositório por HTTP (não por `file://`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c65c046414832b9d9b42bc7df4ad2f)