### PR TITLE
Correção no botão Disponibilizar em MapaView, e criação do teste

### DIFF
--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -187,6 +187,11 @@ onMounted(async () => {
     codSubprocesso.value = id;
     const data = await subprocessosStore.buscarContextoEdicao(id);
     if (data) {
+      if (data.mapa) {
+        mapasStore.mapaCompleto.value = data.mapa as any;
+      } else {
+        await mapasStore.buscarMapaCompleto(id);
+      }
       if (data.atividadesDisponiveis) {
         atividades.value = data.atividadesDisponiveis;
       }
@@ -214,15 +219,18 @@ const atividadesSemCompetencia = computed(() => {
   return atividades.value.filter((atividade) => !atividadesAssociadas.has(atividade.codigo));
 });
 
-const existeCompetenciaSemCadastro = computed(() => {
+const existeCompetenciaSemAtividade = computed(() => {
   return competencias.value.some((competencia) => (competencia.atividades?.length ?? 0) === 0);
+});
+
+const associacoesMapaValidas = computed(() => {
+  return !existeCompetenciaSemAtividade.value && atividadesSemCompetencia.value.length === 0;
 });
 
 const podeConfirmarDisponibilizacao = computed(() => {
   return (
       competencias.value.length > 0
-      && atividadesSemCompetencia.value.length === 0
-      && !existeCompetenciaSemCadastro.value
+      && associacoesMapaValidas.value
   );
 });
 const competenciaSendoEditada = ref<Competencia | null>(null);
@@ -394,7 +402,8 @@ defineExpose({
   podeEditarMapa,
   podeDisponibilizarMapa,
   podeConfirmarDisponibilizacao,
-  existeCompetenciaSemCadastro,
+  existeCompetenciaSemAtividade,
+  associacoesMapaValidas,
   unidade,
   competencias,
   atividades,

--- a/frontend/src/views/__tests__/CadMapaCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadMapaCoverage.spec.ts
@@ -190,6 +190,36 @@ describe('MapaView Coverage', () => {
         });
     });
 
+    it('desabilita disponibilizacao quando existir competencia sem atividade', async () => {
+        const pinia = createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+                mapas: {
+                    mapaCompleto: {
+                        competencias: [{codigo: 1, descricao: 'Comp 1', atividades: []}]
+                    }
+                }
+            }
+        });
+
+        const wrapper = mount(MapaView, {
+            global: {
+                plugins: [pinia],
+                stubs: commonStubs
+            }
+        });
+
+        const mapas = useMapas();
+        mapas.mapaCompleto.value = {
+            competencias: [{codigo: 1, descricao: 'Comp 1', atividades: []}]
+        } as any;
+
+        await wrapper.vm.$nextTick();
+
+        expect((wrapper.vm as any).existeCompetenciaSemAtividade).toBe(true);
+        expect((wrapper.vm as any).podeConfirmarDisponibilizacao).toBe(false);
+    });
+
     it('fecharModalImpacto closes the modal', async () => {
         const pinia = createTestingPinia();
         const wrapper = mount(MapaView, {

--- a/frontend/src/views/__tests__/MapaViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/MapaViewCoverage.spec.ts
@@ -216,7 +216,7 @@ describe("MapaView coverage", () => {
         expect(wrapper.find('[data-testid="btn-cad-mapa-disponibilizar"]').attributes("disabled")).toBeDefined();
     });
 
-    it("mantem o botao disponibilizar desabilitado se existir competencia sem cadastro", async () => {
+    it("mantem o botao disponibilizar desabilitado se existir competencia sem atividade", async () => {
         const wrapper = createWrapper({
             competencias: [
                 {
@@ -231,7 +231,8 @@ describe("MapaView coverage", () => {
 
         (wrapper.vm as any).atividades = [];
 
-        expect((wrapper.vm as any).existeCompetenciaSemCadastro).toBe(true);
+        expect((wrapper.vm as any).existeCompetenciaSemAtividade).toBe(true);
+        expect((wrapper.vm as any).associacoesMapaValidas).toBe(false);
         expect(wrapper.find('[data-testid="btn-cad-mapa-disponibilizar"]').attributes("disabled")).toBeDefined();
     });
 


### PR DESCRIPTION
Problema: Ao criar um processo do tipo revisão e excluo um cadastro especifico, quando eu for disponibilizar o mapa ( http://localhost:5173/processo/401/SECAO_221/mapa) ele deveria perceber se tiver alguma competencia sem nenhum cadastro ele deveria deixar o botão desabilitado.
Solução: No MapaView.vue, o botão Disponibilizar agora também verifica se existe alguma competência sem cadastro/atividade. 

Tambem foi adicionado um teste para cobrir esse caso.