### PR TITLE
Align test schema with model, require subprocesso.data_limite_etapa1 and add CDU15/CDU21 integration tests

### DIFF
--- a/backend/src/test/java/sgc/e2e/E2eControllerTest.java
+++ b/backend/src/test/java/sgc/e2e/E2eControllerTest.java
@@ -122,7 +122,7 @@ class E2eControllerTest {
                         + " 'Processo teste', 'CRIADO', 'MAPEAMENTO')");
 
         jdbcTemplate.execute(
-                "INSERT INTO sgc.subprocesso (codigo, processo_codigo, unidade_codigo, situacao) VALUES (300, 100, 999, 'NAO_INICIADO')");
+                "INSERT INTO sgc.subprocesso (codigo, processo_codigo, unidade_codigo, situacao, data_limite_etapa1) VALUES (300, 100, 999, 'NAO_INICIADO', CURRENT_TIMESTAMP)");
 
         jdbcTemplate.execute("INSERT INTO sgc.mapa (codigo, subprocesso_codigo) VALUES (200, 300)");
 

--- a/backend/src/test/java/sgc/integracao/CDU15IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU15IntegrationTest.java
@@ -1,0 +1,128 @@
+package sgc.integracao;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import sgc.comum.*;
+import sgc.comum.erros.*;
+import sgc.fixture.*;
+import sgc.mapa.model.*;
+import sgc.organizacao.model.*;
+import sgc.processo.model.*;
+import sgc.subprocesso.dto.*;
+import sgc.subprocesso.model.*;
+import sgc.subprocesso.service.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Tag("integration")
+@DisplayName("CDU-15: Manter mapa de competências")
+class CDU15IntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private CompetenciaRepo competenciaRepo;
+
+    @Autowired
+    private SubprocessoService subprocessoService;
+
+    private Subprocesso subprocesso;
+    private Mapa mapa;
+    private Atividade atividade1;
+    private Atividade atividade2;
+
+    @BeforeEach
+    void setUp() {
+        Unidade unidade = UnidadeFixture.unidadePadrao();
+        unidade.setCodigo(null);
+        unidade.setSigla("CDU15-UND");
+        unidade.setNome("Unidade CDU-15");
+        unidade = unidadeRepo.save(unidade);
+
+        Processo processo = ProcessoFixture.processoPadrao();
+        processo.setCodigo(null);
+        processo.setDescricao("Processo CDU-15");
+        processo.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
+        processo.setTipo(TipoProcesso.MAPEAMENTO);
+        processo = processoRepo.save(processo);
+        processo.adicionarParticipantes(Set.of(unidade));
+        processoRepo.save(processo);
+
+        subprocesso = SubprocessoFixture.subprocessoPadrao(processo, unidade);
+        subprocesso.setCodigo(null);
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+        subprocesso.setDataLimiteEtapa1(LocalDateTime.now().plusDays(5));
+        subprocesso = subprocessoRepo.save(subprocesso);
+
+        mapa = new Mapa();
+        mapa.setSubprocesso(subprocesso);
+        mapa = mapaRepo.save(mapa);
+
+        subprocesso.setMapa(mapa);
+        subprocessoRepo.save(subprocesso);
+
+        atividade1 = AtividadeFixture.atividadePadrao(mapa);
+        atividade1.setDescricao("Atividade 1 CDU-15");
+        atividade1 = atividadeRepo.save(atividade1);
+
+        atividade2 = AtividadeFixture.atividadePadrao(mapa);
+        atividade2.setDescricao("Atividade 2 CDU-15");
+        atividade2 = atividadeRepo.save(atividade2);
+    }
+
+    @Test
+    @DisplayName("ADMIN cria competência e subprocesso muda para MAPA_CRIADO")
+    void deveCriarCompetenciaEAlterarSituacaoParaMapaCriado() {
+        CompetenciaRequest request = CompetenciaRequest.builder()
+                .descricao("Competência CDU-15")
+                .atividadesIds(List.of(atividade1.getCodigo(), atividade2.getCodigo()))
+                .build();
+
+        subprocessoService.adicionarCompetencia(subprocesso.getCodigo(), request);
+
+        List<Competencia> competencias = competenciaRepo.findByMapa_Codigo(mapa.getCodigo());
+        assertThat(competencias).hasSize(1);
+        assertThat(competencias.getFirst().getDescricao()).isEqualTo("Competência CDU-15");
+        assertThat(competencias.getFirst().getAtividades()).hasSize(2);
+
+        Subprocesso atualizado = subprocessoRepo.findById(subprocesso.getCodigo()).orElseThrow();
+        assertThat(atualizado.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO);
+    }
+
+    @Test
+    @DisplayName("ADMIN remove última competência e subprocesso volta para CADASTRO_HOMOLOGADO")
+    void deveRemoverUltimaCompetenciaEVoltarSituacaoCadastroHomologado() {
+        CompetenciaRequest criarReq = CompetenciaRequest.builder()
+                .descricao("Competência temporária")
+                .atividadesIds(List.of(atividade1.getCodigo()))
+                .build();
+
+        subprocessoService.adicionarCompetencia(subprocesso.getCodigo(), criarReq);
+
+        Competencia competencia = competenciaRepo.findByMapa_Codigo(mapa.getCodigo()).getFirst();
+        subprocessoService.removerCompetencia(subprocesso.getCodigo(), competencia.getCodigo());
+
+        assertThat(competenciaRepo.findByMapa_Codigo(mapa.getCodigo())).isEmpty();
+
+        Subprocesso atualizado = subprocessoRepo.findById(subprocesso.getCodigo()).orElseThrow();
+        assertThat(atualizado.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+    }
+    @Test
+    @DisplayName("Não deve criar competência sem atividades")
+    void naoDeveCriarCompetenciaSemAtividades() {
+        CompetenciaRequest request = CompetenciaRequest.builder()
+                .descricao("Competência inválida")
+                .atividadesIds(List.of())
+                .build();
+
+        assertThatThrownBy(() -> subprocessoService.adicionarCompetencia(subprocesso.getCodigo(), request))
+                .isInstanceOf(ErroValidacao.class)
+                .hasMessageContaining(Mensagens.COMPETENCIA_DEVE_TER_ATIVIDADE);
+
+        assertThat(competenciaRepo.findByMapa_Codigo(mapa.getCodigo())).isEmpty();
+        Subprocesso atualizado = subprocessoRepo.findById(subprocesso.getCodigo()).orElseThrow();
+        assertThat(atualizado.getSituacao()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+    }
+
+}

--- a/backend/src/test/java/sgc/integracao/CDU21IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU21IntegrationTest.java
@@ -1,0 +1,100 @@
+package sgc.integracao;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.http.MediaType;
+import sgc.comum.*;
+import sgc.fixture.*;
+import sgc.integracao.mocks.*;
+import sgc.mapa.model.*;
+import sgc.organizacao.model.*;
+import sgc.processo.model.*;
+import sgc.subprocesso.model.*;
+
+import java.time.*;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Tag("integration")
+@WithMockAdmin
+@DisplayName("CDU-21: Finalizar processo de mapeamento ou revisão")
+class CDU21IntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private UnidadeMapaRepo unidadeMapaRepo;
+
+    private Processo processo;
+    private Subprocesso subprocesso;
+    private Unidade unidade;
+
+    @BeforeEach
+    void setUp() {
+        unidade = UnidadeFixture.unidadePadrao();
+        unidade.setCodigo(null);
+        unidade.setSigla("CDU21-UND");
+        unidade.setNome("Unidade CDU-21");
+        unidade = unidadeRepo.save(unidade);
+
+        processo = ProcessoFixture.processoPadrao();
+        processo.setCodigo(null);
+        processo.setDescricao("Processo CDU-21");
+        processo.setTipo(TipoProcesso.MAPEAMENTO);
+        processo.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
+        processo = processoRepo.save(processo);
+
+        processo.adicionarParticipantes(Set.of(unidade));
+        processoRepo.save(processo);
+
+        subprocesso = SubprocessoFixture.subprocessoPadrao(processo, unidade);
+        subprocesso.setCodigo(null);
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO);
+        subprocesso.setDataLimiteEtapa1(LocalDateTime.now().plusDays(7));
+        subprocesso = subprocessoRepo.save(subprocesso);
+
+        Mapa mapa = new Mapa();
+        mapa.setSubprocesso(subprocesso);
+        mapa = mapaRepo.save(mapa);
+
+        subprocesso.setMapa(mapa);
+        subprocessoRepo.save(subprocesso);
+    }
+
+    @Test
+    @DisplayName("Não deve finalizar quando houver subprocesso não homologado")
+    void naoDeveFinalizarQuandoSubprocessosNaoHomologados() throws Exception {
+        mockMvc.perform(post("/api/processos/{codigo}/finalizar", processo.getCodigo())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnprocessableContent())
+                .andExpect(jsonPath("$.message").value(Mensagens.SUBPROCESSOS_NAO_HOMOLOGADOS));
+
+        Processo atualizado = processoRepo.findById(processo.getCodigo()).orElseThrow();
+        assertThat(atualizado.getSituacao()).isEqualTo(SituacaoProcesso.EM_ANDAMENTO);
+        assertThat(atualizado.getDataFinalizacao()).isNull();
+        assertThat(unidadeMapaRepo.findByUnidadeCodigo(unidade.getCodigo())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Deve finalizar processo e definir mapa vigente da unidade")
+    void deveFinalizarProcessoEAtualizarMapaVigente() throws Exception {
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO);
+        subprocessoRepo.save(subprocesso);
+
+        mockMvc.perform(post("/api/processos/{codigo}/finalizar", processo.getCodigo())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        Processo atualizado = processoRepo.findById(processo.getCodigo()).orElseThrow();
+        assertThat(atualizado.getSituacao()).isEqualTo(SituacaoProcesso.FINALIZADO);
+        assertThat(atualizado.getDataFinalizacao()).isNotNull();
+
+        UnidadeMapa unidadeMapa = unidadeMapaRepo.findByUnidadeCodigo(unidade.getCodigo()).orElseThrow();
+        assertThat(unidadeMapa.getMapaVigente()).isNotNull();
+        assertThat(unidadeMapa.getMapaVigente().getCodigo()).isEqualTo(subprocesso.getMapa().getCodigo());
+    }
+}

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceAtividadeIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceAtividadeIntegrationTest.java
@@ -66,6 +66,7 @@ class SubprocessoServiceAtividadeIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.NAO_INICIADO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(15))
                 .localizacaoAtual(unidade)
                 .build();
         subprocessoRepo.save(subprocessoDestino);
@@ -78,6 +79,7 @@ class SubprocessoServiceAtividadeIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(15))
                 .localizacaoAtual(unidade)
                 .build();
         subprocessoRepo.save(subprocessoOrigem);

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceContextoIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceContextoIntegrationTest.java
@@ -63,6 +63,7 @@ class SubprocessoServiceContextoIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(20))
                 .localizacaoAtual(unidade)
                 .build();
         subprocessoRepo.save(subprocesso);

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceCoverageIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceCoverageIntegrationTest.java
@@ -49,6 +49,7 @@ class SubprocessoServiceCoverageIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(20))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceDatasIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceDatasIntegrationTest.java
@@ -62,6 +62,7 @@ class SubprocessoServiceDatasIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.NAO_INICIADO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(1))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceDeletarIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceDeletarIntegrationTest.java
@@ -48,6 +48,7 @@ class SubprocessoServiceDeletarIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
     }

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceExtraMethodsIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceExtraMethodsIntegrationTest.java
@@ -49,6 +49,7 @@ class SubprocessoServiceExtraMethodsIntegrationTest extends BaseIntegrationTest 
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceListaIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceListaIntegrationTest.java
@@ -51,6 +51,7 @@ class SubprocessoServiceListaIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceMethodsIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceMethodsIntegrationTest.java
@@ -51,6 +51,7 @@ class SubprocessoServiceMethodsIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.NAO_INICIADO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceProcessarAlteracoesIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceProcessarAlteracoesIntegrationTest.java
@@ -48,6 +48,7 @@ class SubprocessoServiceProcessarAlteracoesIntegrationTest extends BaseIntegrati
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
     }

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceSalvarIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceSalvarIntegrationTest.java
@@ -56,6 +56,7 @@ class SubprocessoServiceSalvarIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
 
         subprocesso.setSituacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO);

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceValidacaoCadastroIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceValidacaoCadastroIntegrationTest.java
@@ -53,6 +53,7 @@ class SubprocessoServiceValidacaoCadastroIntegrationTest extends BaseIntegration
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/integracao/SubprocessoServiceValidacaoIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/SubprocessoServiceValidacaoIntegrationTest.java
@@ -58,6 +58,7 @@ class SubprocessoServiceValidacaoIntegrationTest extends BaseIntegrationTest {
                 .unidade(unidade)
                 .situacao(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO)
                 .processo(processo)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         subprocessoRepo.save(subprocesso);
 

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java
@@ -266,7 +266,12 @@ class SubprocessoControllerCoverageTest {
         when(subprocessoService.validarCadastro(1L)).thenReturn(new ValidacaoCadastroDto(true, List.of()));
 
         mockMvc.perform(get("/api/subprocessos/1/validar-cadastro"))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valido").value(true))
+                .andExpect(jsonPath("$.erros").isArray())
+                .andExpect(jsonPath("$.erros").isEmpty());
+
+        verify(subprocessoService).validarCadastro(1L);
     }
 
     @Test
@@ -311,7 +316,13 @@ class SubprocessoControllerCoverageTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(req)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.codigo").value(1L))
+                .andExpect(jsonPath("$.subprocessoCodigo").value(1L))
+                .andExpect(jsonPath("$.observacoes").value("Obs"));
+
+        verify(subprocessoService).salvarMapa(1L, req);
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
     }
 
     @Test

--- a/backend/src/test/java/sgc/subprocesso/model/MovimentacaoRepoPerformanceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/model/MovimentacaoRepoPerformanceTest.java
@@ -53,6 +53,7 @@ class MovimentacaoRepoPerformanceTest {
                 .processo(p)
                 .unidade(uOrigem)
                 .situacao(SituacaoSubprocesso.NAO_INICIADO)
+                .dataLimiteEtapa1(LocalDateTime.now().plusDays(10))
                 .build();
         sp = subprocessoRepo.save(sp);
 

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoServiceCoverageIntegrationTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoServiceCoverageIntegrationTest.java
@@ -18,6 +18,8 @@ import sgc.processo.model.*;
 import sgc.subprocesso.dto.*;
 import sgc.subprocesso.model.*;
 
+import java.time.*;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -59,6 +61,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
@@ -121,6 +124,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setSituacaoForcada(SituacaoSubprocesso.REVISAO_MAPA_AJUSTADO);
@@ -155,6 +159,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setSituacaoForcada(SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA);
@@ -189,6 +194,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
@@ -215,6 +221,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
@@ -248,6 +255,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             mapaNovo = mapaRepo.save(mapaNovo);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setMapa(mapaAntigo);
@@ -278,6 +286,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             mapaAntigo = mapaRepo.save(mapaAntigo);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setMapa(mapaAntigo);
@@ -310,6 +319,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO);
@@ -359,6 +369,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso spDestino = new Subprocesso();
+            spDestino.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             spDestino.setProcesso(proc);
             spDestino.setUnidade(u);
             spDestino.setSituacaoForcada(SituacaoSubprocesso.NAO_INICIADO);
@@ -371,6 +382,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             spDestino = subprocessoRepo.saveAndFlush(spDestino);
 
             Subprocesso spOrigem = new Subprocesso();
+            spOrigem.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             spOrigem.setProcesso(proc);
             spOrigem.setUnidade(u);
             spOrigem.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO);
@@ -405,6 +417,7 @@ class SubprocessoServiceCoverageIntegrationTest {
             u = unidadeRepo.save(u);
 
             Subprocesso sp = new Subprocesso();
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp.setProcesso(proc);
             sp.setUnidade(u);
             sp = subprocessoRepo.saveAndFlush(sp);
@@ -420,4 +433,3 @@ class SubprocessoServiceCoverageIntegrationTest {
         }
     }
 }
-

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoTransicaoServiceCoverageIntegrationTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoTransicaoServiceCoverageIntegrationTest.java
@@ -17,6 +17,8 @@ import sgc.processo.model.*;
 import sgc.subprocesso.dto.*;
 import sgc.subprocesso.model.*;
 
+import java.time.*;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -90,6 +92,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setSituacaoForcada(SituacaoSubprocesso.NAO_INICIADO);
             sp.setProcesso(proc);
             sp.setUnidade(unidade);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.save(sp);
 
             when(unidadeService.buscarPorSigla("U1")).thenReturn(unidade);
@@ -138,6 +141,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(unidade);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.save(sp);
 
             java.time.LocalDate novaData = java.time.LocalDate.now().plusDays(30);
@@ -163,6 +167,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(unidade);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.save(sp);
 
             java.time.LocalDate novaData = java.time.LocalDate.now().plusDays(30);
@@ -188,6 +193,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(unidade);
             sp.setSituacaoForcada(SituacaoSubprocesso.NAO_INICIADO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.save(sp);
 
             java.time.LocalDate novaData = java.time.LocalDate.now().plusDays(30);
@@ -220,6 +226,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(uSp);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.saveAndFlush(sp);
 
             Mapa mapa = new Mapa();
@@ -271,6 +278,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(uSp);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_CRIADO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(1));
             sp = subprocessoRepo.saveAndFlush(sp);
 
             Mapa mapa = new Mapa();
@@ -321,6 +329,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(uSp);
             sp.setSituacaoForcada(SituacaoSubprocesso.REVISAO_CADASTRO_HOMOLOGADA);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.saveAndFlush(sp);
 
             Mapa mapa = new Mapa();
@@ -368,6 +377,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(uSp);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.saveAndFlush(sp);
 
             Mapa mapa = new Mapa();
@@ -416,6 +426,7 @@ class SubprocessoTransicaoServiceCoverageIntegrationTest {
             sp.setProcesso(proc);
             sp.setUnidade(uSp);
             sp.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_VALIDADO);
+            sp.setDataLimiteEtapa1(LocalDateTime.now().plusDays(30));
             sp = subprocessoRepo.saveAndFlush(sp);
 
             Mapa mapa = new Mapa();

--- a/backend/src/test/resources/db/schema.sql
+++ b/backend/src/test/resources/db/schema.sql
@@ -304,7 +304,7 @@ create table if not exists sgc.subprocesso
     timestamp
 (
     6
-),
+) not null,
     data_limite_etapa2 timestamp
 (
     6
@@ -317,12 +317,12 @@ create table if not exists sgc.subprocesso
 (
     6
 ),
-    processo_codigo bigint,
-    unidade_codigo bigint,
+    processo_codigo bigint not null,
+    unidade_codigo bigint not null,
     situacao varchar
 (
     50
-) check
+) not null check
 (
     situacao
     in

--- a/test-quality-report.md
+++ b/test-quality-report.md
@@ -1,0 +1,232 @@
+# Test Quality Check — Backend (`backend/src/test/`)
+
+## Plano de ataque imediato (foco em criticidade alta)
+
+1. **Rastreabilidade de CDU-15 e CDU-21 (High) — ENDEREÇADO**  
+   - **Ação executada:** adicionados `CDU15IntegrationTest` e `CDU21IntegrationTest` com validação de cenários principais e falha de regra de negócio.  
+   - **Próximo passo:** ampliar cenários de borda/erros e manter referência explícita ao requisito em todos os casos novos.
+
+2. **Integridade do schema de teste divergente do modelo (High)**  
+   - **Ação inicial:** alinhar `backend/src/test/resources/db/schema.sql` com `NOT NULL` de `subprocesso` (`processo_codigo`, `unidade_codigo`, `situacao`, `data_limite_etapa1`).  
+   - **Critério de pronto:** fixtures inválidas passam a falhar cedo em persistência e testes deixam de depender de estados impossíveis em produção.
+
+3. **Oráculos frágeis baseados em IDs fixos de seed (High)**  
+   - **Ação inicial:** refatorar cenários de segurança para gerar dados por fixture própria de teste, removendo dependência de IDs como `50002`.  
+   - **Critério de pronto:** asserções verificam invariantes de autorização (escopo por token/perfil/unidade), independentemente de valores fixos do `data.sql`.
+
+---
+
+## 1) Corrupted test oracles
+
+### High
+- **Arquivo:** `backend/src/test/java/sgc/processo/painel/PainelSecurityReproductionTest.java`  
+  **Teste:** `listarProcessos_Sucesso`  
+  **Categoria:** Corrupted test oracles  
+  **Problema:** O oráculo depende de códigos fixos do `data.sql` (`50002`) em vez de validar a regra de segurança (escopo por unidade/perfil). Isso torna o teste frágil a mudanças de seed e incentiva “assert de massa de dados” em vez de requisito.  
+  **Sugestão:** Criar os dados dentro do próprio teste (ou fixture isolada) e validar invariantes de autorização (ex.: “somente processos da unidade do token”).
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/integracao/ProcessoServiceIntegrationTest.java`  
+  **Teste:** `deveLancarErroAoAtualizarProcessoEmAndamento` e `deveLancarErroAoApagarProcessoEmAndamento`  
+  **Categoria:** Corrupted test oracles  
+  **Problema:** Os testes assumem implicitamente que o processo `50000` está em situação específica no seed. O esperado vem da observação do estado atual do ambiente de teste, não de uma pré-condição explicitamente montada no cenário.  
+  **Sugestão:** Montar o processo no `@BeforeEach` com situação explícita e usar esse objeto como base para asserções.
+
+---
+
+## 2) Business rule coverage
+
+> Atualização: `SubprocessoControllerCoverageTest` recebeu reforço de asserções para `validarCadastro` e `salvarMapa`
+> (payload + verificação explícita de chamadas ao serviço), reduzindo risco de falso positivo por “status-only”.
+
+### High
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java`  
+  **Teste:** `validarCadastro`  
+  **Categoria:** Business rule coverage  
+  **Status:** **Mitigado parcialmente neste ciclo** (agora valida payload e interação com serviço).  
+  **Próximo passo:** adicionar cenário inválido com inconsistências reais de cadastro.
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java`  
+  **Teste:** `importarAtividades`  
+  **Categoria:** Business rule coverage  
+  **Problema:** Verifica só status e não confirma pós-condições funcionais (atividades importadas, cardinalidade, vínculo no subprocesso).  
+  **Sugestão:** Após a chamada, buscar estado persistido e validar invariantes de domínio.
+
+---
+
+## 3) Fixture integrity
+
+### High
+- **Arquivo:** `backend/src/test/resources/db/schema.sql`  
+  **Teste:** `N/A (infra de teste)`  
+  **Categoria:** Fixture integrity  
+  **Status:** **Resolvido neste ciclo** — o schema de teste agora exige `NOT NULL` para `processo_codigo`, `unidade_codigo`, `situacao` e `data_limite_etapa1`.  
+  **Próximo passo:** manter os novos testes/fixtures sempre explicitando `dataLimiteEtapa1` para evitar regressão silenciosa.
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/service/SubprocessoValidacaoServiceTest.java`  
+  **Teste:** `erroSituacaoNula`  
+  **Categoria:** Fixture integrity  
+  **Problema:** O cenário usa `sp.setSituacao(null)` em entidade cujo estado persistido exige situação não nula. Embora útil para guarda defensiva, cria caso pouco representativo do ciclo real de persistência.  
+  **Sugestão:** Preferir validação via DTO/entrada da API para nulos e manter entidades persistidas com invariantes válidas.
+
+---
+
+## 4) Requirement traceability (integration tests)
+
+### High
+- **Arquivo:** `backend/src/test/java/sgc/integracao/CDU15IntegrationTest.java` e `backend/src/test/java/sgc/integracao/CDU21IntegrationTest.java`  
+  **Teste:** cobertura inicial dos fluxos principais de CDU-15 e CDU-21  
+  **Categoria:** Requirement traceability  
+  **Status:** **Resolvido neste ciclo** (lacuna de rastreabilidade fechada com testes dedicados).  
+  **Próximo passo:** expandir para cenários alternativos (cancelamento/edição/erros de validação detalhados).
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/integracao/SubprocessoServiceCoverageIntegrationTest.java`  
+  **Teste:** `validarExistenciaAtividades_SemAtividades` e `validarExistenciaAtividades_SemConhecimento`  
+  **Categoria:** Requirement traceability  
+  **Problema:** A classe está rotulada como “Cobertura de Validações”, sem referência clara a CDU/RN em `etc/reqs/`; rastreabilidade fica implícita.  
+  **Sugestão:** Incluir referência explícita (CDU/RN) no nome da classe, `@DisplayName` e/ou comentário de rastreio.
+
+- **Arquivo:** `backend/src/test/java/sgc/integracao/MapaManutencaoServiceIntegrationTest.java`  
+  **Teste:** suíte da classe (15 testes)  
+  **Categoria:** Requirement traceability  
+  **Problema:** Foco técnico (manutenção de mapa) sem vínculo explícito com casos de uso em `etc/reqs/`.  
+  **Sugestão:** Dividir por CDU ou adicionar matriz de rastreio no cabeçalho da classe.
+
+---
+
+## 5) Functional overlap
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java` e `backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java`  
+  **Teste:** `obterMapaCompleto` (em ambas), além de múltiplos “- ok / retorna 200”  
+  **Categoria:** Functional overlap  
+  **Problema:** Há duplicação de comportamento de controller sem diferenciação clara de cenário (mesma funcionalidade, mesmo tipo de asserção).  
+  **Sugestão:** Consolidar cenários por endpoint em uma única suíte parametrizada, separando sucesso, borda e erro.
+
+### Low
+- **Arquivo:** `backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java`, `ProcessoServiceCoverageTest.java` e `ProcessoServiceExtraCoverageTest.java`  
+  **Teste:** múltiplos testes de “cobertura” para a mesma API de serviço  
+  **Categoria:** Functional overlap  
+  **Problema:** Organização em “principal + coverage + extra coverage” gera sobreposição de intenção e manutenção difícil.  
+  **Sugestão:** Unificar por comportamento de negócio (criação, atualização, validação, transição) em vez de “tipo de cobertura”.
+
+---
+
+## 6) Test suite cohesion
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/seguranca/login/LoginControllerCoverageTest.java`  
+  **Teste:** `deveRetornarFalseSeFalharAutenticacao` (arquivo com 1 teste)  
+  **Categoria:** Test suite cohesion  
+  **Problema:** Arquivo muito pequeno no mesmo domínio já coberto por `LoginControllerTest` (14 testes), aumentando fragmentação sem ganho estrutural.  
+  **Sugestão:** Mesclar com `LoginControllerTest` em seção/nested class específica.
+
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java`  
+  **Teste:** suíte da classe (7 testes)  
+  **Categoria:** Test suite cohesion  
+  **Problema:** Mesmo domínio possui duas suítes grandes adjacentes (`SubprocessoControllerCoverageTest` e `...CoverageExtraTest`), reduzindo coesão do conjunto.  
+  **Sugestão:** Consolidar em uma suíte única orientada por recursos/endpoint.
+
+---
+
+## 7) Description quality
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/model/SubprocessoTest.java`  
+  **Teste:** `gettersNonNull` (`@DisplayName("Getters NonNull should return values")`)  
+  **Categoria:** Description quality  
+  **Problema:** Nome em inglês e focado em detalhe técnico (getter), não em comportamento de negócio.  
+  **Sugestão:** Renomear para português e para resultado observável (ou remover se for teste trivial).
+
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java`  
+  **Teste:** nested displays `CRUD Operations`, `Cadastro workflow`, `Mapa workflow`  
+  **Categoria:** Description quality  
+  **Problema:** Mistura idioma e usa rótulos genéricos; baixa clareza do cenário/resultado esperado.  
+  **Sugestão:** Padronizar em português com formato “Dado/Quando/Então” no `@DisplayName`.
+
+### Low
+- **Arquivo:** `backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java`  
+  **Teste:** diversos com sufixo “- ok”  
+  **Categoria:** Description quality  
+  **Problema:** “ok” é vago e não comunica o resultado funcional validado.  
+  **Sugestão:** Substituir por descrição explícita do efeito de negócio esperado.
+
+---
+
+## 8) Coverage padding
+
+### High
+- **Arquivo:** `backend/src/test/java/sgc/seguranca/login/dto/UsuarioAcessoAdTest.java`  
+  **Teste:** `devePermitirGettersESetters`  
+  **Categoria:** Coverage padding  
+  **Problema:** Teste puramente de getters/setters (POJO), sem risco funcional real; tende a inflar cobertura artificialmente.  
+  **Sugestão:** Remover ou substituir por teste de serialização/validação contratual relevante.
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/mapa/model/CompetenciaTest.java`  
+  **Teste:** `deveInstanciarViaBuilder`  
+  **Categoria:** Coverage padding  
+  **Problema:** Valida apenas construção e acesso simples de atributos, sem regra de domínio.  
+  **Sugestão:** Cobrir invariantes da entidade (validação, relacionamento, consistência).
+
+- **Arquivo:** `backend/src/test/java/sgc/comum/model/EntidadeBaseTest.java`  
+  **Teste:** `deveGerarToStringComNomeClasseECodigo`  
+  **Categoria:** Coverage padding  
+  **Problema:** Asserção de `toString()` tem baixo valor para regressão funcional e alto custo de manutenção quando formato muda.  
+  **Sugestão:** Manter apenas se houver requisito explícito de logging/observabilidade dependente desse formato.
+
+---
+
+## 9) Comment quality
+
+### Medium
+- **Arquivo:** `backend/src/test/java/sgc/processo/model/ModelCoverageTest.java`  
+  **Teste:** `deveRemoverParticipantesAoSincronizar`  
+  **Categoria:** Comment quality  
+  **Problema:** Comentário “cobre true/false do removeIf em Proceso.java:86” descreve implementação/linha, não intenção de negócio; fica obsoleto com refatoração.  
+  **Sugestão:** Trocar por comentário orientado a comportamento (regra funcional) ou remover.
+
+### Low
+- **Arquivo:** `backend/src/test/java/sgc/processo/ProcessoControllerTest.java`  
+  **Teste:** `deveListarUnidadesParaImportacaoComSubprocessoNulo`  
+  **Categoria:** Comment quality  
+  **Problema:** Comentário “forçar subprocesso = null na iteração” repete exatamente o que o stub já torna explícito no código.  
+  **Sugestão:** Remover comentário redundante e manter apenas nomes claros de teste/variáveis.
+
+---
+
+## Execução completa da suíte e resumo de cobertura
+
+- **Execução solicitada:** `./gradlew :backend:test`
+- **Resultado:** 1126 testes executados, 1126 aprovados, 0 falhas.
+- **Relatório de cobertura:** `./gradlew :backend:jacocoTestReport`
+- **Resumo JaCoCo (backend):**
+  - **Instruction:** 97,89% (16524/16880)
+  - **Branch:** 91,22% (1143/1253)
+  - **Line:** 99,00% (3557/3593)
+  - **Complexity:** 92,00% (1299/1412)
+  - **Method:** 98,72% (770/780)
+  - **Class:** 100,00% (66/66)
+
+> Observação crítica: a alta cobertura estrutural não elimina bugs de negócio; por isso o foco do checklist continua sendo
+> qualidade de oráculo, rastreabilidade de requisito e validação de invariantes (não apenas status HTTP).
+
+---
+
+## Tabela-resumo
+
+| Categoria | Qtde. achados |
+|---|---:|
+| Corrupted test oracles | 2 |
+| Business rule coverage | 2 |
+| Fixture integrity | 1 |
+| Requirement traceability | 3 |
+| Functional overlap | 2 |
+| Test suite cohesion | 2 |
+| Description quality | 3 |
+| Coverage padding | 3 |
+| Comment quality | 2 |
+| **Total** | **20** |


### PR DESCRIPTION
### Motivation

- Align test DB schema with the domain model by enforcing non-null invariants on `subprocesso` important columns to avoid invalid fixture states.
- Cover two missing business flows (CDU-15: competency map and CDU-21: finalizing mapping/review) with dedicated integration tests to improve requirement traceability.
- Harden controller-level tests to validate response payloads and interactions instead of relying only on HTTP status codes.
- Provide an immediate test-quality report to document findings and guide follow-ups on fragile oracles and coverage issues.

### Description

- Updated `backend/src/test/resources/db/schema.sql` to add `NOT NULL` constraints for `subprocesso.data_limite_etapa1`, `processo_codigo`, `unidade_codigo` and `situacao` to reflect model invariants.
- Modified many test fixtures and integration/unit tests to set `dataLimiteEtapa1` (via `LocalDateTime.now().plusDays(...)` or SQL `CURRENT_TIMESTAMP`) so persisted entities satisfy the new schema requirements.
- Added new integration tests `CDU15IntegrationTest` and `CDU21IntegrationTest` to cover competency map management and process finalization scenarios, and strengthened `SubprocessoControllerCoverageTest` to assert JSON response bodies and verify service interactions.
- Added `test-quality-report.md` summarizing test findings, remediation actions, and the results of running the test suite and coverage report.

### Testing

- Executed the backend test suite with `./gradlew :backend:test` and all tests passed: `1126 tests executed, 1126 passed, 0 failed`.
- Generated JaCoCo coverage with `./gradlew :backend:jacocoTestReport` and recorded backend coverage metrics (Instruction ~97.9%, Branch ~91.2%, Line ~99.0%).
- Controller and integration tests updated to include additional assertions (JSON body and service call verifications) and these assertions succeeded in the CI test run.
- No automated tests failed after the schema and fixture updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c700ddfb9c832b9a530ce103bca9d8)