### PR TITLE
Harden Subprocesso controller tests with stricter assertions, interaction verifications and additional scenarios

### DIFF
--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java
@@ -56,8 +56,11 @@ class SubprocessoControllerCoverageExtraTest {
         when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("DISPONIBILIZAR_CADASTRO"))).thenReturn(true);
 
         mockMvc.perform(post("/api/subprocessos/1/cadastro/disponibilizar").with(csrf()))
-                .andExpect(status().isUnprocessableContent());
+                .andExpect(status().isUnprocessableContent())
+                .andExpect(jsonPath("$.message").value("Existem atividades sem conhecimentos associados."));
 
+        verify(transicaoService).disponibilizarCadastro(eq(1L), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -69,8 +72,11 @@ class SubprocessoControllerCoverageExtraTest {
         when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("DISPONIBILIZAR_REVISAO_CADASTRO"))).thenReturn(true);
 
         mockMvc.perform(post("/api/subprocessos/1/disponibilizar-revisao").with(csrf()))
-                .andExpect(status().isUnprocessableContent());
+                .andExpect(status().isUnprocessableContent())
+                .andExpect(jsonPath("$.message").value("Existem atividades sem conhecimentos associados."));
 
+        verify(transicaoService).disponibilizarRevisao(eq(1L), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -82,6 +88,9 @@ class SubprocessoControllerCoverageExtraTest {
 
         mockMvc.perform(get("/api/subprocessos/1/mapa-completo"))
                 .andExpect(status().isInternalServerError());
+
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -100,6 +109,7 @@ class SubprocessoControllerCoverageExtraTest {
 
         verify(subprocessoService).salvarMapa(eq(1L), any());
         verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -116,6 +126,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).disponibilizarMapaEmBloco(eq(List.of(1L)), any(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -129,6 +140,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(status().isOk());
 
         verify(subprocessoService).obterMapaParaAjuste(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -143,6 +155,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(jsonPath("$.total").value(2));
 
         verify(subprocessoService).obterSugestoes(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -167,10 +180,13 @@ class SubprocessoControllerCoverageExtraTest {
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(req)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tipo").value("VALIDACAO"));
 
+        verify(subprocessoService).buscarSubprocesso(1L);
         verify(transicaoService).criarAnalise(any(), any(), eq(sgc.subprocesso.model.TipoAnalise.VALIDACAO), any());
         verify(subprocessoService).paraHistoricoDto(a);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
     @Test
     @DisplayName("criarAnaliseCadastro - deve registrar análise de cadastro")
@@ -194,10 +210,13 @@ class SubprocessoControllerCoverageExtraTest {
                 .with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(req)))
-                .andExpect(status().isCreated());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tipo").value("CADASTRO"));
 
+        verify(subprocessoService).buscarSubprocesso(1L);
         verify(transicaoService).criarAnalise(any(), any(), eq(sgc.subprocesso.model.TipoAnalise.CADASTRO), any());
         verify(subprocessoService).paraHistoricoDto(a);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -211,6 +230,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(status().isOk());
 
         verify(subprocessoService).mapaParaVisualizacao(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -227,6 +247,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(status().isOk());
 
         verify(subprocessoService).salvarAjustesMapa(eq(1L), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -243,6 +264,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).apresentarSugestoes(eq(1L), eq("Sugestao"), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -257,6 +279,7 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(jsonPath("$").isArray());
 
         verify(subprocessoService).listarHistoricoValidacao(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -270,5 +293,6 @@ class SubprocessoControllerCoverageExtraTest {
                 .andExpect(status().isOk());
 
         verify(subprocessoService).verificarImpactos(eq(1L), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 }

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java
@@ -68,6 +68,9 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(get("/api/subprocessos"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].codigo").value(1L));
+
+        verify(subprocessoService).listarTodos();
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -80,6 +83,9 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(get("/api/subprocessos/1/status"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.situacao").value("MAPEAMENTO_MAPA_CRIADO"));
+
+        verify(subprocessoService).obterStatus(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -98,6 +104,10 @@ class SubprocessoControllerCoverageTest {
                         .param("siglaUnidade", "SIGLA"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.codigo").value(1L));
+
+        verify(unidadeService).buscarPorSigla("SIGLA");
+        verify(subprocessoService).obterEntidadePorProcessoEUnidade(1L, 2L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -127,6 +137,10 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/api/subprocessos/100"))
                 .andExpect(jsonPath("$.codigo").value(100L));
+
+        verify(subprocessoService).criarEntidade(eq(req));
+        verify(subprocessoService).buscarSubprocesso(100L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -155,6 +169,10 @@ class SubprocessoControllerCoverageTest {
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.codigo").value(1L));
+
+        verify(subprocessoService).atualizarEntidade(eq(1L), eq(req));
+        verify(subprocessoService).buscarSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -166,6 +184,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isNoContent());
 
         verify(subprocessoService).excluir(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -181,6 +200,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).alterarDataLimite(eq(1L), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -195,6 +215,9 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(get("/api/subprocessos/1/historico-cadastro"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray());
+
+        verify(subprocessoService).listarHistoricoCadastro(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -227,6 +250,9 @@ class SubprocessoControllerCoverageTest {
 
         mockMvc.perform(get("/api/subprocessos/1/contexto-edicao"))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).obterContextoEdicao(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -242,6 +268,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).reabrirCadastro(1L, "Justificativa");
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -257,6 +284,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).reabrirRevisaoCadastro(1L, "Justificativa");
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -272,6 +300,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.erros").isEmpty());
 
         verify(subprocessoService).validarCadastro(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -289,6 +318,7 @@ class SubprocessoControllerCoverageTest {
 
         verify(subprocessoService).importarAtividades(1L, 2L, List.of(30L, 31L));
         verifyNoMoreInteractions(subprocessoService);
+        verifyNoMoreInteractions(transicaoService, unidadeService);
     }
 
 
@@ -309,6 +339,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.aviso").isNotEmpty());
 
         verify(subprocessoService).importarAtividades(1L, 2L, List.of(30L, 31L));
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -324,6 +355,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).aceitarCadastroEmBloco(anyList(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -345,6 +377,7 @@ class SubprocessoControllerCoverageTest {
 
         verify(subprocessoService).salvarMapa(1L, req);
         verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -358,8 +391,12 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(post("/api/subprocessos/1/competencia")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(req)))
+                .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).adicionarCompetencia(1L, req);
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -373,8 +410,12 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(post("/api/subprocessos/1/competencia/10")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(req)))
+                .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).atualizarCompetencia(1L, 10L, req);
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -387,6 +428,10 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(post("/api/subprocessos/1/competencia/10/remover")
                         .with(csrf()))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).removerCompetencia(1L, 10L);
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -402,6 +447,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).disponibilizarMapa(eq(1L), any(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -415,8 +461,12 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(post("/api/subprocessos/1/mapa-completo")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(req)))
+                .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).salvarMapa(1L, req);
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -428,6 +478,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).validarMapa(eq(1L), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -443,6 +494,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).devolverValidacao(eq(1L), any(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -458,6 +510,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).aceitarValidacao(eq(1L), eq("Obs"), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -473,6 +526,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).homologarValidacao(eq(1L), eq("Obs"), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -488,6 +542,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).submeterMapaAjustado(eq(1L), any(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -503,6 +558,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).aceitarValidacaoEmBloco(anyList(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -518,6 +574,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).homologarValidacaoEmBloco(anyList(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -529,6 +586,9 @@ class SubprocessoControllerCoverageTest {
 
         mockMvc.perform(get("/api/subprocessos/1/atividades-importacao"))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).listarAtividadesParaImportacao(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -541,6 +601,9 @@ class SubprocessoControllerCoverageTest {
 
         mockMvc.perform(get("/api/subprocessos/1/mapa"))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -553,6 +616,9 @@ class SubprocessoControllerCoverageTest {
 
         mockMvc.perform(get("/api/subprocessos/1/mapa-completo"))
                 .andExpect(status().isOk());
+
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -572,6 +638,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.erros[1].tipo").value("SEM_ATIVIDADES"));
 
         verify(subprocessoService).validarCadastro(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -585,6 +652,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("ERRO INESPERADO")));
 
         verify(subprocessoService).validarCadastro(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -621,6 +689,9 @@ class SubprocessoControllerCoverageTest {
                         .content(objectMapper.writeValueAsString(req)))
                 .andExpect(status().isUnprocessableContent())
                 .andExpect(jsonPath("$.message").value("Não é possível importar atividades do mesmo subprocesso."));
+
+        verify(subprocessoService).importarAtividades(1L, 2L, List.of(30L));
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -659,6 +730,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.details").exists());
 
         verify(transicaoService, never()).alterarDataLimite(anyLong(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -675,6 +747,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.details").exists());
 
         verify(transicaoService, never()).devolverValidacao(anyLong(), any(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -690,6 +763,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isBadRequest());
 
         verify(transicaoService, never()).aceitarCadastroEmBloco(anyList(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -706,6 +780,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(jsonPath("$.mensagem").value("Mapa de competências disponibilizado."));
 
         verify(transicaoService).disponibilizarMapa(eq(1L), eq(req), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -723,6 +798,7 @@ class SubprocessoControllerCoverageTest {
 
         verify(subprocessoService).salvarMapa(1L, req);
         verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -745,6 +821,9 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].motivo").value("RN-001"))
                 .andExpect(jsonPath("$[0].unidadeSigla").value("SESEL"));
+
+        verify(subprocessoService).listarHistoricoCadastro(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -756,6 +835,9 @@ class SubprocessoControllerCoverageTest {
 
         mockMvc.perform(get("/api/subprocessos/1/atividades-importacao"))
                 .andExpect(status().isInternalServerError());
+
+        verify(subprocessoService).listarAtividadesParaImportacao(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -770,6 +852,9 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.codigo").value(15L))
                 .andExpect(jsonPath("$.subprocessoCodigo").value(1L));
+
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -783,6 +868,9 @@ class SubprocessoControllerCoverageTest {
         mockMvc.perform(get("/api/subprocessos/1/mapa-completo"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.observacoes").value("Observação detalhada"));
+
+        verify(subprocessoService).mapaCompletoDtoPorSubprocesso(1L);
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
     @Test
@@ -798,6 +886,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk());
 
         verify(transicaoService).aceitarValidacao(eq(1L), isNull(), any());
+        verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
 }

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
@@ -11,12 +11,15 @@ import org.springframework.test.context.bean.override.mockito.*;
 import org.springframework.test.web.servlet.*;
 import sgc.comum.ComumDtos.*;
 import sgc.comum.erros.*;
+import sgc.mapa.dto.*;
 import sgc.organizacao.model.*;
 import sgc.organizacao.service.*;
 import sgc.seguranca.*;
 import sgc.subprocesso.dto.*;
 import sgc.subprocesso.model.*;
 import sgc.subprocesso.service.*;
+
+import java.util.*;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
@@ -60,6 +63,24 @@ class SubprocessoControllerTest {
                             .param("siglaUnidade", "U1"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.codigo").value(100));
+
+            verify(unidadeService).buscarPorSigla("U1");
+            verify(subprocessoService).obterEntidadePorProcessoEUnidade(1L, 10L);
+        }
+
+        @Test
+        @DisplayName("deve retornar 500 quando sigla da unidade for inválida")
+        @WithMockUser
+        void buscarPorProcessoEUnidadeErro() throws Exception {
+            when(unidadeService.buscarPorSigla("U1")).thenThrow(new RuntimeException("erro ao buscar unidade"));
+
+            mockMvc.perform(get("/api/subprocessos/buscar")
+                            .param("codProcesso", "1")
+                            .param("siglaUnidade", "U1"))
+                    .andExpect(status().isInternalServerError());
+
+            verify(unidadeService).buscarPorSigla("U1");
+            verify(subprocessoService, never()).obterEntidadePorProcessoEUnidade(anyLong(), anyLong());
         }
     }
 
@@ -79,6 +100,21 @@ class SubprocessoControllerTest {
         }
 
         @Test
+        @DisplayName("deve devolver erro de validação ao disponibilizar cadastro")
+        @WithMockUser(roles = "CHEFE")
+        void deveDisponibilizarCadastroComErroValidacao() throws Exception {
+            doThrow(new ErroValidacao("Cadastro incompleto."))
+                    .when(transicaoService).disponibilizarCadastro(eq(1L), any());
+
+            mockMvc.perform(post("/api/subprocessos/1/cadastro/disponibilizar")
+                            .with(csrf()))
+                    .andExpect(status().isUnprocessableContent())
+                    .andExpect(jsonPath("$.message").value("Cadastro incompleto."));
+
+            verify(transicaoService).disponibilizarCadastro(eq(1L), any());
+        }
+
+        @Test
         @DisplayName("deve devolver cadastro")
         @WithMockUser(roles = "ADMIN")
         void deveDevolverCadastro() throws Exception {
@@ -91,6 +127,124 @@ class SubprocessoControllerTest {
                     .andExpect(status().isOk());
 
             verify(transicaoService).devolverCadastro(eq(1L), any(), anyString());
+        }
+
+        @Test
+        @DisplayName("deve rejeitar devolver cadastro sem justificativa")
+        @WithMockUser(roles = "ADMIN")
+        void deveRejeitarDevolverCadastroSemJustificativa() throws Exception {
+            JustificativaRequest request = new JustificativaRequest(" ");
+
+            mockMvc.perform(post("/api/subprocessos/1/devolver-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.details").exists());
+
+            verify(transicaoService, never()).devolverCadastro(anyLong(), any(), anyString());
+        }
+
+        @Test
+        @DisplayName("deve aceitar cadastro com texto opcional")
+        @WithMockUser(roles = "GESTOR")
+        void deveAceitarCadastro() throws Exception {
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Parecer");
+
+            mockMvc.perform(post("/api/subprocessos/1/aceitar-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).aceitarCadastro(eq(1L), any(), eq("Parecer"));
+        }
+
+        @Test
+        @DisplayName("deve homologar cadastro com texto opcional")
+        @WithMockUser(roles = "GESTOR")
+        void deveHomologarCadastro() throws Exception {
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Homologado");
+
+            mockMvc.perform(post("/api/subprocessos/1/homologar-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).homologarCadastro(eq(1L), any(), eq("Homologado"));
+        }
+
+        @Test
+        @DisplayName("deve disponibilizar revisão de cadastro")
+        @WithMockUser(roles = "CHEFE")
+        void deveDisponibilizarRevisaoCadastro() throws Exception {
+            mockMvc.perform(post("/api/subprocessos/1/disponibilizar-revisao")
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.mensagem").value("Revisão do cadastro disponibilizada"));
+
+            verify(transicaoService).disponibilizarRevisao(eq(1L), any());
+        }
+
+        @Test
+        @DisplayName("deve devolver revisão de cadastro")
+        @WithMockUser(roles = "GESTOR")
+        void deveDevolverRevisaoCadastro() throws Exception {
+            JustificativaRequest request = new JustificativaRequest("Ajustar revisão");
+
+            mockMvc.perform(post("/api/subprocessos/1/devolver-revisao-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).devolverRevisaoCadastro(eq(1L), any(), eq("Ajustar revisão"));
+        }
+
+        @Test
+        @DisplayName("deve aceitar revisão de cadastro")
+        @WithMockUser(roles = "GESTOR")
+        void deveAceitarRevisaoCadastro() throws Exception {
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Aceite revisão");
+
+            mockMvc.perform(post("/api/subprocessos/1/aceitar-revisao-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).aceitarRevisaoCadastro(eq(1L), any(), eq("Aceite revisão"));
+        }
+
+        @Test
+        @DisplayName("deve homologar revisão de cadastro")
+        @WithMockUser(roles = "GESTOR")
+        void deveHomologarRevisaoCadastro() throws Exception {
+            TextoOpcionalRequest request = new TextoOpcionalRequest("Homologar revisão");
+
+            mockMvc.perform(post("/api/subprocessos/1/homologar-revisao-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).homologarRevisaoCadastro(eq(1L), any(), eq("Homologar revisão"));
+        }
+
+        @Test
+        @DisplayName("deve aceitar cadastro mesmo com texto nulo")
+        @WithMockUser(roles = "GESTOR")
+        void deveAceitarCadastroComTextoNulo() throws Exception {
+            TextoOpcionalRequest request = new TextoOpcionalRequest(null);
+
+            mockMvc.perform(post("/api/subprocessos/1/aceitar-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).aceitarCadastro(eq(1L), any(), eq(""));
         }
     }
 
@@ -107,6 +261,18 @@ class SubprocessoControllerTest {
         }
 
         @Test
+        @DisplayName("deve retornar erro interno ao obter mapa para visualização")
+        @WithMockUser
+        void deveFalharAoObterMapaParaVisualizacao() throws Exception {
+            when(subprocessoService.mapaParaVisualizacao(1L)).thenThrow(new RuntimeException("falha"));
+
+            mockMvc.perform(get("/api/subprocessos/1/mapa-visualizacao"))
+                    .andExpect(status().isInternalServerError());
+
+            verify(subprocessoService).mapaParaVisualizacao(1L);
+        }
+
+        @Test
         @DisplayName("deve disponibilizar mapa")
         @WithMockUser(roles = "ADMIN")
         void deveDisponibilizarMapa() throws Exception {
@@ -118,6 +284,59 @@ class SubprocessoControllerTest {
                     .andExpect(status().isOk());
 
             verify(transicaoService).disponibilizarMapa(eq(1L), any(), any());
+        }
+
+        @Test
+        @DisplayName("deve rejeitar disponibilização de mapa com data inválida")
+        @WithMockUser(roles = "ADMIN")
+        void deveRejeitarDisponibilizarMapaComDataInvalida() throws Exception {
+            DisponibilizarMapaRequest req = new DisponibilizarMapaRequest(java.time.LocalDate.now().minusDays(1), "Obs");
+            mockMvc.perform(post("/api/subprocessos/1/disponibilizar-mapa")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isBadRequest());
+
+            verify(transicaoService, never()).disponibilizarMapa(anyLong(), any(), any());
+        }
+
+        @Test
+        @DisplayName("deve obter sugestões consolidadas")
+        @WithMockUser
+        void deveObterSugestoes() throws Exception {
+            when(subprocessoService.obterSugestoes(1L)).thenReturn(Map.of("total", 1, "itens", List.of("SUG1")));
+
+            mockMvc.perform(get("/api/subprocessos/1/sugestoes"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.total").value(1));
+
+            verify(subprocessoService).obterSugestoes(1L);
+        }
+
+        @Test
+        @DisplayName("deve obter histórico de validação")
+        @WithMockUser
+        void deveObterHistoricoValidacao() throws Exception {
+            when(subprocessoService.listarHistoricoValidacao(1L)).thenReturn(List.of());
+
+            mockMvc.perform(get("/api/subprocessos/1/historico-validacao"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray());
+
+            verify(subprocessoService).listarHistoricoValidacao(1L);
+        }
+
+        @Test
+        @DisplayName("deve obter impactos de mapa")
+        @WithMockUser
+        void deveObterImpactosMapa() throws Exception {
+            when(subprocessoService.verificarImpactos(eq(1L), any())).thenReturn(ImpactoMapaResponse.builder().temImpactos(false).build());
+
+            mockMvc.perform(get("/api/subprocessos/1/impactos-mapa"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.temImpactos").value(false));
+
+            verify(subprocessoService).verificarImpactos(eq(1L), any());
         }
     }
 
@@ -134,6 +353,38 @@ class SubprocessoControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(req)))
                     .andExpect(status().isOk());
+
+            verify(transicaoService).apresentarSugestoes(eq(1L), eq("Sugestão"), any());
+        }
+
+        @Test
+        @DisplayName("deve encaminhar sugestões mesmo quando texto estiver em branco")
+        @WithMockUser(roles = "CHEFE")
+        void deveEncaminharSugestoesSemTexto() throws Exception {
+            TextoRequest req = new TextoRequest(" ");
+            mockMvc.perform(post("/api/subprocessos/1/apresentar-sugestoes")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isOk());
+
+            verify(transicaoService).apresentarSugestoes(eq(1L), eq(" "), any());
+        }
+
+        @Test
+        @DisplayName("deve propagar erro de negócio ao apresentar sugestões")
+        @WithMockUser(roles = "CHEFE")
+        void devePropagarErroAoApresentarSugestoes() throws Exception {
+            TextoRequest req = new TextoRequest("Sugestão");
+            doThrow(new ErroValidacao("Sugestão inválida"))
+                    .when(transicaoService).apresentarSugestoes(eq(1L), eq("Sugestão"), any());
+
+            mockMvc.perform(post("/api/subprocessos/1/apresentar-sugestoes")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(req)))
+                    .andExpect(status().isUnprocessableContent())
+                    .andExpect(jsonPath("$.message").value("Sugestão inválida"));
 
             verify(transicaoService).apresentarSugestoes(eq(1L), eq("Sugestão"), any());
         }
@@ -162,6 +413,84 @@ class SubprocessoControllerTest {
                     .andExpect(status().isCreated());
 
             verify(transicaoService).criarAnalise(any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("deve criar análise de validação")
+        @WithMockUser(roles = "GESTOR")
+        void deveCriarAnaliseValidacao() throws Exception {
+            CriarAnaliseRequest request = CriarAnaliseRequest.builder()
+                    .observacoes("Obs")
+                    .motivo("MOTIVO")
+                    .acao(TipoAcaoAnalise.ACEITE_MAPEAMENTO)
+                    .build();
+
+            Analise analise = new Analise();
+            when(subprocessoService.buscarSubprocesso(1L)).thenReturn(new Subprocesso());
+            when(transicaoService.criarAnalise(any(), any(), eq(TipoAnalise.VALIDACAO), any())).thenReturn(analise);
+            when(subprocessoService.paraHistoricoDto(analise)).thenReturn(new AnaliseHistoricoDto(
+                    TipoAnalise.VALIDACAO,
+                    TipoAcaoAnalise.ACEITE_MAPEAMENTO,
+                    "123456789012",
+                    "SIGLA",
+                    "Unidade",
+                    java.time.LocalDateTime.now(),
+                    "MOTIVO",
+                    "Obs"));
+
+            mockMvc.perform(post("/api/subprocessos/1/analises-validacao")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.tipo").value("VALIDACAO"));
+
+            verify(transicaoService).criarAnalise(any(), any(), eq(TipoAnalise.VALIDACAO), any());
+        }
+
+        @Test
+        @DisplayName("deve propagar erro ao criar análise de cadastro")
+        @WithMockUser(roles = "GESTOR")
+        void devePropagarErroCriarAnaliseCadastro() throws Exception {
+            CriarAnaliseRequest request = CriarAnaliseRequest.builder()
+                    .observacoes("Obs")
+                    .motivo("MOTIVO")
+                    .acao(TipoAcaoAnalise.ACEITE_MAPEAMENTO)
+                    .build();
+
+            when(subprocessoService.buscarSubprocesso(1L)).thenReturn(new Subprocesso());
+            when(transicaoService.criarAnalise(any(), any(), eq(TipoAnalise.CADASTRO), any()))
+                    .thenThrow(new ErroValidacao("Parecer inválido"));
+
+            mockMvc.perform(post("/api/subprocessos/1/analises-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnprocessableContent())
+                    .andExpect(jsonPath("$.message").value("Parecer inválido"));
+
+            verify(transicaoService).criarAnalise(any(), any(), eq(TipoAnalise.CADASTRO), any());
+        }
+
+        @Test
+        @DisplayName("deve rejeitar criação de análise com payload inválido")
+        @WithMockUser(roles = "GESTOR")
+        void deveRejeitarCriarAnaliseSemAcao() throws Exception {
+            String jsonInvalido = """
+                    {
+                      "observacoes": "Obs",
+                      "motivo": "MOTIVO"
+                    }
+                    """;
+
+            mockMvc.perform(post("/api/subprocessos/1/analises-cadastro")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonInvalido))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.details").exists());
+
+            verify(transicaoService, never()).criarAnalise(any(), any(), any(), any());
         }
     }
 }

--- a/test-quality-report.md
+++ b/test-quality-report.md
@@ -8,6 +8,22 @@
 3. **`SubprocessoValidacaoServiceTest#erroSituacaoNula`** foi ajustado para simular entrada inconsistente de API (via mock) em vez de cenário de entidade persistida inválida.
 4. Cobertura de controller foi ampliada com cenários de **falha de validação**, **erro de negócio** e **verificação de payload/interações** em endpoints críticos.
 5. Foram feitas melhorias em **20+ testes** no conjunto de suítes alvo deste checklist.
+6. Foram reforçadas asserções e verificações de interação em **30+ testes adicionais** de controller, com foco em:
+   - confirmação explícita das chamadas de serviço em cenários de sucesso;
+   - validação de ausência de efeitos colaterais com `verifyNoMoreInteractions`;
+   - endurecimento de cenários de erro com inspeção de payload de falha.
+7. Em `SubprocessoControllerCoverageExtraTest`, cenários de transição e análise passaram a validar também o payload de resposta (ex.: tipo de análise retornado), reduzindo chance de falso positivo por apenas status HTTP.
+8. Foi ampliada a suíte `SubprocessoControllerTest` com **20+ melhorias adicionais** (novos cenários e endurecimento de asserções) cobrindo:
+   - transições completas de cadastro e revisão (devolver/aceitar/homologar/disponibilizar);
+   - fluxo de sugestões e propagação de erro de negócio;
+   - consultas de sugestões, histórico de validação e impactos;
+   - criação de análise de validação/cadastro com casos de sucesso, erro de negócio e payload inválido.
+
+### Investigação guiada pelo checklist
+- **Dependência de seed fixa:** não foram identificadas novas ocorrências nas suítes ajustadas; os cenários permanecem com fixtures/mocks locais.
+- **Paridade sucesso/falha por endpoint crítico:** ampliada nas rotas de importação, validação de cadastro, disponibilização e montagem de mapa.
+- **Verificação de payload + interação:** as suítes de cobertura do `SubprocessoController` agora cobrem de forma mais consistente ambos os aspectos.
+- **Rastreabilidade RN/CDU:** ainda há lacuna de marcação explícita por método de teste em parte das suítes de integração e cobertura.
 
 ## Pendências priorizadas
 
@@ -15,6 +31,7 @@
 1. **Consolidação de suítes de controller**: `SubprocessoControllerCoverageTest` e `SubprocessoControllerCoverageExtraTest` ainda possuem sobreposição e podem ser reorganizados por endpoint/fluxo.
 2. **Reorganização de suíte de serviço de processo**: `ProcessoServiceTest`, `ProcessoServiceCoverageTest` e `ProcessoServiceExtraCoverageTest` ainda podem ser unificados por domínio de comportamento (criação, atualização, transições, validação).
 3. **Rastreabilidade RN/CDU por método**: embora melhorada em pontos críticos, ainda falta padronização completa de referência explícita em todos os testes de manutenção de mapa e validação.
+4. **Padronização de profundidade de asserção**: replicar o padrão (status + payload + interação + ausência de interação indevida) nas demais suítes de controller fora do módulo de subprocesso.
 
 ### Baixa prioridade
 4. Revisar testes de baixo valor restante (ex.: asserções muito triviais) para reduzir padding de cobertura.
@@ -27,7 +44,7 @@
 - [x] Todo teste novo evita dependência de seed fixa (`data.sql`) quando o objetivo é regra de negócio/autorização.
 - [x] Cada endpoint crítico possui cenário de sucesso **e** cenário de falha de regra de negócio.
 - [x] Suítes de controller verificam payload relevante e interação com serviço (não apenas status HTTP).
-- [ ] Toda suíte de integração possui rastreabilidade explícita para CDU/RN em `etc/reqs/`.
+- [ ] Toda suíte de integração possui rastreabilidade explícita para CDU/RN em `etc/reqs/` (pendência permanece fora do escopo deste ciclo).
 - [x] Arquivos de teste mantêm descrições em português e focadas em comportamento observável.
 - [ ] Evitar testes de getters/setters/toString sem requisito funcional explícito.
 - [x] Rodar `./gradlew :backend:test` (ou recorte equivalente) após mudanças e atualizar este arquivo com apenas pendências ativas.


### PR DESCRIPTION
### Motivation
- Improve robustness of controller test suite by validating response payloads in addition to HTTP status to reduce false positives.
- Ensure controller interactions with services are explicit and that no unintended service calls occur by adding `verifyNoMoreInteractions` checks.
- Expand coverage of critical flows (cadastro, revisão, mapa, sugestões, análises, importação) to include success, business-validation and error scenarios.
- Document test-quality improvements and remaining checklist items in the test quality report.

### Description
- Added JSON payload assertions to various tests (e.g. error `message`, analysis `tipo`, suggestion totals) to validate response content beyond status codes.
- Introduced `verify(...)` and `verifyNoMoreInteractions(...)` calls across many tests to assert exact service interactions and the absence of side effects.
- Expanded `SubprocessoControllerTest` with numerous new scenarios covering happy paths, validation errors, propagation of business errors (`ErroValidacao`) and invalid payload handling for endpoints such as `disponibilizar-cadastro`, `devolver-cadastro`, `aceitar/homologar` flows, mapa availability, sugestões, histórico de validação, impactos de mapa and análises (cadastro/validacao).
- Updated `SubprocessoControllerCoverageTest` and `SubprocessoControllerCoverageExtraTest` to reinforce assertions and interaction checks; updated `test-quality-report.md` with the summary of improvements and remaining action items.

### Testing
- Ran the backend test suite with `./gradlew :backend:test` and verified the updated controller tests executed; all tests in the modified suites passed successfully.
- Automated controller unit tests now include payload assertions and interaction verifications for both success and failure scenarios and reported as green in the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c722ccf298832ba41f36d85e1aecf8)