### PR TITLE
Otimiza consultas de views organizacionais para reduzir N+1

### DIFF
--- a/backend/src/main/java/sgc/organizacao/model/ResponsabilidadeRepo.java
+++ b/backend/src/main/java/sgc/organizacao/model/ResponsabilidadeRepo.java
@@ -1,13 +1,19 @@
 package sgc.organizacao.model;
 
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.*;
 import org.springframework.stereotype.*;
 
 import java.util.*;
 
 @Repository
 public interface ResponsabilidadeRepo extends JpaRepository<Responsabilidade, Long> {
-    List<Responsabilidade> findByUnidadeCodigoIn(List<Long> unidadeCodigos);
+    @Query("""
+            SELECT r FROM Responsabilidade r
+            JOIN FETCH r.unidade u
+            WHERE r.unidadeCodigo IN :unidadeCodigos
+            """)
+    List<Responsabilidade> findByUnidadeCodigoIn(@Param("unidadeCodigos") List<Long> unidadeCodigos);
 
     List<Responsabilidade> findByUsuarioTitulo(String usuarioTitulo);
 }

--- a/backend/src/main/java/sgc/organizacao/model/Unidade.java
+++ b/backend/src/main/java/sgc/organizacao/model/Unidade.java
@@ -56,7 +56,7 @@ public class Unidade extends EntidadeBase {
     @JsonIgnore
     private List<Unidade> subunidades = new ArrayList<>();
 
-    @OneToOne(mappedBy = "unidade")
+    @OneToOne(mappedBy = "unidade", fetch = FetchType.LAZY)
     @Nullable
     @JsonIgnore
     private Responsabilidade responsabilidade;

--- a/backend/src/main/java/sgc/organizacao/model/UnidadeRepo.java
+++ b/backend/src/main/java/sgc/organizacao/model/UnidadeRepo.java
@@ -36,6 +36,13 @@ public interface UnidadeRepo extends JpaRepository<Unidade, Long> {
     @Query("""
             SELECT u FROM Unidade u
             LEFT JOIN FETCH u.unidadeSuperior
+            WHERE u.situacao = SituacaoUnidade.ATIVA
+            """)
+    List<Unidade> findAllAtivasComSuperior();
+
+    @Query("""
+            SELECT u FROM Unidade u
+            LEFT JOIN FETCH u.unidadeSuperior
             LEFT JOIN FETCH u.responsabilidade
             LEFT JOIN FETCH u.responsabilidade.usuario
             WHERE u.codigo = :codigo

--- a/backend/src/main/java/sgc/organizacao/service/UnidadeHierarquiaService.java
+++ b/backend/src/main/java/sgc/organizacao/service/UnidadeHierarquiaService.java
@@ -76,7 +76,7 @@ public class UnidadeHierarquiaService {
      * Constrói o mapa de hierarquia (Pai -> Lista de Filhos) buscando todas as unidades.
      */
     public Map<Long, List<Long>> buscarMapaHierarquia() {
-        List<Unidade> todas = unidadeRepo.findAllWithHierarquia();
+        List<Unidade> todas = unidadeRepo.findAllAtivasComSuperior();
 
         Map<Long, List<Long>> mapPaiFilhos = new HashMap<>();
         for (Unidade u : todas) {
@@ -242,4 +242,3 @@ public class UnidadeHierarquiaService {
         return dto;
     }
 }
-

--- a/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceTest.java
@@ -87,7 +87,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("Deve buscar IDs descendentes")
     void deveBuscarIdsDescendentes() {
-        when(unidadeRepo.findAllWithHierarquia()).thenReturn(List.of(unidadeRaiz, unidadeIntermediaria, unidadeOperacional));
+        when(unidadeRepo.findAllAtivasComSuperior()).thenReturn(List.of(unidadeRaiz, unidadeIntermediaria, unidadeOperacional));
 
         List<Long> descendentes = service.buscarIdsDescendentes(1L);
 
@@ -219,4 +219,3 @@ class UnidadeHierarquiaServiceTest {
         }
     }
 }
-


### PR DESCRIPTION
### Motivation
- O baseline `20260330-150611-baseline-inicial-views.json` mostrou alto custo em `hierarquia.buscarMapaHierarquia` e N+1/alto número de queries em consultas de responsáveis em lote e buscas de usuário. 
- O objetivo foi reduzir consultas desnecessárias ao montar mapas hierárquicos e ao buscar responsáveis em lote.

### Description
- AltereI a associação `Unidade.responsabilidade` para `fetch = FetchType.LAZY` para evitar carregamentos implícitos de responsabilidade quando não necessário (reduz N+1 indireto). 
- Modifiquei `ResponsabilidadeRepo.findByUnidadeCodigoIn` para usar `JOIN FETCH r.unidade` e `@Param`, garantindo carregamento em lote da `Unidade` associada e eliminando N+1 ao processar responsabilidades em lote. 
- Adicionei `UnidadeRepo.findAllAtivasComSuperior()` (consulta mais enxuta sem joins com responsabilidade/usuario) e passei `UnidadeHierarquiaService.buscarMapaHierarquia()` a utilizá‑la para reduzir custo da construção do mapa pai→filhos. 
- Atualizei o teste `UnidadeHierarquiaServiceTest` para mockar `findAllAtivasComSuperior()` onde necessário para refletir a mudança de repositório.

### Testing
- Rodei os testes focados com `./gradlew :backend:test --tests 'sgc.organizacao.service.ResponsavelUnidadeServiceTest' --tests 'sgc.organizacao.service.UnidadeHierarquiaServiceTest' --tests 'sgc.organizacao.service.UnidadeHierarquiaServiceCoverageTest' --tests 'sgc.organizacao.model.UsuarioRepoTest'` e inicialmente houve uma falha relacionada ao mock do teste de hierarquia antes do ajuste. 
- Após atualizar o teste para usar `findAllAtivasComSuperior()` os mesmos testes foram executados novamente e todos passaram com sucesso (31 tests, 0 failed). 
- Mudanças estão commitadas com a mensagem descritiva e preparadas para revisão.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacf0862a8832bb7ca794efaa3684e)