### PR TITLE
Mark units without effective responsible as ineligible and add validations/nullability

### DIFF
--- a/backend/src/main/java/sgc/comum/Mensagens.java
+++ b/backend/src/main/java/sgc/comum/Mensagens.java
@@ -137,6 +137,7 @@ public final class Mensagens {
     public static final String UNIDADES_INTERMEDIARIA_INVALIDAS = "Unidades INTERMEDIARIA inválidas: %s";
     public static final String UNIDADES_SEM_MAPA_VIGENTE        = "Unidades sem mapa vigente: %s";
     public static final String UNIDADES_SEM_SUBPROCESSOS        = "Algumas unidades selecionadas não possuem subprocessos vinculados neste processo: %s";
+    public static final String OPERACAO_NAO_PERMITIDA           = "Não foi possível concluir a operação.";
 
     // ── Histórico de Movimentações ──────────────────────────────────────────
     public static final String HIST_CADASTRO_DISPONIBILIZADO     = "Disponibilização do cadastro de atividades";

--- a/backend/src/main/java/sgc/organizacao/dto/UnidadeDto.java
+++ b/backend/src/main/java/sgc/organizacao/dto/UnidadeDto.java
@@ -40,7 +40,7 @@ public class UnidadeDto {
 
     @JsonView(OrganizacaoViews.Publica.class)
     @JsonProperty("tituloTitular")
-    private String tituloTitular;
+    private @Nullable String tituloTitular;
 
     @JsonView(OrganizacaoViews.Publica.class)
     @JsonProperty("isElegivel")
@@ -67,4 +67,3 @@ public class UnidadeDto {
         return dto;
     }
 }
-

--- a/backend/src/main/java/sgc/organizacao/model/Unidade.java
+++ b/backend/src/main/java/sgc/organizacao/model/Unidade.java
@@ -28,14 +28,14 @@ public class Unidade extends EntidadeBase {
     @JsonView(ComumViews.Publica.class)
     private String sigla;
 
-    @Column(name = "matricula_titular", length = 8, nullable = false)
-    private String matriculaTitular;
+    @Column(name = "matricula_titular", length = 8)
+    private @Nullable String matriculaTitular;
 
-    @Column(name = "titulo_titular", length = 12, nullable = false)
-    private String tituloTitular;
+    @Column(name = "titulo_titular", length = 12)
+    private @Nullable String tituloTitular;
 
-    @Column(name = "data_inicio_titularidade", nullable = false)
-    private LocalDateTime dataInicioTitularidade;
+    @Column(name = "data_inicio_titularidade")
+    private @Nullable LocalDateTime dataInicioTitularidade;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "tipo", length = 20, nullable = false)

--- a/backend/src/main/java/sgc/organizacao/service/UnidadeHierarquiaService.java
+++ b/backend/src/main/java/sgc/organizacao/service/UnidadeHierarquiaService.java
@@ -51,9 +51,17 @@ public class UnidadeHierarquiaService {
 
         return buscarArvoreComElegibilidade(u ->
                 u.getTipo() != INTERMEDIARIA
+                        && possuiResponsavelEfetivo(u)
                         && (!requerMapaVigente || unidadesComMapa.contains(u.getCodigo()))
                         && !unidadesBloqueadas.contains(u.getCodigo())
         );
+    }
+
+    private boolean possuiResponsavelEfetivo(Unidade unidade) {
+        Responsabilidade responsabilidade = unidade.getResponsabilidade();
+        return responsabilidade != null
+                && responsabilidade.getUsuarioTitulo() != null
+                && !responsabilidade.getUsuarioTitulo().isBlank();
     }
 
     /**

--- a/backend/src/main/java/sgc/processo/service/ProcessoService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoService.java
@@ -46,6 +46,7 @@ public class ProcessoService {
     private final ProcessoRepo processoRepo;
     private final ComumRepo repo;
     private final UnidadeService unidadeService;
+    private final ResponsabilidadeRepo responsabilidadeRepo;
     private final SubprocessoService subprocessoService;
     private final SubprocessoConsultaService consultaService;
     private final SubprocessoValidacaoService validacaoService;
@@ -369,6 +370,10 @@ public class ProcessoService {
                 .map(Unidade::getSigla).toList();
         if (!invalidas.isEmpty()) throw new ErroValidacao(Mensagens.UNIDADES_INTERMEDIARIA_INVALIDAS.formatted(String.join(", ", invalidas)));
 
+        if (possuiUnidadeSemResponsavelEfetivo(entidades)) {
+            throw new ErroValidacao(Mensagens.OPERACAO_NAO_PERMITIDA);
+        }
+
         if (tipo == REVISAO || tipo == DIAGNOSTICO) {
             List<String> semMapa = codigosUnidades.stream()
                     .filter(codigo -> !unidadeService.verificarMapaVigente(codigo))
@@ -379,6 +384,10 @@ public class ProcessoService {
 
     private List<String> validarUnidadesInicio(TipoProcesso tipo, List<Long> cods) {
         List<String> erros = new ArrayList<>();
+        List<Unidade> unidades = unidadeService.porCodigos(cods);
+        if (possuiUnidadeSemResponsavelEfetivo(unidades)) {
+            erros.add(Mensagens.OPERACAO_NAO_PERMITIDA);
+        }
         if (tipo == REVISAO || tipo == DIAGNOSTICO) {
             unidadeService.buscarSiglasPorCodigos(cods.stream().filter(codigo -> !unidadeService.verificarMapaVigente(codigo)).toList())
                     .stream().findFirst().ifPresent(s -> erros.add(Mensagens.UNIDADES_SEM_MAPA));
@@ -386,6 +395,15 @@ public class ProcessoService {
         List<Long> bloqueadas = processoRepo.listarUnidadesEmProcessoAtivo(EM_ANDAMENTO, cods);
         if (!bloqueadas.isEmpty()) erros.add(Mensagens.UNIDADES_EM_PROCESSO_ATIVO);
         return erros;
+    }
+
+    private boolean possuiUnidadeSemResponsavelEfetivo(List<Unidade> unidades) {
+        List<Long> codigos = unidades.stream().map(Unidade::getCodigo).toList();
+        Set<Long> unidadesComResponsavelEfetivo = responsabilidadeRepo.findByUnidadeCodigoIn(codigos).stream()
+                .filter(responsabilidade -> responsabilidade.getUsuarioTitulo() != null && !responsabilidade.getUsuarioTitulo().isBlank())
+                .map(Responsabilidade::getUnidadeCodigo)
+                .collect(Collectors.toSet());
+        return unidades.stream().anyMatch(unidade -> !unidadesComResponsavelEfetivo.contains(unidade.getCodigo()));
     }
 
     private void validarFinalizacao(Long codProcesso, Processo processo) {
@@ -600,6 +618,4 @@ public class ProcessoService {
         }
     }
 }
-
-
 

--- a/backend/src/test/java/sgc/integracao/ProcessoServiceIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/ProcessoServiceIntegrationTest.java
@@ -94,6 +94,22 @@ class ProcessoServiceIntegrationTest extends BaseIntegrationTest {
                     .isInstanceOf(ErroValidacao.class)
                     .hasMessageContaining("mapa vigente");
         }
+
+        @Test
+        @DisplayName("Deve lançar erro ao criar processo com unidade sem responsável efetivo")
+        void deveLancarErroAoCriarComUnidadeSemResponsavelEfetivo() {
+            LocalDateTime dataLimite = LocalDateTime.now().plusDays(30);
+            CriarProcessoRequest request = CriarProcessoRequest.builder()
+                    .descricao("Processo com unidade inelegível")
+                    .tipo(TipoProcesso.MAPEAMENTO)
+                    .dataLimiteEtapa1(dataLimite)
+                    .unidades(List.of(905L))
+                    .build();
+
+            assertThatThrownBy(() -> service.criar(request))
+                    .isInstanceOf(ErroValidacao.class)
+                    .hasMessageContaining("Não foi possível concluir a operação.");
+        }
     }
 
     @Nested

--- a/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceTest.java
@@ -43,16 +43,19 @@ class UnidadeHierarquiaServiceTest {
     void setUp() {
         unidadeRaiz = UnidadeTestBuilder.raiz().build();
         unidadeRaiz.setCodigo(1L);
+        unidadeRaiz.setResponsabilidade(criarResponsabilidade(1L));
 
         unidadeIntermediaria = UnidadeTestBuilder.intermediaria()
                 .comSuperior(unidadeRaiz)
                 .build();
         unidadeIntermediaria.setCodigo(2L);
+        unidadeIntermediaria.setResponsabilidade(criarResponsabilidade(2L));
 
         unidadeOperacional = UnidadeTestBuilder.operacional()
                 .comSuperior(unidadeIntermediaria)
                 .build();
         unidadeOperacional.setCodigo(3L);
+        unidadeOperacional.setResponsabilidade(criarResponsabilidade(3L));
     }
 
     @Test
@@ -217,5 +220,28 @@ class UnidadeHierarquiaServiceTest {
             List<UnidadeDto> res2 = service.buscarArvoreComElegibilidade(false, Set.of(unidadeRaiz.getCodigo()));
             assertThat(res2.getFirst().isElegivel()).isFalse(); // Bloqueada
         }
+
+        @Test
+        @DisplayName("Deve marcar como inelegível unidade sem responsável efetivo")
+        void deveMarcarInelegivelSemResponsavelEfetivo() {
+            unidadeOperacional.setResponsabilidade(null);
+            when(unidadeRepo.findAllWithHierarquia()).thenReturn(List.of(unidadeRaiz, unidadeIntermediaria, unidadeOperacional));
+
+            List<UnidadeDto> resultado = service.buscarArvoreComElegibilidade(false, Set.of());
+
+            UnidadeDto operacionalDto = resultado.getFirst().getSubunidades().getFirst().getSubunidades().getFirst();
+            assertThat(operacionalDto.isElegivel()).isFalse();
+        }
+    }
+
+    private Responsabilidade criarResponsabilidade(Long codigoUnidade) {
+        Responsabilidade responsabilidade = new Responsabilidade();
+        responsabilidade.setUnidadeCodigo(codigoUnidade);
+        responsabilidade.setUsuarioTitulo("RESP-" + codigoUnidade);
+        Usuario usuario = new Usuario();
+        usuario.setTituloEleitoral("RESP-" + codigoUnidade);
+        usuario.setNome("Responsável " + codigoUnidade);
+        responsabilidade.setUsuario(usuario);
+        return responsabilidade;
     }
 }

--- a/backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java
@@ -48,6 +48,8 @@ class ProcessoServiceTest {
     @Mock
     private UnidadeService unidadeService;
     @Mock
+    private ResponsabilidadeRepo responsabilidadeRepo;
+    @Mock
     private SubprocessoService subprocessoService;
     @Mock
     private SubprocessoConsultaService consultaService;
@@ -65,6 +67,20 @@ class ProcessoServiceTest {
     private SgcPermissionEvaluator permissionEvaluator;
     @Mock
     private SubprocessoTransicaoService transicaoService;
+
+    @BeforeEach
+    void configurarMocksPadrao() {
+        lenient().when(responsabilidadeRepo.findByUnidadeCodigoIn(anyList()))
+                .thenAnswer(invocacao -> {
+                    List<Long> codigos = invocacao.getArgument(0);
+                    return codigos.stream().map(codigo -> {
+                        Responsabilidade responsabilidade = new Responsabilidade();
+                        responsabilidade.setUnidadeCodigo(codigo);
+                        responsabilidade.setUsuarioTitulo("RESP-" + codigo);
+                        return responsabilidade;
+                    }).toList();
+                });
+    }
 
     @Nested
     @DisplayName("Cobertura e Casos de Borda")
@@ -460,6 +476,23 @@ class ProcessoServiceTest {
             assertThat(resultado).isNotNull();
             assertThat(resultado.getDescricao()).isEqualTo("Teste");
             verify(processoRepo).saveAndFlush(any());
+        }
+
+        @Test
+        @DisplayName("Deve falhar ao criar processo com unidade sem responsável efetivo")
+        void deveFalharCriacaoSemResponsavelEfetivo() {
+            CriarProcessoRequest req = new CriarProcessoRequest(
+                    "Teste", TipoProcesso.MAPEAMENTO, LocalDateTime.now(), List.of(1L));
+            Unidade unidade = new Unidade();
+            unidade.setCodigo(1L);
+            unidade.setSigla("U1");
+            unidade.setSituacao(SituacaoUnidade.ATIVA);
+            when(unidadeService.buscarPorCodigo(1L)).thenReturn(unidade);
+            when(responsabilidadeRepo.findByUnidadeCodigoIn(List.of(1L))).thenReturn(List.of());
+
+            assertThatThrownBy(() -> processoService.criar(req))
+                    .isInstanceOf(ErroValidacao.class)
+                    .hasMessageContaining(Mensagens.OPERACAO_NAO_PERMITIDA);
         }
     }
 

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -149,6 +149,9 @@ INSERT INTO SGC.VW_UNIDADE (codigo, NOME, SIGLA, TIPO, SITUACAO, unidade_superio
                             matricula_titular, data_inicio_titularidade)
 VALUES ('904', 'CDU05-READONLY-UNIT', 'CDU05-READONLY-UNIT', 'OPERACIONAL', 'ATIVA', 2, '777', '00000777',
         CURRENT_TIMESTAMP);
+INSERT INTO SGC.VW_UNIDADE (codigo, NOME, SIGLA, TIPO, SITUACAO, unidade_superior_codigo, titulo_titular,
+                            matricula_titular, data_inicio_titularidade)
+VALUES ('905', 'UNIDADE-SEM-RESP', 'UNIDADE-SEM-RESP', 'OPERACIONAL', 'ATIVA', 2, NULL, NULL, NULL);
 
 -- -------------------------------------------------------------------------------------------------
 -- UNIDADE_MAPA (relaciona unidades com mapas vigentes)

--- a/e2e/cdu-04.spec.ts
+++ b/e2e/cdu-04.spec.ts
@@ -19,6 +19,23 @@ import {TEXTOS} from '../frontend/src/constants/textos.js';
 
 test.describe('CDU-04 - Iniciar processo', () => {
 
+    test('Deve marcar unidade sem responsável efetivo como inelegível na árvore', async ({
+                                                                                              _resetAutomatico,
+                                                                                              page,
+                                                                                              _autenticadoComoAdmin
+    }) => {
+        await page.goto('/painel');
+        await page.getByTestId('btn-painel-criar-processo').click();
+        await expect(page).toHaveURL(/\/processo\/cadastro/);
+
+        await page.getByTestId('sel-processo-tipo').selectOption('MAPEAMENTO');
+        await page.getByTestId('btn-arvore-expand-SECRETARIA_1').click();
+
+        const checkboxUnidadeSemResponsavel = page.getByTestId('chk-arvore-unidade-SECAO_SEM_RESP');
+        await expect(checkboxUnidadeSemResponsavel).toBeVisible();
+        await expect(checkboxUnidadeSemResponsavel).toBeDisabled();
+    });
+
     test('Deve iniciar um processo e validar criação de subprocessos e alertas', async ({
                                                                                             _resetAutomatico,
                                                                                             page,

--- a/e2e/setup/seed.sql
+++ b/e2e/setup/seed.sql
@@ -52,6 +52,9 @@ VALUES (17, 'Coordenadoria 22', 'COORD_22', 'INTERMEDIARIA', 'ATIVA', 11, '13131
 INSERT INTO sgc.vw_unidade (codigo, nome, sigla, tipo, situacao, unidade_superior_codigo, titulo_titular,
                             matricula_titular, data_inicio_titularidade)
 VALUES (18, 'Seção 221', 'SECAO_221', 'OPERACIONAL', 'ATIVA', 17, '141414', '00141414', CURRENT_TIMESTAMP);
+INSERT INTO sgc.vw_unidade (codigo, nome, sigla, tipo, situacao, unidade_superior_codigo, titulo_titular,
+                            matricula_titular, data_inicio_titularidade)
+VALUES (19, 'Seção sem responsável', 'SECAO_SEM_RESP', 'OPERACIONAL', 'ATIVA', 5, NULL, NULL, NULL);
 
 -- Nova Subárvore (Secretaria 3)
 INSERT INTO sgc.vw_unidade (codigo, nome, sigla, tipo, situacao, unidade_superior_codigo, titulo_titular,
@@ -619,4 +622,3 @@ ALTER TABLE sgc.movimentacao
     ALTER COLUMN codigo RESTART WITH 50;
 ALTER TABLE sgc.alerta
     ALTER COLUMN codigo RESTART WITH 10;
-


### PR DESCRIPTION
### Motivation

- Prevent creating or starting processes that include units lacking an effective responsible and make such units clearly ineligible in the UI tree.
- Make titular fields nullable in the `Unidade` view model to reflect optional data coming from the database.

### Description

- Added a generic error message `OPERACAO_NAO_PERMITIDA` to `Mensagens` for use in responsibility-related validation failures.
- Made `matriculaTitular`, `tituloTitular` and `dataInicioTitularidade` nullable in `Unidade` and updated `UnidadeDto` to accept a nullable `tituloTitular`.
- In `UnidadeHierarquiaService` added a `possuiResponsavelEfetivo` helper and updated `buscarArvoreComElegibilidade` to mark units without an effective responsible as inelegible.
- In `ProcessoService` injected `ResponsabilidadeRepo`, added `possuiUnidadeSemResponsavelEfetivo`, and used it in `validarUnidadesParaProcesso` and `validarUnidadesInicio` to block operations when a unit lacks an effective responsible.
- Updated and added automated tests: unit tests in `ProcessoServiceTest` and `UnidadeHierarquiaServiceTest`, an integration test in `ProcessoServiceIntegrationTest`, e2e spec adjustments, and test data seeds to include a unit without a responsible.

### Testing

- Ran the automated unit and integration test suite via `./mvnw test`, which exercised `ProcessoServiceTest`, `UnidadeHierarquiaServiceTest` and `ProcessoServiceIntegrationTest`, and all tests passed.
- Updated test fixtures and seed SQL to include a unit without a responsible and added assertions verifying the new validation and tree-eligibility behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cad5112ef4832b9a8ab08eee3bb1d9)