### PR TITLE
Quality check and minor fixes for frontend and root modules

### DIFF
--- a/e2e/cdu-26.spec.ts
+++ b/e2e/cdu-26.spec.ts
@@ -2,7 +2,7 @@ import {expect, test} from './fixtures/complete-fixtures.js';
 import {criarProcessoMapaValidadoFixture, validarProcessoFixture} from './fixtures/fixtures-processos.js';
 import {fazerLogout, navegarParaSubprocesso} from './helpers/helpers-navegacao.js';
 import {acessarDetalhesProcesso} from './helpers/helpers-processos.js';
-import {loginComPerfil, USUARIOS} from './helpers/helpers-auth.js';
+import {loginComPerfil} from './helpers/helpers-auth.js';
 
 /**
  * CDU-26 - Homologar validação de mapas de competências em bloco

--- a/frontend/src/components/__tests__/BarraNavegacao.spec.ts
+++ b/frontend/src/components/__tests__/BarraNavegacao.spec.ts
@@ -21,7 +21,12 @@ vi.mock("vue-router", () => ({
 }));
 
 // Helper to create mock routes
-const createMockRoute = (path: string, matched: any[], routeName = "", params: Record<string, string> = {}) => ({
+const createMockRoute = (
+    path: string,
+    matched: any[],
+    routeName = "",
+    params: Record<string, string> = {},
+) => ({
     path,
     matched,
     params,


### PR DESCRIPTION
This PR addresses quality check findings in both the root and frontend modules. 

Specifically:
1.  **E2E Fix**: Removed an unused import of `USUARIOS` in `e2e/cdu-26.spec.ts` that was triggering a linting warning in the root module.
2.  **Frontend Test Refactoring**: Formatted the `createMockRoute` helper function in `frontend/src/components/__tests__/BarraNavegacao.spec.ts` to spread its 4 parameters across multiple lines, improving readability and aligning with the project's strict parameter count guidance in `AGENTS.md`.
3.  **Validation**: Successfully ran `npm run typecheck`, root and frontend linting (with `--max-warnings 0`), and frontend unit tests to ensure a clean baseline for the repository.

---
*PR created automatically by Jules for task [2605097196094746738](https://jules.google.com/task/2605097196094746738) started by @lgalvao*