### PR TITLE
Centraliza download de PDFs, trata seleção de unidade e unifica carregamento/erros

### DIFF
--- a/frontend/src/composables/api/__tests__/useRelatorios.spec.ts
+++ b/frontend/src/composables/api/__tests__/useRelatorios.spec.ts
@@ -52,6 +52,7 @@ describe('useRelatorios', () => {
     
     expect(global.URL.createObjectURL).toHaveBeenCalled();
     expect(document.createElement).toHaveBeenCalledWith('a');
+    expect(global.URL.revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/mock-url');
   });
 
   it('deve fazer o download do relatorio de mapas em pdf sem unidadeId', async () => {

--- a/frontend/src/composables/api/useRelatorios.ts
+++ b/frontend/src/composables/api/useRelatorios.ts
@@ -1,5 +1,17 @@
 import apiClient from '@/axios-setup';
 
+function baixarArquivoPdf(dadosArquivo: BlobPart, nomeArquivo: string) {
+  const urlTemporaria = globalThis.URL.createObjectURL(new Blob([dadosArquivo]));
+  const link = document.createElement('a');
+
+  link.href = urlTemporaria;
+  link.setAttribute('download', nomeArquivo);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  globalThis.URL.revokeObjectURL(urlTemporaria);
+}
+
 export function useRelatorios() {
   const axios = apiClient;
 
@@ -12,34 +24,17 @@ export function useRelatorios() {
     const response = await axios.get(`/relatorios/andamento/${codProcesso}/exportar`, {
       responseType: 'blob'
     });
-    
-    // Create a download link for the PDF blob
-    const url = globalThis.URL.createObjectURL(new Blob([response.data]));
-    const link = document.createElement('a');
-    link.href = url;
-    link.setAttribute('download', `relatorio-andamento-${codProcesso}.pdf`);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+
+    baixarArquivoPdf(response.data, `relatorio-andamento-${codProcesso}.pdf`);
   };
-  
+
   const downloadRelatorioMapasPdf = async (codProcesso: number, unidadeId?: number) => {
-    let urlStr = `/relatorios/mapas/${codProcesso}/exportar`;
-    if (unidadeId) {
-      urlStr += `?unidadeId=${unidadeId}`;
-    }
-    
-    const response = await axios.get(urlStr, {
+    const sufixoUnidade = unidadeId ? `?unidadeId=${unidadeId}` : '';
+    const response = await axios.get(`/relatorios/mapas/${codProcesso}/exportar${sufixoUnidade}`, {
       responseType: 'blob'
     });
-    
-    const url = globalThis.URL.createObjectURL(new Blob([response.data]));
-    const link = document.createElement('a');
-    link.href = url;
-    link.setAttribute('download', `relatorio-mapas-${codProcesso}.pdf`);
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+
+    baixarArquivoPdf(response.data, `relatorio-mapas-${codProcesso}.pdf`);
   };
 
   return {

--- a/frontend/src/views/PainelView.vue
+++ b/frontend/src/views/PainelView.vue
@@ -118,28 +118,25 @@ async function buscarProcessosPainel(
 }
 
 async function carregarDados() {
-  if (perfil.perfilSelecionado.value && perfilStore.unidadeSelecionada) {
-    const unidadeCodigo = (perfilStore.unidadeSelecionada as any).codigo || perfilStore.unidadeSelecionada;
-    const promises: Promise<any>[] = [
-      buscarProcessosPainel(
-          unidadeCodigo,
-          0,
-          10,
-      ), // Paginação inicial
-    ];
-
-    promises.push(
-        buscarAlertas(
-            unidadeCodigo,
-            0,
-            10,
-            "dataHora",
-            "desc"
-        ), // Paginação inicial ordenada por dataHora DESC
-    );
-
-    await Promise.all(promises);
+  const unidadeCodigo = obterCodigoUnidadeSelecionada();
+  if (!perfil.perfilSelecionado.value || !unidadeCodigo) {
+    return;
   }
+
+  await Promise.all([
+    buscarProcessosPainel(
+      unidadeCodigo,
+      0,
+      10,
+    ),
+    buscarAlertas(
+      unidadeCodigo,
+      0,
+      10,
+      "dataHora",
+      "desc"
+    ),
+  ]);
 }
 
 function exibirToastPendente() {
@@ -176,7 +173,11 @@ function ordenarPor(campo: keyof ProcessoResumo) {
     criterio.value = campo;
     asc.value = true;
   }
-  const unidadeCodigo = (perfilStore.unidadeSelecionada as any)?.codigo || perfilStore.unidadeSelecionada;
+  const unidadeCodigo = obterCodigoUnidadeSelecionada();
+  if (!unidadeCodigo) {
+    return;
+  }
+
   buscarProcessosPainel(
       unidadeCodigo,
       0,
@@ -184,6 +185,20 @@ function ordenarPor(campo: keyof ProcessoResumo) {
       criterio.value,
       asc.value ? "asc" : "desc",
   );
+}
+
+function obterCodigoUnidadeSelecionada() {
+  const unidadeSelecionada = perfilStore.unidadeSelecionada as unknown;
+
+  if (typeof unidadeSelecionada === "number") {
+    return unidadeSelecionada;
+  }
+
+  if (typeof unidadeSelecionada === "object" && unidadeSelecionada !== null && "codigo" in unidadeSelecionada) {
+    return Number(unidadeSelecionada.codigo);
+  }
+
+  return null;
 }
 
 function abrirDetalhesProcesso(processo: ProcessoResumo | undefined) {

--- a/frontend/src/views/RelatoriosView.vue
+++ b/frontend/src/views/RelatoriosView.vue
@@ -88,7 +88,7 @@
 </template>
 
 <script lang="ts" setup>
-import {computed, onMounted, ref} from "vue";
+import {computed, onMounted, ref, type Ref} from "vue";
 import {BButton, BCard, BCol, BFormGroup, BFormSelect, BRow, BSpinner, BTab, BTable, BTabs} from "bootstrap-vue-next";
 import LayoutPadrao from "@/components/layout/LayoutPadrao.vue";
 import PageHeader from "@/components/layout/PageHeader.vue";
@@ -114,7 +114,7 @@ const unidadeIdSelecionadaMapas = ref<number | null>(null);
 const gerandoAndamento = ref(false);
 const gerandoMapas = ref(false);
 
-const relatorioAndamento = ref<any[]>([]);
+const relatorioAndamento = ref<Array<Record<string, unknown>>>([]);
 
 const opcoesProcessos = computed(() => {
   const processos = processosDisponiveis.value;
@@ -124,18 +124,53 @@ const opcoesProcessos = computed(() => {
   ];
 });
 
-// Options for units (mocked for now, will connect to useUnidadesStore if necessary)
-const opcoesUnidades = ref<Array<{ value: number | null, text: string }>>([
-  { value: null, text: TEXTOS.relatorios.TODAS_UNIDADES }
-]);
+const opcoesUnidades = computed<Array<{ value: number | null, text: string }>>(() => {
+  const codigoUnidade = obterCodigoUnidadeSelecionada();
+  const opcoesBase = [{ value: null, text: TEXTOS.relatorios.TODAS_UNIDADES }];
+
+  if (!codigoUnidade) {
+    return opcoesBase;
+  }
+
+  const sigla = perfilStore.unidadeSelecionadaSigla ?? `Unidade ${codigoUnidade}`;
+  return [...opcoesBase, { value: codigoUnidade, text: sigla }];
+});
 
 function obterCodigoUnidadeSelecionada() {
   if (!perfil.perfilSelecionado.value || !perfilStore.unidadeSelecionada) {
     return null;
   }
 
-  const unidadeSelecionada = perfilStore.unidadeSelecionada as any;
-  return Number(unidadeSelecionada?.codigo || unidadeSelecionada);
+  const unidadeSelecionada = perfilStore.unidadeSelecionada as unknown;
+  if (typeof unidadeSelecionada === "number") {
+    return unidadeSelecionada;
+  }
+
+  if (typeof unidadeSelecionada === "object" && unidadeSelecionada !== null && "codigo" in unidadeSelecionada) {
+    return Number(unidadeSelecionada.codigo);
+  }
+
+  return null;
+}
+
+async function executarComCarregamento(
+  acao: () => Promise<void>,
+  mensagemErro: string,
+  carregando?: Ref<boolean>
+) {
+  if (carregando) {
+    carregando.value = true;
+  }
+
+  try {
+    await acao();
+  } catch {
+    notify(mensagemErro, "danger");
+  } finally {
+    if (carregando) {
+      carregando.value = false;
+    }
+  }
 }
 
 async function carregarProcessosDisponiveis() {
@@ -151,38 +186,26 @@ async function carregarProcessosDisponiveis() {
 
 const gerarRelatorioAndamento = async () => {
   if (!processoIdSelecionado.value) return;
-  gerandoAndamento.value = true;
-  try {
-     relatorioAndamento.value = await obterRelatorioAndamento(processoIdSelecionado.value);
-  } catch {
-     notify(TEXTOS.relatorios.ERRO_BUSCA, "danger");
-  } finally {
-     gerandoAndamento.value = false;
-  }
+  await executarComCarregamento(async () => {
+    relatorioAndamento.value = await obterRelatorioAndamento(processoIdSelecionado.value);
+  }, TEXTOS.relatorios.ERRO_BUSCA, gerandoAndamento);
 };
 
 const exportarPdfAndamento = async () => {
   if (!processoIdSelecionado.value) return;
-  try {
-      await downloadRelatorioAndamentoPdf(processoIdSelecionado.value);
-  } catch {
-      notify(TEXTOS.relatorios.ERRO_EXPORTAR, "danger");
-  }
+  await executarComCarregamento(async () => {
+    await downloadRelatorioAndamentoPdf(processoIdSelecionado.value!);
+  }, TEXTOS.relatorios.ERRO_EXPORTAR);
 };
 
 const gerarRelatorioMapas = async () => {
     if (!processoIdSelecionadoMapas.value) return;
-    gerandoMapas.value = true;
-    try {
-        await downloadRelatorioMapasPdf(
-            processoIdSelecionadoMapas.value, 
-            unidadeIdSelecionadaMapas.value || undefined
-        );
-    } catch {
-       notify(TEXTOS.relatorios.ERRO_GERAR, "danger");
-    } finally {
-       gerandoMapas.value = false;
-    }
+    await executarComCarregamento(async () => {
+      await downloadRelatorioMapasPdf(
+        processoIdSelecionadoMapas.value!,
+        unidadeIdSelecionadaMapas.value || undefined
+      );
+    }, TEXTOS.relatorios.ERRO_GERAR, gerandoMapas);
 }
 
 onMounted(async () => {


### PR DESCRIPTION
### Motivation
- Garantir que os blobs gerados para download sejam corretamente liberados e evitar código duplicado na criação do link de download.
- Lidar com diferentes formatos de `unidadeSelecionada` (número ou objeto com `codigo`) de forma robusta em várias views.
- Unificar o controle de estado de carregamento e tratamento de erro para ações assíncronas repetitivas.

### Description
- Adiciona `baixarArquivoPdf` que cria e revoga o `ObjectURL` e o usa em `useRelatorios` para os downloads de PDF, e simplifica a construção da URL para mapas com sufixo opcional.`
- Atualiza o teste `frontend/src/composables/api/__tests__/useRelatorios.spec.ts` para verificar que `URL.revokeObjectURL` é chamado após o download.
- Refatora `PainelView.vue` para introduzir `obterCodigoUnidadeSelecionada`, aplica checagens antecipadas, e simplifica `carregarDados` e `ordenarPor` para usar o código da unidade obtido.
- Refatora `RelatoriosView.vue` para adicionar tipagem em refs, transforma `opcoesUnidades` em `computed`, adiciona `executarComCarregamento` para encapsular loading/erro e aplica esse wrapper em `gerarRelatorioAndamento`, `exportarPdfAndamento` e `gerarRelatorioMapas` e usa `obterCodigoUnidadeSelecionada` e carregamento de processos.

### Testing
- Atualizado o teste unitário `useRelatorios.spec.ts` para incluir a verificação de `URL.revokeObjectURL` e asserções de criação do link; o teste foi executado como parte da suíte unitária.
- Executadas as suítes de teste unitário (`yarn test:unit`), e a execução dos testes automáticos terminou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd69e9a644832b81502074a22e26a0)