### PR TITLE
docs: Update simplification guidelines for intranet scale

### DIFF
--- a/simplification-suggestions.md
+++ b/simplification-suggestions.md
@@ -1,42 +1,87 @@
 # Sugestões de Simplificação Arquitetural - SGC
 
-Este documento contém recomendações para simplificar a arquitetura e reduzir a complexidade e fragmentação no projeto SGC, focando no contexto de um sistema intranet para 5-10 usuários simultâneos, conforme as diretrizes estabelecidas.
+Este documento contém recomendações para simplificar a arquitetura e reduzir a complexidade e fragmentação no projeto SGC. O sistema é voltado para uso interno (intranet) por no máximo 5 a 10 usuários simultâneos. Nesse contexto restrito, regras de design de software pensadas para alta escalabilidade, distribuição e modularização agressiva constituem **overengineering** e devem ser evitadas.
 
 ## Diretrizes de Combate ao Overengineering (Sistema Intranet 5-10 Usuários)
 
-Dado o contexto estrito do SGC (intranet, 5-10 usuários simultâneos), muitas diretrizes aplicáveis a sistemas altamente escaláveis e super-modularizados **não se aplicam**. A arquitetura deve privilegiar a simplicidade extrema, a legibilidade direta e a ausência de camadas desnecessárias.
+A arquitetura deve privilegiar o "caminho mais curto" entre a requisição e o banco de dados. Menos camadas significam menos código para ler, entender e manter.
 
-*   **Proibição de Facades e Camadas Pass-Through:** Evite criar `Facades` (como `PainelFacade`, `UsuarioFacade`, ou `AtividadeFacade`). A lógica de negócio deve residir diretamente nos Serviços de domínio. Camadas intermediárias que apenas repassam chamadas aumentam a carga cognitiva e dificultam a manutenção.
-*   **Acesso Direto a Repositórios:** Controllers estão **autorizados e encorajados** a acessar diretamente as interfaces de Repositório (`Spring Data JPA`) para operações CRUD básicas ou leituras triviais. Não crie um Serviço apenas para delegar um `findById` ou `findAll`.
-*   **Rejeição de Arquiteturas Complexas:** Padrões como Onion Architecture, Hexagonal Architecture (Ports and Adapters) e Clean Architecture estrita adicionam abstrações (interfaces, mapeamentos de domínio-para-entidade) que são injustificadas. Utilize o modelo de Entidades JPA diretamente como o modelo de domínio principal.
-*   **Procedural vs Orientação a Objetos Pura:** Para lógicas de negócio diretas, abrace métodos procedurais claros nos Serviços. Evite criar hierarquias complexas de herança, múltiplos Design Patterns (Factories, Builders para objetos simples) ou abstrações genéricas projetadas para casos de uso que não existem.
-*   **Consolidação de Serviços:** Evite a "explosão de classes". Agrupe lógicas altamente coesas em um mesmo Serviço. Por exemplo, unifique `SubprocessoTransicaoService` e `SubprocessoValidacaoService` para dentro de `SubprocessoService` em vez de fragmentá-los, a menos que o arquivo se torne intragovernável.
-*   **Pinia Stores Essenciais (Frontend):** Reduza o uso de Pinia Stores que atuam apenas como "pass-through" (repassadores) para chamadas de API (`axios`). Utilize Composables simples (e.g., `useProcessos`) ou faça as chamadas diretamente nos componentes/views. O Pinia deve ser reservado para estado genuinamente global e compartilhado.
-*   **Wrappers Visuais e Componentes de Pass-through:** Questione a necessidade de componentes Vue que apenas envelopam bibliotecas de UI (como `BButton`) sem adicionar valor semântico ou lógico significativo (e.g., `LoadingButton.vue`). Use os componentes originais sempre que possível para manter a árvore do Vue rasa.
-*   **Devolução de Entidades JPA (Leituras Simples):** DTOs continuam importantes para fronteiras externas de mutação (Criação/Atualização), mas para leituras simples (GET) onde não há risco de exposição de dados ou N+1, o Controller pode retornar a entidade JPA diretamente para evitar mapeamentos (boilerplate) redundantes. Se usar DTOs, prefira Java Records estritos.
+1.  **Acesso Direto a Repositórios a partir dos Controllers:**
+    *   **Diretriz:** Controllers estão **autorizados e encorajados** a acessar as interfaces `Spring Data JPA` diretamente para operações CRUD básicas, listagens ou verificações pontuais.
+    *   **Justificativa:** Criar um `Service` que apenas chama `repo.findById()` ou `repo.findAll()` não adiciona valor de negócio, apenas "pass-through" desnecessário e boilerplate.
 
-## Situação Atual (Backend - Java / Spring Boot)
+2.  **Proibição de Facades (Backend):**
+    *   **Diretriz:** Padrões como Facades não devem ser utilizados. A lógica de negócio deve pertencer aos Serviços de domínio. Se um serviço precisar chamar outro, ele deve injetá-lo diretamente ou as lógicas devem ser fundidas, evitando camadas orquestradoras sem comportamento próprio.
+    *   **Justificativa:** Facades muitas vezes se tornam gargalos ou apenas repassam chamadas, inflando o número de classes necessárias para acompanhar o fluxo mental de uma requisição.
 
-1.  **Consolidação de Serviços do Subprocesso:**
-    *   **Problema:** Alta fragmentação e tamanho excessivo nas classes `SubprocessoService` (42KB), `SubprocessoTransicaoService` (33KB), `SubprocessoConsultaService`, etc. A lógica de negócio relacionada a subprocessos está muito dispersa e acoplada.
-    *   **Solução:** Consolidar a lógica coesa em serviços de domínio mais diretos.
-        *   Avaliar a real necessidade de separar `SubprocessoTransicaoService` e `SubprocessoService`. Uma abordagem mais simples reduz a navegação mental.
-    *   **Ação:** Refatorar o pacote `sgc.subprocesso.service` fundindo serviços afins.
+3.  **Consolidação de Serviços (Evite a Fragmentação):**
+    *   **Diretriz:** Agrupe lógicas coesas da mesma entidade em um único `Service`.
+    *   **Justificativa:** Múltiplos serviços muito granulares (ex: `ValidacaoService`, `TransicaoService`, `ConsultaService` para a mesma entidade) diluem o fluxo e exigem injeções circulares e muita navegação. Métodos privados dentro de uma classe maior (e bem estruturada) são preferíveis à divisão excessiva em dezenas de classes.
 
-2.  **Acesso Direto ao Repositório (CRUD Simples):**
-    *   **Problema:** Camadas de serviço atuando apenas como repassadoras.
-    *   **Solução:** Permitir que os Controllers (ex: `ProcessoController`, `SubprocessoController`) injetem e utilizem diretamente as interfaces de Repository.
+4.  **Devolução de Entidades JPA (Sem DTOs para Leituras Simples):**
+    *   **Diretriz:** Para endpoints simples de leitura (`GET`) onde não há exposição de senhas, dados sensíveis ou perigos de *N+1*, é perfeitamente aceitável retornar a entidade do Hibernate diretamente.
+    *   **Justificativa:** Mapeadores e DTOs excessivos geram trabalho braçal. Se usar DTOs, prefira `Java Records`. Bibliotecas genéricas de mapeamento e Mappers explícitos podem ser cortados na maioria dos casos simples.
 
-3.  **Remoção de Facades Desnecessárias:**
-    *   **Problema:** Facades como `AtividadeFacade` (`backend/src/main/java/sgc/mapa/AtividadeFacade.java`), `PainelFacade`, `AlertaFacade`, `RelatorioFacade`, `LoginFacade`, e `UsuarioFacade` adicionam indireção sem abstração significativa. Elas atuam quase unicamente como "pass-through", transferindo chamadas diretamente aos serviços subjacentes sem adicionar valor claro de negócio.
-    *   **Solução:** Mover a lógica da Facade diretamente para os serviços de domínio relevantes. Por exemplo, unificar `LoginFacade` com o serviço de autenticação principal, ou mover operações específicas de `AtividadeFacade` para `MapaManutencaoService`.
+5.  **Rejeição de Clean Architecture, Hexagonal ou Onion:**
+    *   **Diretriz:** O modelo do Hibernate (`@Entity`) é o nosso único modelo de domínio. Não devem ser criadas separações artificiais entre Entidades do Banco de Dados e Objetos de Domínio Puros.
+    *   **Justificativa:** O benefício de trocar o banco de dados futuramente não compensa o custo imediato e permanente de manter múltiplos modelos paralelos.
 
-## Situação Atual (Frontend - Vue.js / TypeScript)
+6.  **Stores do Pinia (Frontend) Apenas para Estado Global:**
+    *   **Diretriz:** Não crie Stores do Pinia apenas para centralizar chamadas `axios` ou para uso em apenas uma tela.
+    *   **Justificativa:** Se a requisição não impacta a sessão de outras telas, faça a chamada usando um simples *Composable* Vue (`useFetch`, `useProcessos`) ou mesmo métodos simples no próprio componente `.vue`.
 
-1.  **Remoção de Wrappers Visuais Finos:**
-    *   **Problema:** Componentes como `LoadingButton.vue` são wrappers finos sobre `BButton` (`frontend/src/components/comum/LoadingButton.vue`), adicionando sobrecarga na árvore do Vue sem muita justificativa, e com baixa reusabilidade. A mesma lógica é repetida em diversas views.
-    *   **Solução:** Remover `LoadingButton.vue` e usar `<BButton>` nativo diretamente com um `<BSpinner>` na aplicação para manter a árvore de componentes plana e simples. A complexidade do wrapper não compensa seu benefício no contexto de um sistema pequeno.
+7.  **Evitar Wrappers Visuais Finos (Frontend):**
+    *   **Diretriz:** Não crie componentes no Vue apenas para encapsular uma prop do Bootstrap. Use as tags da biblioteca (`BootstrapVueNext`) nativamente sempre que possível.
+    *   **Justificativa:** Mantém a árvore do Virtual DOM rasa e reduz a quantidade de arquivos para manter.
 
-2.  **Redução de Complexidade em Views:**
-    *   **Problema:** Views muito extensas (ex: `ProcessoDetalheView.vue` e `MapaView.vue`).
-    *   **Solução:** Extrair lógica reativa complexa para composables específicos da view.
+---
+
+## Foco de Ação: Situação Atual no Backend
+
+Com base no código da aplicação, há vários pontos de melhoria alinhados a estas diretrizes:
+
+### 1. Eliminação de Facades Desnecessárias
+
+Foram identificadas diversas classes com o sufixo `Facade` que consistem principalmente em código de orquestração pass-through.
+*   **Problema:** Em `AtividadeController.java`, a injeção é em `AtividadeFacade.java`. A facade apenas delega chamadas para `MapaManutencaoService` (ex: `mapaManutencaoService.atividadeCodigo(codAtividade)`). Além de `AtividadeFacade`, existem `LoginFacade`, `PainelFacade`, `AlertaFacade`, `RelatorioFacade` e `UsuarioFacade`.
+*   **Ação Recomendada:** Remover essas classes `*Facade.java`. A lógica de autorização presente nas Facades pode ser tratada através de `@PreAuthorize` nos Controllers ou consolidada no Serviço principal. Os Controllers podem depender diretamente de `MapaManutencaoService` ou `UsuarioService`.
+
+### 2. Fragmentação Extrema: O Domínio de Subprocesso
+
+*   **Problema:** A pasta `backend/src/main/java/sgc/subprocesso/service` abriga uma explosão de classes separadas:
+    *   `SubprocessoService.java` (19KB)
+    *   `SubprocessoTransicaoService.java` (32KB)
+    *   `SubprocessoConsultaService.java` (21KB)
+    *   `SubprocessoValidacaoService.java` (10KB)
+    *   `SubprocessoNotificacaoService.java`
+    *   `SubprocessoSituacaoService.java`
+*   **Ação Recomendada:** Proceder com uma consolidação radical. Integrar métodos de Validação e Transição ao `SubprocessoService`. Para as consultas, o Controller poderia até mesmo bater direto em `SubprocessoRepository`. Deve-se unificar as lógicas que mutam estado para dentro de um `SubprocessoService` unificado e forte. A divisão em "sub-serviços" que injetam um ao outro gera complexidade de ciclo de vida do Spring.
+
+### 3. Remoção de Mapeamentos e Builders Desnecessários
+*   **Problema:** A base de código está com dezenas de `Dto.java` e `Request.java` até para cenários rasos, às vezes associados a Builders ou Factory patterns.
+*   **Ação Recomendada:** Avaliar quais DTOs são usados apenas de pass-through. Nos métodos `GET` em que não se vaza propriedades (como senhas), migrar o retorno direto para as classes `@Entity`. Onde o DTO for de fato necessário, converter todas as classes simples para *Records*. Evitar instanciar Objetos Puros com Builders complexos se setters funcionam.
+
+---
+
+## Foco de Ação: Situação Atual no Frontend
+
+### 1. Remoção do Wrapper Pass-Through: `LoadingButton.vue`
+
+*   **Problema:** O arquivo `frontend/src/components/comum/LoadingButton.vue` é um mero envelope para o componente nativo `<BButton>` do BootstrapVueNext, encapsulando condicionalmente um `<BSpinner>` com base numa prop `loading`. Isso adiciona uma camada de componente desnecessária em dezenas de referências e propaga *slots* pass-through.
+*   **Ação Recomendada:** Eliminar `LoadingButton.vue`. O componente consumiria diretamente:
+    ```vue
+    <BButton :disabled="loading" ...>
+      <BSpinner v-if="loading" class="me-1" small />
+      Texto Original
+    </BButton>
+    ```
+    Isso simplifica a árvore de componentes e remove a manutenção do utilitário.
+
+### 2. Substituição de Stores do Pinia
+
+*   **Problema:** Alguns repositórios de Store (como em `frontend/src/stores/subprocessos.ts` ou `perfil.ts`) podem estar atuando de forma síncrona com o servidor ou mantendo dados de cache sem necessidade, replicando responsabilidades que já poderiam estar resolvidas nas chamadas nativas de um Service simples (`authService.ts`, etc).
+*   **Ação Recomendada:** Migrar o acesso a rotas específicas da API diretamente em "Composables" puros Vue (ex: `useSubprocessoListagem()`), que mantêm *state* local apenas durante o ciclo de vida do componente, limitando as Stores globais à autenticação/usuário logado, se necessário.
+
+---
+
+O respeito a essas orientações simplificadas garante uma base de código menor e muito mais rastreável para a escala real do sistema, eliminando a carga cognitiva do overengineering.


### PR DESCRIPTION
This PR updates `simplification-suggestions.md` to establish firm guidelines against overengineering. Given the system's operational context (intranet, 5-10 concurrent users), the updated guidelines explicitly recommend favoring direct, procedural code over complex layered architectures.

Key additions:
- Removal of backend `Facade` classes.
- Consolidation of excessively fragmented domains (like `Subprocesso*Service`).
- Allowing Controllers to directly access Repositories.
- Removing thin Vue wrappers (e.g. `LoadingButton.vue`) and single-use Pinia stores.

---
*PR created automatically by Jules for task [17099728120008816495](https://jules.google.com/task/17099728120008816495) started by @lgalvao*