### PR TITLE
Frontend Quality Check and Type Fix

### DIFF
--- a/frontend/src/views/RelatoriosView.vue
+++ b/frontend/src/views/RelatoriosView.vue
@@ -185,24 +185,27 @@ async function carregarProcessosDisponiveis() {
 }
 
 const gerarRelatorioAndamento = async () => {
-  if (!processoIdSelecionado.value) return;
+  const codProcesso = processoIdSelecionado.value;
+  if (!codProcesso) return;
   await executarComCarregamento(async () => {
-    relatorioAndamento.value = await obterRelatorioAndamento(processoIdSelecionado.value);
+    relatorioAndamento.value = await obterRelatorioAndamento(codProcesso);
   }, TEXTOS.relatorios.ERRO_BUSCA, gerandoAndamento);
 };
 
 const exportarPdfAndamento = async () => {
-  if (!processoIdSelecionado.value) return;
+  const codProcesso = processoIdSelecionado.value;
+  if (!codProcesso) return;
   await executarComCarregamento(async () => {
-    await downloadRelatorioAndamentoPdf(processoIdSelecionado.value!);
+    await downloadRelatorioAndamentoPdf(codProcesso);
   }, TEXTOS.relatorios.ERRO_EXPORTAR);
 };
 
 const gerarRelatorioMapas = async () => {
-    if (!processoIdSelecionadoMapas.value) return;
+    const codProcesso = processoIdSelecionadoMapas.value;
+    if (!codProcesso) return;
     await executarComCarregamento(async () => {
       await downloadRelatorioMapasPdf(
-        processoIdSelecionadoMapas.value!,
+        codProcesso,
         unidadeIdSelecionadaMapas.value || undefined
       );
     }, TEXTOS.relatorios.ERRO_GERAR, gerandoMapas);


### PR DESCRIPTION
This change addresses a TypeScript error in `RelatoriosView.vue` where a nullable `number | null` was being passed to a function expecting a `number`. The fix uses local variable capture to ensure type narrowing and closure safety. Additionally, the entire frontend was validated for linting and unit test compliance.

---
*PR created automatically by Jules for task [18193686865326088357](https://jules.google.com/task/18193686865326088357) started by @lgalvao*