### PR TITLE
Simplificar coletor de snapshot de QA e adicionar plano de simplificação

### DIFF
--- a/etc/scripts/qa/snapshot-coletar-execucao.mjs
+++ b/etc/scripts/qa/snapshot-coletar-execucao.mjs
@@ -225,6 +225,18 @@ function calcularPercentual(covered, missed) {
     return Number(((covered / total) * 100).toFixed(2));
 }
 
+function calcularPercentualPorTotal(cobertos, total) {
+    if (total <= 0) {
+        return 0;
+    }
+
+    return Number(((cobertos / total) * 100).toFixed(2));
+}
+
+function extrairInteiroCounter(counter, campo) {
+    return Number.parseInt(counter?.$?.[campo] ?? "0", 10);
+}
+
 async function extrairCoberturaJacoco(caminhoXml) {
     const conteudo = await lerArquivoSeExistir(caminhoXml);
     if (!conteudo) {
@@ -241,8 +253,8 @@ async function extrairCoberturaJacoco(caminhoXml) {
             const countersClasse = classe.counter ?? [];
             const line = countersClasse.find((counter) => counter.$.type === "LINE");
             const branch = countersClasse.find((counter) => counter.$.type === "BRANCH");
-            const covered = Number.parseInt(line?.$.covered ?? "0", 10);
-            const missed = Number.parseInt(line?.$.missed ?? "0", 10);
+            const covered = extrairInteiroCounter(line, "covered");
+            const missed = extrairInteiroCounter(line, "missed");
             const percentual = calcularPercentual(covered, missed);
 
             classes.push({
@@ -251,8 +263,8 @@ async function extrairCoberturaJacoco(caminhoXml) {
                 linhasCobertas: covered,
                 linhasPerdidas: missed,
                 branchesPercentual: calcularPercentual(
-                    Number.parseInt(branch?.$.covered ?? "0", 10),
-                    Number.parseInt(branch?.$.missed ?? "0", 10)
+                    extrairInteiroCounter(branch, "covered"),
+                    extrairInteiroCounter(branch, "missed")
                 )
             });
         }
@@ -261,11 +273,11 @@ async function extrairCoberturaJacoco(caminhoXml) {
     const resumo = {};
     for (const counter of counters) {
         resumo[counter.$.type] = {
-            cobertos: Number.parseInt(counter.$.covered, 10),
-            perdidos: Number.parseInt(counter.$.missed, 10),
+            cobertos: extrairInteiroCounter(counter, "covered"),
+            perdidos: extrairInteiroCounter(counter, "missed"),
             percentual: calcularPercentual(
-                Number.parseInt(counter.$.covered, 10),
-                Number.parseInt(counter.$.missed, 10)
+                extrairInteiroCounter(counter, "covered"),
+                extrairInteiroCounter(counter, "missed")
             )
         };
     }
@@ -279,6 +291,43 @@ async function extrairCoberturaJacoco(caminhoXml) {
     };
 }
 
+function extrairContagemCobertura(mapaCobertura = {}) {
+    const total = Object.keys(mapaCobertura).length;
+    const cobertos = Object.values(mapaCobertura).filter((valor) => valor > 0).length;
+    return {total, cobertos};
+}
+
+function extrairContagemBranches(mapaBranches = {}) {
+    const total = Object.values(mapaBranches).reduce((acumulado, valores) => acumulado + valores.length, 0);
+    const cobertos = Object.values(mapaBranches).reduce(
+        (acumulado, valores) => acumulado + valores.filter((valor) => valor > 0).length,
+        0
+    );
+    return {total, cobertos};
+}
+
+function criarTotaisCoberturaFrontend() {
+    return {
+        statements: {cobertos: 0, total: 0},
+        branches: {cobertos: 0, total: 0},
+        functions: {cobertos: 0, total: 0},
+        lines: {cobertos: 0, total: 0}
+    };
+}
+
+function acumularTotaisCobertura(totais, chave, contagem) {
+    totais[chave].total += contagem.total;
+    totais[chave].cobertos += contagem.cobertos;
+}
+
+function criarResumoCobertura(cobertos, total) {
+    return {
+        cobertos,
+        total,
+        percentual: calcularPercentualPorTotal(cobertos, total)
+    };
+}
+
 async function extrairCoberturaFrontend(caminhoJson) {
     const conteudo = await lerArquivoSeExistir(caminhoJson);
     if (!conteudo) {
@@ -287,73 +336,36 @@ async function extrairCoberturaFrontend(caminhoJson) {
 
     const cobertura = JSON.parse(conteudo);
     const arquivos = [];
-    const totais = {
-        statements: {cobertos: 0, total: 0},
-        branches: {cobertos: 0, total: 0},
-        functions: {cobertos: 0, total: 0},
-        lines: {cobertos: 0, total: 0}
-    };
+    const totais = criarTotaisCoberturaFrontend();
 
     for (const [arquivo, dados] of Object.entries(cobertura)) {
-        const statementTotal = Object.keys(dados.s ?? {}).length;
-        const statementCobertos = Object.values(dados.s ?? {}).filter((valor) => valor > 0).length;
-        const functionTotal = Object.keys(dados.f ?? {}).length;
-        const functionCobertos = Object.values(dados.f ?? {}).filter((valor) => valor > 0).length;
-        const branchTotal = Object.values(dados.b ?? {}).reduce((total, valores) => total + valores.length, 0);
-        const branchCobertos = Object.values(dados.b ?? {}).reduce(
-            (total, valores) => total + valores.filter((valor) => valor > 0).length,
-            0
-        );
-        const lineTotal = Object.keys(dados.statementMap ?? {}).length;
-        const lineCobertos = statementCobertos;
+        const statements = extrairContagemCobertura(dados.s ?? {});
+        const functions = extrairContagemCobertura(dados.f ?? {});
+        const branches = extrairContagemBranches(dados.b ?? {});
+        const lines = {
+            total: Object.keys(dados.statementMap ?? {}).length,
+            cobertos: statements.cobertos
+        };
 
-        totais.statements.total += statementTotal;
-        totais.statements.cobertos += statementCobertos;
-        totais.functions.total += functionTotal;
-        totais.functions.cobertos += functionCobertos;
-        totais.branches.total += branchTotal;
-        totais.branches.cobertos += branchCobertos;
-        totais.lines.total += lineTotal;
-        totais.lines.cobertos += lineCobertos;
+        acumularTotaisCobertura(totais, "statements", statements);
+        acumularTotaisCobertura(totais, "functions", functions);
+        acumularTotaisCobertura(totais, "branches", branches);
+        acumularTotaisCobertura(totais, "lines", lines);
 
         arquivos.push({
             arquivo: caminhoRelativo(arquivo),
-            statementsPercentual: statementTotal > 0 ? Number(((statementCobertos / statementTotal) * 100).toFixed(2)) : 0,
-            branchesPercentual: branchTotal > 0 ? Number(((branchCobertos / branchTotal) * 100).toFixed(2)) : 0,
-            functionsPercentual: functionTotal > 0 ? Number(((functionCobertos / functionTotal) * 100).toFixed(2)) : 0,
-            linesPercentual: lineTotal > 0 ? Number(((lineCobertos / lineTotal) * 100).toFixed(2)) : 0
+            statementsPercentual: calcularPercentualPorTotal(statements.cobertos, statements.total),
+            branchesPercentual: calcularPercentualPorTotal(branches.cobertos, branches.total),
+            functionsPercentual: calcularPercentualPorTotal(functions.cobertos, functions.total),
+            linesPercentual: calcularPercentualPorTotal(lines.cobertos, lines.total)
         });
     }
 
     return {
-        statements: {
-            cobertos: totais.statements.cobertos,
-            total: totais.statements.total,
-            percentual: totais.statements.total > 0
-                ? Number(((totais.statements.cobertos / totais.statements.total) * 100).toFixed(2))
-                : 0
-        },
-        branches: {
-            cobertos: totais.branches.cobertos,
-            total: totais.branches.total,
-            percentual: totais.branches.total > 0
-                ? Number(((totais.branches.cobertos / totais.branches.total) * 100).toFixed(2))
-                : 0
-        },
-        functions: {
-            cobertos: totais.functions.cobertos,
-            total: totais.functions.total,
-            percentual: totais.functions.total > 0
-                ? Number(((totais.functions.cobertos / totais.functions.total) * 100).toFixed(2))
-                : 0
-        },
-        lines: {
-            cobertos: totais.lines.cobertos,
-            total: totais.lines.total,
-            percentual: totais.lines.total > 0
-                ? Number(((totais.lines.cobertos / totais.lines.total) * 100).toFixed(2))
-                : 0
-        },
+        statements: criarResumoCobertura(totais.statements.cobertos, totais.statements.total),
+        branches: criarResumoCobertura(totais.branches.cobertos, totais.branches.total),
+        functions: criarResumoCobertura(totais.functions.cobertos, totais.functions.total),
+        lines: criarResumoCobertura(totais.lines.cobertos, totais.lines.total),
         arquivos: arquivos.sort((a, b) => a.linesPercentual - b.linesPercentual).slice(0, 20)
     };
 }

--- a/simplification-plan.md
+++ b/simplification-plan.md
@@ -1,0 +1,126 @@
+# Plano detalhado de simplificação (investigação profunda)
+
+## Objetivo
+Reduzir complexidade acidental no SGC sem alterar regras de negócio, preservando testes verdes e melhorando legibilidade/manutenibilidade.
+
+## Metodologia usada (com medições)
+
+### 1) Mapa de hotspots por tamanho de arquivo
+Comando usado:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+roots=['backend/src/main','frontend/src','etc/scripts']
+files=[]
+for r in roots:
+ p=Path(r)
+ for f in p.rglob('*'):
+  if 'node_modules' in f.parts: continue
+  if f.is_file() and f.suffix in {'.java','.ts','.vue','.js','.mjs'}:
+   try:n=sum(1 for _ in open(f,encoding='utf-8'))
+   except: continue
+   files.append((n,str(f)))
+for n,f in sorted(files, reverse=True)[:15]:
+ print(f"{n:4} {f}")
+PY
+```
+
+Fatos observados:
+- `etc/scripts/qa/snapshot-coletar-execucao.mjs`: **874 linhas** (maior hotspot de scripts de QA).
+- `backend/src/main/java/sgc/e2e/E2eController.java`: **762 linhas**.
+- `backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java`: **736 linhas**.
+- Várias views/specs do frontend também acima de 500 linhas.
+
+**Conclusão:** há concentração de responsabilidades em poucos arquivos extensos.
+
+### 2) Complexidade ciclomática aproximada por função (heurística)
+Comando usado:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+import re
+EXTS={'.java','.js','.mjs','.ts'}
+rows=[]
+for f in Path('.').rglob('*'):
+ if 'node_modules' in f.parts or not f.is_file() or f.suffix not in EXTS: continue
+ if not any(p in f.parts for p in ['backend','frontend','etc']): continue
+ txt=f.read_text(encoding='utf-8',errors='ignore').splitlines()
+ for i,l in enumerate(txt,1):
+  s=l.strip()
+  if re.match(r'^(async\\s+)?function\\s+\\w+\\s*\\(',s) or re.match(r'^(public|private|protected)\\s+[^=;]+\\)\\s*\\{\\s*$',s):
+   depth=0;found=False
+   for j in range(i-1,len(txt)):
+    depth += txt[j].count('{')-txt[j].count('}')
+    if '{' in txt[j]: found=True
+    if found and depth==0:
+     end=j+1;break
+   body='\\n'.join(txt[i-1:end])
+   cc=1+sum(body.count(k) for k in [' if ',' for ',' while ',' case ',' catch ','&&','||','?'])
+   rows.append((cc,end-i+1,str(f),i,end))
+for cc,ln,f,s,e in sorted(rows, reverse=True)[:12]:
+ print(f"CC~{cc:3} {ln:4}L {f}:{s}-{e}")
+PY
+```
+
+Fatos observados:
+- `extrairCoberturaJacoco` em `snapshot-coletar-execucao.mjs`: **CC~33 (53 linhas)**.
+- `extrairCoberturaFrontend` no mesmo arquivo: **CC~25 (78 linhas)**.
+- Outras funções desse arquivo também no topo global de complexidade.
+
+**Conclusão:** parte relevante da complexidade do toolkit de QA estava concentrada em um único script com lógica repetida (cálculo de percentuais, parse de contadores e agregação de totais).
+
+### 3) Verificação de justificativa da complexidade
+- Complexidade **justificada**: múltiplas fontes de dados (JUnit XML, JaCoCo XML, V8 JSON, lint, typecheck, Playwright) e consolidação em snapshot único.
+- Complexidade **não justificada** (acidental): repetição de fórmulas e parse numérico em blocos quase idênticos dentro de `extrairCoberturaFrontend` e `extrairCoberturaJacoco`.
+
+## Plano de simplificação acionável
+
+## Fase 1 — Scripts de QA (em andamento)
+1. **Extrair utilitários puros de cobertura** para remover repetição de cálculo/contagem.
+2. **Reduzir funções longas** (`extrairCoberturaFrontend`, `extrairCoberturaJacoco`) quebrando em helpers pequenos.
+3. **Manter contrato de saída JSON idêntico** (sem breaking change).
+4. **Validar com testes/lint do pacote `etc/scripts`**.
+
+Critério de pronto da Fase 1:
+- redução mensurável de tamanho/CC das funções-alvo;
+- testes relevantes passando.
+
+## Fase 2 — Backend (próxima)
+1. Medir métodos mais complexos em `E2eController` e `SubprocessoTransicaoService`.
+2. Extrair "orquestração" para services auxiliares com limite máximo de 3 parâmetros (DTO command quando necessário).
+3. Proteger comportamento com testes de integração focados em fluxo.
+
+Critério de pronto:
+- menos branches por método crítico;
+- sem regressão em `./gradlew :backend:test`.
+
+## Fase 3 — Frontend (próxima)
+1. Identificar views com responsabilidades mistas (fetch + transformação + render + regra de domínio).
+2. Mover transformação para composables/services tipados.
+3. Padronizar mensagens de erro com `normalizeError` e remover duplicações de parsing.
+
+Critério de pronto:
+- redução de blocos de lógica no `<script setup>` de views grandes;
+- `npm run typecheck`, `npm run lint` e `npm run test:unit` verdes.
+
+## Execução iniciada (Fase 1)
+A Fase 1 foi iniciada imediatamente após este plano com refatoração incremental do coletor de snapshot.
+
+Resultados parciais medidos após a refatoração:
+- `extrairCoberturaFrontend`: de **78 linhas / CC~25** para **41 linhas / CC~11**.
+- `extrairCoberturaJacoco`: de **CC~33** para **CC~21**.
+- Sem mudança funcional esperada no formato de retorno.
+
+## Riscos e mitigação
+- **Risco:** mudança sutil no arredondamento de percentuais.
+  - **Mitigação:** helper único de percentual com teste de regressão via CLI.
+- **Risco:** divergência de totais consolidados por erro de agregação.
+  - **Mitigação:** manter estrutura de saída e executar testes/lint direcionados.
+
+## Evidências de validação executadas nesta rodada
+- `npm --prefix etc/scripts test -- test/sgc.test.js -t snapshot`
+- `npm --prefix etc/scripts run lint`
+
+Observação: a coleta completa do dashboard (`npm run qa:dashboard`) falhou neste ambiente por ausência de relatório JaCoCo esperado (`backend/build/reports/jacoco/test/jacocoTestReport.xml`), portanto foi tratada como evidência de limitação de ambiente da etapa completa, não da refatoração local.


### PR DESCRIPTION
### Motivation
- Reduzir complexidade acidental no coletor de snapshot de QA, concentrada em funções longas e blocos repetidos de parse/aggregação.
- Formalizar um plano de simplificação (investigação baseada em medições) para guiar refatorações futuras sem quebrar contratos.

### Description
- Adiciona `simplification-plan.md` com mapa de hotspots, heurística de complexidade, distinção entre complexidade justificada e acidental, e plano em 3 fases com critérios de pronto.
- Refatora `etc/scripts/qa/snapshot-coletar-execucao.mjs` extraindo helpers puros: `calcularPercentualPorTotal`, `extrairInteiroCounter`, `extrairContagemCobertura`, `extrairContagemBranches`, `criarTotaisCoberturaFrontend`, `acumularTotaisCobertura` e `criarResumoCobertura`.
- Simplifica `extrairCoberturaJacoco` e `extrairCoberturaFrontend` para delegar lógica repetida aos helpers, mantendo o contrato de saída JSON inalterado.
- Commit das alterações no script de QA e inclusão do plano de simplificação no repositório.

### Testing
- Executado `npm --prefix etc/scripts test -- test/sgc.test.js -t snapshot` (Vitest) e a suíte alvo passou com sucesso.
- Executado `npm --prefix etc/scripts run lint` e o lint do pacote `etc/scripts` passou sem erros.
- Execução completa de `npm run qa:dashboard` falhou no ambiente atual por ausência do arquivo JaCoCo esperado (`backend/build/reports/jacoco/test/jacocoTestReport.xml`), sendo essa uma limitação do ambiente e não da refatoração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf38c24c70832bb3615c0f6fcfae56)