### PR TITLE
Extract derived-effects helpers and split transition persistence/notification in SubprocessoTransicaoService

### DIFF
--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java
@@ -675,26 +675,26 @@ public class SubprocessoTransicaoService {
 
     public void alterarDataLimite(Long codSubprocesso, LocalDate novaDataLimite) {
         Subprocesso sp = consultaService.buscarSubprocesso(codSubprocesso);
-        SituacaoSubprocesso s = sp.getSituacao();
-        String situacaoSp = s.name();
+        String situacaoSp = sp.getSituacao().name();
         LocalDate ultimaDataLimite = obterUltimaDataLimite(sp);
 
         if (ultimaDataLimite != null && novaDataLimite.isBefore(ultimaDataLimite)) {
             throw new sgc.comum.erros.ErroValidacao(Mensagens.DATA_LIMITE_MAIOR_OU_IGUAL_ULTIMA_DATA_SUBPROCESSO);
         }
 
-        LocalDateTime dataLimiteEtapa1 = novaDataLimite.atStartOfDay();
-        if (situacaoSp.contains("CADASTRO")) {
-            sp.setDataLimiteEtapa1(dataLimiteEtapa1);
-        } else if (situacaoSp.contains("MAPA")) {
-            sp.setDataLimiteEtapa2(dataLimiteEtapa1);
-        } else {
-            sp.setDataLimiteEtapa1(dataLimiteEtapa1);
-        }
+        atualizarDataLimitePorSituacao(sp, situacaoSp, novaDataLimite.atStartOfDay());
 
         subprocessoRepo.save(sp);
 
         executarEfeitosDerivadosAlteracaoDataLimite(sp, novaDataLimite, situacaoSp);
+    }
+
+    private void atualizarDataLimitePorSituacao(Subprocesso sp, String situacaoSp, LocalDateTime novaDataLimiteInicioDoDia) {
+        if (situacaoSp.contains("MAPA")) {
+            sp.setDataLimiteEtapa2(novaDataLimiteInicioDoDia);
+            return;
+        }
+        sp.setDataLimiteEtapa1(novaDataLimiteInicioDoDia);
     }
 
     private void executarEfeitosDerivadosAlteracaoDataLimite(Subprocesso sp, LocalDate novaDataLimite, String situacaoSp) {
@@ -713,8 +713,12 @@ public class SubprocessoTransicaoService {
     }
 
     private void criarAlertaAlteracaoDataLimite(Subprocesso sp, String situacaoSp, String novaDataStr) {
-        int etapa = situacaoSp.contains("MAPA") ? 2 : 1;
+        int etapa = obterEtapaPorSituacao(situacaoSp);
         alertaService.criarAlertaAlteracaoDataLimite(sp.getProcesso(), sp.getUnidade(), novaDataStr, etapa);
+    }
+
+    private int obterEtapaPorSituacao(String situacaoSp) {
+        return situacaoSp.contains("MAPA") ? 2 : 1;
     }
 
 

--- a/plano-simplificacao-consolidado.md
+++ b/plano-simplificacao-consolidado.md
@@ -395,12 +395,14 @@ Saiu a mistura direta de regra principal com efeitos derivados em dois pontos de
 
 Na continuação desta rodada, o ponto central `registrarTransicao` também foi fatiado em duas etapas explícitas: persistência da transição e disparo de notificação. Com isso, o fluxo principal passou a evidenciar melhor a separação entre mudança de estado e efeito derivado sem alterar assinatura pública nem semântica do método.
 
+Ainda nesta sequência, o fluxo de alteração de data limite recebeu um corte interno adicional para reduzir regra implícita duplicada por `contains("MAPA")`: a escolha do campo de data e o cálculo da etapa de alerta passaram a ter helpers dedicados, deixando a regra principal mais direta.
+
 ### Registro da rodada
 
 * **Data da rodada:** 2026-04-03
 * **Frente principal:** Frente 1 — Quebra coesa de `SubprocessoTransicaoService`
 * **Arquivo(s) alvo:** `backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java`, `plano-simplificacao-consolidado.md`
-* **Corte aplicado:** extração de helpers privados para efeitos derivados (alertas/e-mail) mantendo o fluxo de transição explícito nos métodos de negócio.
+* **Corte aplicado:** extração de helpers privados para efeitos derivados (alertas/e-mail), fatiamento de `registrarTransicao` e isolamento da regra de etapa/data na alteração de data limite.
 * **Risco principal observado:** possível alteração acidental na ordem de disparo dos efeitos derivados após persistência.
-* **Validação executada:** compilação de testes do backend e suíte focada de testes de `SubprocessoTransicaoService`, reexecutadas após fatiar `registrarTransicao`.
-* **Pendência aberta para próxima rodada:** avaliar consolidação adicional dos efeitos derivados de transição em ponto único sem ampliar superfície pública, especialmente alertas de reabertura.
+* **Validação executada:** compilação de testes do backend e suíte focada de testes de `SubprocessoTransicaoService`, reexecutadas após os cortes incrementais no fluxo de transição e data limite.
+* **Pendência aberta para próxima rodada:** avaliar consolidação adicional dos efeitos derivados de transição em ponto único sem ampliar superfície pública, especialmente alertas de reabertura e trilha de e-mail.


### PR DESCRIPTION
### Motivation

- Reduce method responsibility in `SubprocessoTransicaoService` by separating core state transitions from side effects (notifications, emails, alerts).
- Make flows for homologation and deadline changes clearer and easier to refactor in subsequent rounds.

### Description

- Split `registrarTransicao` into two private steps by introducing `persistirTransicao` and `notificarTransicao`, keeping the public API unchanged and preserving behavior.
- Extracted derived-effect helpers `executarEfeitosDerivadosHomologacaoCadastro` and `executarEfeitosDerivadosAlteracaoDataLimite`, and moved email and alert creation into `enviarEmailAlteracaoDataLimite` and `criarAlertaAlteracaoDataLimite` respectively.
- Kept the main orchestration and validations in place while delegating alert/email/notification responsibilities to private methods to improve readability.
- Updated `plano-simplificacao-consolidado.md` to record the chosen refactor cut and the results of this round.

### Testing

- Ran the backend test suite via `./gradlew test` and a focused suite for `SubprocessoTransicaoService`; all automated tests passed.
- Verified compilation and execution of unit tests after refactor with no regressions detected in the covered flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d00e8553e0832bb65d07b45a04b02f)