### PR TITLE
Add integration checks for business-rules document, JUnit suite and test deps

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -77,6 +77,8 @@ dependencies {
     implementation("jakarta.servlet:jakarta.servlet-api")
     implementation("tools.jackson.core:jackson-core:3.1.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.junit.platform:junit-platform-suite-api")
+    testRuntimeOnly("org.junit.platform:junit-platform-suite-engine")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")

--- a/backend/src/test/java/sgc/integracao/RegrasNegocioDocumentoIntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/RegrasNegocioDocumentoIntegrationTest.java
@@ -1,0 +1,163 @@
+package sgc.integracao;
+
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.*;
+import java.util.regex.*;
+import java.util.stream.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Tag("integration")
+@DisplayName("Integração do documento de regras de negócio")
+class RegrasNegocioDocumentoIntegrationTest {
+    private static final Pattern PADRAO_REGRA = Pattern.compile("\\*\\*(RN-\\d{2}\\.\\d{2})\\*\\*\\s*—\\s*(.+?)\\n> Fonte:\\s*(.+)", Pattern.DOTALL);
+    private static final Pattern PADRAO_ARQUIVO_FONTE = Pattern.compile("`([^`]+\\.md)`");
+    private static final Pattern PADRAO_CDU = Pattern.compile("cdu-(\\d{2})\\.md");
+
+    private static Path raizRepositorio;
+    private static String conteudoRegrasNegocio;
+
+    @BeforeAll
+    static void carregarDocumento() throws IOException {
+        raizRepositorio = localizarRaizRepositorio();
+        Path arquivoRegras = raizRepositorio.resolve("etc/reqs/regras-negocio.md");
+        assertThat(arquivoRegras)
+                .as("Arquivo de regras de negócio deve existir")
+                .exists();
+        conteudoRegrasNegocio = Files.readString(arquivoRegras);
+    }
+
+    @Test
+    @DisplayName("Deve ter regras RN únicas e com texto não vazio")
+    void deveTerRegrasUnicasComTextoPreenchido() {
+        Matcher matcher = PADRAO_REGRA.matcher(conteudoRegrasNegocio);
+        Set<String> codigos = new LinkedHashSet<>();
+        List<String> duplicados = new ArrayList<>();
+
+        while (matcher.find()) {
+            String codigo = matcher.group(1).trim();
+            String descricao = matcher.group(2).trim();
+            String fonte = matcher.group(3).trim();
+
+            if (!codigos.add(codigo)) {
+                duplicados.add(codigo);
+            }
+
+            assertThat(descricao)
+                    .as("Descrição da regra %s deve estar preenchida", codigo)
+                    .isNotBlank();
+            assertThat(fonte)
+                    .as("Fonte da regra %s deve estar preenchida", codigo)
+                    .isNotBlank();
+        }
+
+        assertThat(codigos)
+                .as("Documento deve conter regras RN")
+                .isNotEmpty();
+        assertThat(duplicados)
+                .as("Documento não deve repetir códigos RN")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("Cada regra deve referenciar arquivos de requisito existentes")
+    void deveReferenciarArquivosDeRequisitosExistentes() {
+        Matcher regrasMatcher = PADRAO_REGRA.matcher(conteudoRegrasNegocio);
+        int regrasValidadas = 0;
+
+        while (regrasMatcher.find()) {
+            String codigo = regrasMatcher.group(1).trim();
+            String blocoFonte = regrasMatcher.group(3);
+            Matcher fontesMatcher = PADRAO_ARQUIVO_FONTE.matcher(blocoFonte);
+            List<String> fontes = new ArrayList<>();
+            while (fontesMatcher.find()) {
+                fontes.add(fontesMatcher.group(1));
+            }
+
+            assertThat(fontes)
+                    .as("Regra %s deve apontar ao menos um arquivo de fonte", codigo)
+                    .isNotEmpty();
+
+            for (String fonte : fontes) {
+                Path caminhoFonte = resolverFonteMarkdown(fonte);
+                assertThat(caminhoFonte)
+                        .as("Regra %s deve referenciar arquivo existente: %s", codigo, fonte)
+                        .exists();
+            }
+
+            regrasValidadas++;
+        }
+
+        assertThat(regrasValidadas)
+                .as("Quantidade de regras validadas")
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("Toda referência de CDU em regra deve ter teste de integração dedicado")
+    void deveTerTesteIntegracaoParaCadaCduReferenciadoNasRegras() throws IOException {
+        Set<String> cdusReferenciados = extrairCdusReferenciadosNoDocumento();
+        Set<String> classesIntegracao = listarClassesIntegracaoCdu();
+
+        List<String> ausentes = cdusReferenciados.stream()
+                .filter(codigo -> !classesIntegracao.contains(codigo))
+                .sorted()
+                .map(codigo -> "CDU" + codigo + "IntegrationTest")
+                .toList();
+
+        assertThat(cdusReferenciados)
+                .as("Regras de negócio devem referenciar CDUs")
+                .isNotEmpty();
+        assertThat(ausentes)
+                .as("Cada CDU citado nas regras precisa de teste de integração dedicado")
+                .isEmpty();
+    }
+
+    private static Set<String> extrairCdusReferenciadosNoDocumento() {
+        Matcher matcher = PADRAO_CDU.matcher(conteudoRegrasNegocio);
+        Set<String> codigos = new TreeSet<>();
+        while (matcher.find()) {
+            codigos.add(matcher.group(1));
+        }
+        return codigos;
+    }
+
+    private static Set<String> listarClassesIntegracaoCdu() throws IOException {
+        Path pastaIntegracao = raizRepositorio.resolve("backend/src/test/java/sgc/integracao");
+        try (Stream<Path> caminhos = Files.list(pastaIntegracao)) {
+            return caminhos
+                    .map(Path::getFileName)
+                    .map(Path::toString)
+                    .map(nome -> PADRAO_NOME_CLASSE_INTEGRACAO.matcher(nome))
+                    .filter(Matcher::matches)
+                    .map(matcher -> matcher.group(1))
+                    .collect(Collectors.toCollection(TreeSet::new));
+        }
+    }
+
+    private static final Pattern PADRAO_NOME_CLASSE_INTEGRACAO = Pattern.compile("CDU(\\d{2})IntegrationTest\\.java");
+
+    private static Path localizarRaizRepositorio() {
+        Path atual = Paths.get("").toAbsolutePath().normalize();
+        while (atual != null) {
+            if (Files.exists(atual.resolve("etc/reqs/regras-negocio.md"))) {
+                return atual;
+            }
+            atual = atual.getParent();
+        }
+        throw new IllegalStateException("Não foi possível localizar a raiz do repositório do SGC.");
+    }
+
+    private static Path resolverFonteMarkdown(String fonte) {
+        if (fonte.startsWith("etc/")) {
+            return raizRepositorio.resolve(fonte);
+        }
+        if (fonte.startsWith("views/") || fonte.startsWith("design/") || fonte.startsWith("cdu-") || fonte.startsWith("_")) {
+            return raizRepositorio.resolve("etc/reqs").resolve(fonte);
+        }
+        return raizRepositorio.resolve(fonte);
+    }
+}

--- a/backend/src/test/java/sgc/integracao/RegrasNegocioExtraidasSuiteTest.java
+++ b/backend/src/test/java/sgc/integracao/RegrasNegocioExtraidasSuiteTest.java
@@ -1,0 +1,50 @@
+package sgc.integracao;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@Tag("integration")
+@DisplayName("Suíte paralela de regras de negócio extraídas")
+@SelectClasses({
+        CDU01IntegrationTest.class,
+        CDU02IntegrationTest.class,
+        CDU03IntegrationTest.class,
+        CDU04IntegrationTest.class,
+        CDU05IntegrationTest.class,
+        CDU06IntegrationTest.class,
+        CDU07IntegrationTest.class,
+        CDU08IntegrationTest.class,
+        CDU09IntegrationTest.class,
+        CDU10IntegrationTest.class,
+        CDU11IntegrationTest.class,
+        CDU12IntegrationTest.class,
+        CDU13IntegrationTest.class,
+        CDU14IntegrationTest.class,
+        CDU15IntegrationTest.class,
+        CDU16IntegrationTest.class,
+        CDU17IntegrationTest.class,
+        CDU18IntegrationTest.class,
+        CDU19IntegrationTest.class,
+        CDU20IntegrationTest.class,
+        CDU21IntegrationTest.class,
+        CDU22IntegrationTest.class,
+        CDU23IntegrationTest.class,
+        CDU24IntegrationTest.class,
+        CDU25IntegrationTest.class,
+        CDU26IntegrationTest.class,
+        CDU27IntegrationTest.class,
+        CDU28IntegrationTest.class,
+        CDU29IntegrationTest.class,
+        CDU30IntegrationTest.class,
+        CDU31IntegrationTest.class,
+        CDU32IntegrationTest.class,
+        CDU33IntegrationTest.class,
+        CDU34IntegrationTest.class,
+        CDU35IntegrationTest.class,
+        CDU36IntegrationTest.class
+})
+class RegrasNegocioExtraidasSuiteTest {
+}

--- a/etc/reqs/regras-negocio.md
+++ b/etc/reqs/regras-negocio.md
@@ -238,7 +238,7 @@ Este documento consolida todas as regras de negócio do Sistema de Gestão de Co
 > Fonte: `cdu-08.md` (passo 14)
 
 **RN-06.05** — O CHEFE pode **importar atividades** de processos de mapeamento ou revisão finalizados, de qualquer unidade. Devem ser exibidos **todos** os processos finalizados, de todas as unidades, independentemente da hierarquia.
-> Fonte: `cdu-08.md` (passo 13.1), memória armazenada (CDU-08)
+> Fonte: `cdu-08.md` (passo 13.1)
 
 **RN-06.06** — Na importação, são copiadas apenas as atividades cujas descrições **não coincidam** com nenhuma atividade já cadastrada na unidade. Se houver coincidência, o sistema informa sobre as atividades não importadas, mas prossegue sem erro.
 > Fonte: `cdu-08.md` (passos 13.7.1–13.7.2)
@@ -254,6 +254,9 @@ Este documento consolida todas as regras de negócio do Sistema de Gestão de Co
 
 **RN-06.10** — O cadastro de atividades e conhecimentos pode ser **visualizado** (somente leitura) por qualquer perfil, desde que o cadastro já tenha sido disponibilizado pelo CHEFE.
 > Fonte: `cdu-11.md`
+
+**RN-06.11** — Ao abrir a tela de cadastro de atividades e conhecimentos, se já existirem atividades no mapa vinculado ao subprocesso da unidade, a tela deve ser exibida previamente preenchida com essas informações.
+> Fonte: `cdu-08.md` (passo 4)
 
 ---
 
@@ -366,6 +369,9 @@ Este documento consolida todas as regras de negócio do Sistema de Gestão de Co
 
 **RN-10.06** — O botão **Criar processo** é exibido somente para usuário logado com perfil ADMIN.
 > Fonte: `cdu-02.md` (passo 2.3)
+
+**RN-10.07** — Na tela `Detalhes do processo`, os botões de operações em bloco de cadastro e de mapa só devem ser exibidos quando existirem unidades subordinadas com subprocessos elegíveis e localizados na unidade do usuário.
+> Fonte: `cdu-06.md` (passo 2.2.2)
 
 ---
 


### PR DESCRIPTION
### Motivation
- Validate consistency and completeness of `etc/reqs/regras-negocio.md` by ensuring RN codes are unique and descriptions and sources are present.
- Ensure every referenced source file exists and that each referenced CDU has a dedicated integration test.
- Provide a runnable JUnit Platform suite for extracted CDU integration tests and add required JUnit Platform dependencies.

### Description
- Added `RegrasNegocioDocumentoIntegrationTest` which parses `regras-negocio.md` to assert unique RN codes, non-empty descriptions/sources, referenced markdown files exist, and that each referenced CDU has a corresponding integration test class.
- Added `RegrasNegocioExtraidasSuiteTest` JUnit Platform suite that selects `CDU01IntegrationTest` through `CDU36IntegrationTest` for parallel execution.
- Updated `backend/build.gradle.kts` to include `org.junit.platform:junit-platform-suite-api` and `org.junit.platform:junit-platform-suite-engine` test/runtime dependencies.
- Updated `etc/reqs/regras-negocio.md` with small rule edits and additions (`RN-06.11`, `RN-10.07`) and a minor source-note cleanup.

### Testing
- Executed the backend test task with `./gradlew :backend:test` which runs unit and integration tests; the test run completed successfully.
- Verified the new integration test and suite compile under the updated Gradle dependencies and were included in the test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0ff9bdb3c832ba22ed49546bfb7d3)