### PR TITLE
Frontend quality cleanup and refactor

### DIFF
--- a/frontend/src/__tests__/views/PainelView.spec.ts
+++ b/frontend/src/__tests__/views/PainelView.spec.ts
@@ -123,8 +123,8 @@ describe("PainelView.vue", () => {
 
         await wrapper.vm.$nextTick();
 
-        expect(painelService.listarProcessos).toHaveBeenCalledWith(1, 0, 10, undefined, undefined);
-        expect(painelService.listarAlertas).toHaveBeenCalledWith(1, 0, 10, "dataHora", "desc");
+        expect(painelService.listarProcessos).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10});
+        expect(painelService.listarAlertas).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10, sort: "dataHora", order: "desc"});
     });
 
     it("não deve carregar dados se perfil não estiver selecionado", async () => {
@@ -160,14 +160,14 @@ describe("PainelView.vue", () => {
 
         await wrapper.findComponent({name: 'TabelaProcessos'}).vm.$emit('ordenar', 'dataCriacao');
 
-        expect(painelService.listarProcessos).toHaveBeenLastCalledWith(
-            1, 0, 10, "dataCriacao", "asc"
-        );
+        expect(painelService.listarProcessos).toHaveBeenLastCalledWith({
+            codUnidade: 1, page: 0, size: 10, sort: "dataCriacao", order: "asc"
+        });
 
         await wrapper.findComponent({name: 'TabelaProcessos'}).vm.$emit('ordenar', 'dataCriacao');
-        expect(painelService.listarProcessos).toHaveBeenLastCalledWith(
-            1, 0, 10, "dataCriacao", "desc"
-        );
+        expect(painelService.listarProcessos).toHaveBeenLastCalledWith({
+            codUnidade: 1, page: 0, size: 10, sort: "dataCriacao", order: "desc"
+        });
     });
 
     it("deve navegar ao selecionar processo", async () => {

--- a/frontend/src/__tests__/views/PainelViewCoverage.spec.ts
+++ b/frontend/src/__tests__/views/PainelViewCoverage.spec.ts
@@ -116,14 +116,14 @@ describe('PainelView Coverage', () => {
 
         await (wrapper.vm as any).ordenarPor('descricao');
 
-        expect(painelService.listarProcessos).toHaveBeenLastCalledWith(
-            1, 0, 10, 'descricao', 'desc'
-        );
+        expect(painelService.listarProcessos).toHaveBeenLastCalledWith({
+            codUnidade: 1, page: 0, size: 10, sort: 'descricao', order: 'desc'
+        });
 
         await (wrapper.vm as any).ordenarPor('tipo');
-        expect(painelService.listarProcessos).toHaveBeenLastCalledWith(
-            1, 0, 10, 'tipo', 'asc'
-        );
+        expect(painelService.listarProcessos).toHaveBeenLastCalledWith({
+            codUnidade: 1, page: 0, size: 10, sort: 'tipo', order: 'asc'
+        });
     });
 
     it('redirects to CadProcesso on cta-vazio event', async () => {

--- a/frontend/src/composables/useNotification.ts
+++ b/frontend/src/composables/useNotification.ts
@@ -25,10 +25,13 @@ export function useNotification() {
     function notifyStructured(
         summary: string,
         details: string[],
-        variant: VarianteAlerta = 'danger',
-        stackTrace?: string,
-        dismissible = true,
+        options: {
+            variant?: VarianteAlerta;
+            stackTrace?: string;
+            dismissible?: boolean;
+        } = {}
     ) {
+        const {variant = 'danger', stackTrace, dismissible = true} = options;
         notificacao.value = {notification: {summary, details}, variant, stackTrace, dismissible};
     }
 

--- a/frontend/src/services/__tests__/painelService.spec.ts
+++ b/frontend/src/services/__tests__/painelService.spec.ts
@@ -27,7 +27,7 @@ describe("painelService", () => {
             };
             mockApi.get.mockResolvedValueOnce({data: responseData});
 
-            const result = await service.listarProcessos(1);
+            const result = await service.listarProcessos({codUnidade: 1});
 
             expect(mockApi.get).toHaveBeenCalledWith("/painel/processos", {
                 params: {unidade: 1, page: 0, size: 20},
@@ -37,7 +37,7 @@ describe("painelService", () => {
 
         it("deve lidar com paginação", async () => {
             mockApi.get.mockResolvedValueOnce({data: {content: []}});
-            await service.listarProcessos(undefined, 2, 10);
+            await service.listarProcessos({page: 2, size: 10});
             expect(mockApi.get).toHaveBeenCalledWith("/painel/processos", {
                 params: {page: 2, size: 10},
             });
@@ -45,13 +45,13 @@ describe("painelService", () => {
 
         it("deve lidar com ordenação", async () => {
             mockApi.get.mockResolvedValueOnce({data: {content: []}});
-            await service.listarProcessos(undefined, 0, 10, "descricao", "desc");
+            await service.listarProcessos({page: 0, size: 10, sort: "descricao", order: "desc"});
             expect(mockApi.get).toHaveBeenCalledWith("/painel/processos", {
                 params: {page: 0, size: 10, sort: "descricao,desc"},
             });
         });
 
-        testErrorHandling(() => service.listarProcessos(1));
+        testErrorHandling(() => service.listarProcessos({codUnidade: 1}));
     });
 
     describe("listarAlertas", () => {
@@ -69,7 +69,7 @@ describe("painelService", () => {
             };
             mockApi.get.mockResolvedValueOnce({data: responseData});
 
-            const result = await service.listarAlertas(1);
+            const result = await service.listarAlertas({codUnidade: 1});
 
             expect(mockApi.get).toHaveBeenCalledWith("/painel/alertas", {
                 params: {unidade: 1, page: 0, size: 20},
@@ -79,12 +79,12 @@ describe("painelService", () => {
 
         it("deve lidar com ordenação", async () => {
             mockApi.get.mockResolvedValueOnce({data: {content: []}});
-            await service.listarAlertas(1, 0, 10, "dataHora", "asc");
+            await service.listarAlertas({codUnidade: 1, page: 0, size: 10, sort: "dataHora", order: "asc"});
             expect(mockApi.get).toHaveBeenCalledWith("/painel/alertas", {
                 params: {unidade: 1, page: 0, size: 10, sort: "dataHora,asc"},
             });
         });
 
-        testErrorHandling(() => service.listarAlertas(1));
+        testErrorHandling(() => service.listarAlertas({codUnidade: 1}));
     });
 });

--- a/frontend/src/services/painelService.ts
+++ b/frontend/src/services/painelService.ts
@@ -12,48 +12,50 @@ export interface Page<T> {
     empty: boolean;
 }
 
+export interface ListarParams<T = string> {
+    codUnidade?: number;
+    page?: number;
+    size?: number;
+    sort?: T;
+    order?: "asc" | "desc";
+}
+
 export async function listarProcessos(
-    codUnidade?: number,
-    page: number = 0,
-    size: number = 20,
-    sort?: keyof ProcessoResumo,
-    order?: "asc" | "desc",
+    params: ListarParams<keyof ProcessoResumo> = {}
 ): Promise<Page<ProcessoResumo>> {
-    const params: any = {
+    const { codUnidade, page = 0, size = 20, sort, order } = params;
+    const queryParams: any = {
         page,
         size,
     };
     if (codUnidade !== undefined && codUnidade !== null) {
-        params.unidade = codUnidade;
+        queryParams.unidade = codUnidade;
     }
     if (sort) {
-        params.sort = `${sort},${order}`;
+        queryParams.sort = `${sort},${order}`;
     }
     const response = await apiClient.get<Page<ProcessoResumo>>("/painel/processos", {
-        params,
+        params: queryParams,
     });
     return response.data;
 }
 
 export async function listarAlertas(
-    codUnidade?: number,
-    page: number = 0,
-    size: number = 20,
-    sort?: "dataHora" | "processo",
-    order?: "asc" | "desc",
+    params: ListarParams<"dataHora" | "processo"> = {}
 ): Promise<Page<Alerta>> {
-    const params: any = {
+    const { codUnidade, page = 0, size = 20, sort, order } = params;
+    const queryParams: any = {
         page,
         size,
     };
     if (codUnidade !== undefined && codUnidade !== null) {
-        params.unidade = codUnidade;
+        queryParams.unidade = codUnidade;
     }
     if (sort) {
-        params.sort = `${sort},${order}`;
+        queryParams.sort = `${sort},${order}`;
     }
     const response = await apiClient.get<Page<Alerta>>("/painel/alertas", {
-        params,
+        params: queryParams,
     });
     return response.data;
 }

--- a/frontend/src/utils/__tests__/treeUtils.spec.ts
+++ b/frontend/src/utils/__tests__/treeUtils.spec.ts
@@ -15,12 +15,12 @@ describe('treeUtils', () => {
 
         it('deve achatar uma arvore com diferentes chaves de filhos', () => {
             const arvore = [
-                {id: 1, filhos: [{id: 2}]},
-                {id: 3}
+                {codigo: 1, filhos: [{codigo: 2}]},
+                {codigo: 3}
             ];
             const resultado = flattenTree(arvore, 'filhos');
             expect(resultado).toHaveLength(3);
-            expect(resultado.map(i => i.id)).toEqual([1, 2, 3]);
+            expect(resultado.map(i => i.codigo)).toEqual([1, 2, 3]);
         });
 
         it('deve lidar com array vazio', () => {
@@ -49,17 +49,17 @@ describe('treeUtils', () => {
         it('deve lidar recursivamente com multiplos níveis', () => {
             const arvore = [
                 {
-                    id: 1,
+                    codigo: 1,
                     children: [
                         {
-                            id: 2,
-                            children: [{id: 3}]
+                            codigo: 2,
+                            children: [{codigo: 3}]
                         }
                     ]
                 }
             ];
             const resultado = flattenTree(arvore, 'children');
-            expect(resultado.map(i => i.id)).toEqual([1, 2, 3]);
+            expect(resultado.map(i => i.codigo)).toEqual([1, 2, 3]);
         });
     });
 });

--- a/frontend/src/utils/treeUtils.ts
+++ b/frontend/src/utils/treeUtils.ts
@@ -17,11 +17,11 @@
  * @example
  * // Com filhos (processos)
  * const arvore = [
- *   { id: 1, filhos: [{ id: 2 }] },
- *   { id: 3 }
+ *   { codigo: 1, filhos: [{ codigo: 2 }] },
+ *   { codigo: 3 }
  * ];
  * const plano = flattenTree(arvore, 'filhos');
- * // Resultado: [{ id: 1, ... }, { id: 2 }, { id: 3 }]
+ * // Resultado: [{ codigo: 1, ... }, { codigo: 2 }, { codigo: 3 }]
  */
 export function flattenTree<T extends Record<string, any>>(
     items: T[],

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -398,15 +398,15 @@ function sincronizarEstadoInicialContexto(data: any) {
 
 async function carregarContextoInicial() {
   const codProcessoRef = Number(props.codProcesso);
-  const id = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(codProcessoRef, props.sigla);
+  const codigo = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(codProcessoRef, props.sigla);
 
-  if (!id) {
+  if (!codigo) {
     logger.error("ERRO: Subprocesso não encontrado!");
     return;
   }
 
-  codSubprocesso.value = id;
-  const data = await subprocessosStore.buscarContextoEdicao(id);
+  codSubprocesso.value = codigo;
+  const data = await subprocessosStore.buscarContextoEdicao(codigo);
   if (!data) {
     return;
   }

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -206,10 +206,10 @@ async function carregarMapaInicial(codigo: number) {
 }
 
 onMounted(async () => {
-  const id = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(codProcesso.value, siglaUnidade.value);
-  if (id) {
-    codSubprocesso.value = id;
-    await carregarMapaInicial(id);
+  const codigo = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(codProcesso.value, siglaUnidade.value);
+  if (codigo) {
+    codSubprocesso.value = codigo;
+    await carregarMapaInicial(codigo);
   }
 });
 

--- a/frontend/src/views/PainelView.vue
+++ b/frontend/src/views/PainelView.vue
@@ -89,31 +89,17 @@ const criterio = ref<keyof ProcessoResumo>("descricao");
 const asc = ref(true);
 
 async function buscarAlertas(
-    unidade: number,
-    page: number,
-    size: number,
-    sort?: "dataHora" | "processo",
-    order?: "asc" | "desc",
+    params: painelService.ListarParams<"dataHora" | "processo">
 ) {
-  const response = await painelService.listarAlertas(unidade, page, size, sort, order);
+  const response = await painelService.listarAlertas(params);
   alertas.value = response.content;
   alertasPage.value = response;
 }
 
 async function buscarProcessosPainel(
-    unidade: number,
-    page: number,
-    size: number,
-    sort?: keyof ProcessoResumo,
-    order?: "asc" | "desc",
+    params: painelService.ListarParams<keyof ProcessoResumo>
 ) {
-  const response = await painelService.listarProcessos(
-      unidade,
-      page,
-      size,
-      sort,
-      order,
-  );
+  const response = await painelService.listarProcessos(params);
   processosPainel.value = response?.content ?? [];
 }
 
@@ -124,18 +110,18 @@ async function carregarDados() {
   }
 
   await Promise.all([
-    buscarProcessosPainel(
-      unidadeCodigo,
-      0,
-      10,
-    ),
-    buscarAlertas(
-      unidadeCodigo,
-      0,
-      10,
-      "dataHora",
-      "desc"
-    ),
+    buscarProcessosPainel({
+      codUnidade: unidadeCodigo,
+      page: 0,
+      size: 10,
+    }),
+    buscarAlertas({
+      codUnidade: unidadeCodigo,
+      page: 0,
+      size: 10,
+      sort: "dataHora",
+      order: "desc"
+    }),
   ]);
 }
 
@@ -178,13 +164,13 @@ function ordenarPor(campo: keyof ProcessoResumo) {
     return;
   }
 
-  buscarProcessosPainel(
-      unidadeCodigo,
-      0,
-      10,
-      criterio.value,
-      asc.value ? "asc" : "desc",
-  );
+  buscarProcessosPainel({
+      codUnidade: unidadeCodigo,
+      page: 0,
+      size: 10,
+      sort: criterio.value,
+      order: asc.value ? "asc" : "desc",
+  });
 }
 
 function obterCodigoUnidadeSelecionada() {

--- a/frontend/src/views/ProcessoCadastroView.vue
+++ b/frontend/src/views/ProcessoCadastroView.vue
@@ -327,8 +327,10 @@ function handleApiErrors(error: any, title: string, defaultMsg: string) {
       notifyStructured(
           erroNormalizado.message || defaultMsg,
           genericErrors as string[],
-          'danger',
-          erroNormalizado.stackTrace || undefined,
+          {
+            variant: 'danger',
+            stackTrace: erroNormalizado.stackTrace || undefined,
+          }
       );
       window.scrollTo(0, 0);
     } else if (hasFieldErrors) {

--- a/frontend/src/views/RelatoriosView.vue
+++ b/frontend/src/views/RelatoriosView.vue
@@ -180,7 +180,11 @@ async function carregarProcessosDisponiveis() {
     return;
   }
 
-  const response = await painelService.listarProcessos(unidadeCodigo, 0, 100);
+  const response = await painelService.listarProcessos({
+    codUnidade: unidadeCodigo,
+    page: 0,
+    size: 100
+  });
   processosDisponiveis.value = response?.content ?? [];
 }
 

--- a/frontend/src/views/SubprocessoView.vue
+++ b/frontend/src/views/SubprocessoView.vue
@@ -343,19 +343,19 @@ onMounted(async () => {
   exibirToastPendente();
   subprocessosStore.subprocessoDetalhe = null;
   try {
-    const id = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(
+    const codigo = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(
         props.codProcesso,
         props.siglaUnidade,
     );
 
-    if (id) {
+    if (codigo) {
       erroNaoEncontrado.value = false;
-      codSubprocesso.value = id;
-      const data = await subprocessosStore.buscarContextoEdicao(id);
+      codSubprocesso.value = codigo;
+      const data = await subprocessosStore.buscarContextoEdicao(codigo);
       if (data?.mapa) {
         mapaStore.mapaCompleto.value = data.mapa as any;
       } else {
-        await mapaStore.buscarMapaCompleto(id);
+        await mapaStore.buscarMapaCompleto(codigo);
       }
     } else {
       erroNaoEncontrado.value = true;

--- a/frontend/src/views/__tests__/CadProcesso.spec.ts
+++ b/frontend/src/views/__tests__/CadProcesso.spec.ts
@@ -564,7 +564,7 @@ describe('ProcessoCadastroView.vue', () => {
 
     it('shows alert with multiple errors', async () => {
         const {wrapper} = createWrapper();
-        (wrapper.vm).notifyStructured('Corpo', ['Erro 1', 'Erro 2'], 'danger');
+        (wrapper.vm).notifyStructured('Corpo', ['Erro 1', 'Erro 2'], {variant: 'danger'});
         await nextTick();
 
         expect(wrapper.vm.notificacao).not.toBeNull();

--- a/frontend/src/views/__tests__/PainelView.spec.ts
+++ b/frontend/src/views/__tests__/PainelView.spec.ts
@@ -90,8 +90,8 @@ describe('PainelView', () => {
     const wrapper = mount(PainelView, options);
     await wrapper.vm.$nextTick();
 
-    expect(painelService.listarProcessos).toHaveBeenCalledWith(1, 0, 10, undefined, undefined);
-    expect(painelService.listarAlertas).toHaveBeenCalledWith(1, 0, 10, 'dataHora', 'desc');
+    expect(painelService.listarProcessos).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10});
+    expect(painelService.listarAlertas).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10, sort: 'dataHora', order: 'desc'});
     expect(mockToastCreate).toHaveBeenCalledWith(expect.objectContaining({ props: expect.objectContaining({ body: 'Sucesso' }) }));
   });
 
@@ -110,13 +110,13 @@ describe('PainelView', () => {
     // Inverter direção no mesmo critério (default é "descricao" e asc=true)
     vm.ordenarPor('descricao');
     expect(vm.asc).toBe(false);
-    expect(painelService.listarProcessos).toHaveBeenCalledWith(1, 0, 10, 'descricao', 'desc');
+    expect(painelService.listarProcessos).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10, sort: 'descricao', order: 'desc'});
 
     // Mudar critério
     vm.ordenarPor('dataCriacao');
     expect(vm.criterio).toBe('dataCriacao');
     expect(vm.asc).toBe(true);
-    expect(painelService.listarProcessos).toHaveBeenCalledWith(1, 0, 10, 'dataCriacao', 'asc');
+    expect(painelService.listarProcessos).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10, sort: 'dataCriacao', order: 'asc'});
   });
 
   it('deve abrir detalhes do processo se linkDestino existir', async () => {

--- a/frontend/src/views/__tests__/RelatoriosView.spec.ts
+++ b/frontend/src/views/__tests__/RelatoriosView.spec.ts
@@ -195,6 +195,6 @@ describe('Relatorios.vue', () => {
             }
         }, stubs));
         await flushPromises();
-        expect(painelService.listarProcessos).toHaveBeenCalledWith(5, 0, 100);
+        expect(painelService.listarProcessos).toHaveBeenCalledWith({codUnidade: 5, page: 0, size: 100});
     });
 });


### PR DESCRIPTION
This PR addresses several code quality and naming convention issues in the frontend. It renames 'id' to 'codigo' for entity references in several key views and utilities. It also refactors core service methods and composables that had more than 3 parameters to use an options object, as per the project's coding standards. All unit tests and type checks have been updated and verified.

---
*PR created automatically by Jules for task [14711081169927341001](https://jules.google.com/task/14711081169927341001) started by @lgalvao*