### PR TITLE
Improve Frontend Type Safety and Quality Compliance

### DIFF
--- a/etc/qualidade/codigo-cheiros/latest/ultimo-resumo.md
+++ b/etc/qualidade/codigo-cheiros/latest/ultimo-resumo.md
@@ -1,18 +1,18 @@
 # Auditoria de cheiros de codigo
 
-Gerado em: 2026-04-05T15:52:10.408Z
-Pontuacao: 1382 (critico)
+Gerado em: 2026-04-06T01:26:14.857Z
+Pontuacao: 1254 (critico)
 
 ## Contagens
 
 | Sinal | Total | Delta | Peso |
 |---|---:|---:|---:|
-| Backend DTOs com @Nullable | 89 | +7 | 5 |
-| Backend checks explicitos de null | 191 | -4 | 2 |
-| Backend Objects.isNull/nonNull | 5 | 0 | 2 |
-| Frontend producao com any explicito | 38 | 0 | 4 |
-| Frontend testes com any explicito | 319 | 0 | 1 |
-| Frontend catch tipado como any | 4 | 0 | 3 |
+| Backend DTOs com @Nullable | 89 | 0 | 5 |
+| Backend checks explicitos de null | 192 | 0 | 2 |
+| Backend Objects.isNull/nonNull | 4 | 0 | 2 |
+| Frontend producao com any explicito | 10 | -9 | 4 |
+| Frontend testes com any explicito | 315 | -3 | 1 |
+| Frontend catch tipado como any | 0 | 0 | 3 |
 | Frontend checks explicitos de null | 19 | 0 | 2 |
 | Frontend fallbacks defensivos com || | 24 | 0 | 1 |
 
@@ -22,22 +22,22 @@ Pontuacao: 1382 (critico)
 |---|---:|---|
 | backend/src/main/java/sgc/organizacao/dto/UnidadeDto.java | 45 | backend_nullable_dto: 7, backend_null_checks: 5 |
 | backend/src/main/java/sgc/e2e/E2eController.java | 30 | backend_null_checks: 15 |
-| backend/src/main/java/sgc/processo/service/ProcessoService.java | 30 | backend_null_checks: 14, backend_objects_null: 1 |
+| backend/src/main/java/sgc/organizacao/ValidadorDadosOrganizacionais.java | 30 | backend_null_checks: 14, backend_objects_null: 1 |
 | backend/src/main/java/sgc/processo/dto/ProcessoDetalheDto.java | 29 | backend_nullable_dto: 5, backend_null_checks: 2 |
 | backend/src/main/java/sgc/subprocesso/dto/SubprocessoResumoDto.java | 29 | backend_nullable_dto: 5, backend_null_checks: 2 |
-| backend/src/main/java/sgc/organizacao/ValidadorDadosOrganizacionais.java | 28 | backend_null_checks: 12, backend_objects_null: 2 |
+| backend/src/main/java/sgc/processo/service/ProcessoService.java | 26 | backend_null_checks: 12, backend_objects_null: 1 |
 | backend/src/main/java/sgc/subprocesso/dto/SubprocessoListagemDto.java | 25 | backend_nullable_dto: 5 |
+| backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java | 22 | backend_null_checks: 11 |
 | backend/src/main/java/sgc/mapa/dto/AtualizarEstadoMapaCommand.java | 20 | backend_nullable_dto: 4 |
 | backend/src/main/java/sgc/mapa/dto/AtualizarMapaRequest.java | 20 | backend_nullable_dto: 4 |
 | backend/src/main/java/sgc/mapa/dto/CriarMapaRequest.java | 20 | backend_nullable_dto: 4 |
 | backend/src/main/java/sgc/mapa/dto/MapaResumoDto.java | 20 | backend_nullable_dto: 4 |
 | backend/src/main/java/sgc/subprocesso/dto/AtualizarSubprocessoRequest.java | 20 | backend_nullable_dto: 4 |
-| backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java | 20 | backend_null_checks: 10 |
 | frontend/src/views/__tests__/ProcessoViewCoverage.spec.ts | 17 | frontend_any_testes: 17 |
 | backend/src/main/java/sgc/organizacao/service/UnidadeHierarquiaService.java | 16 | backend_null_checks: 8 |
 
 ## Escopos
 
 - backend: 837 ponto(s)
-- frontend: 226 ponto(s)
-- frontend_testes: 319 ponto(s)
+- frontend: 102 ponto(s)
+- frontend_testes: 315 ponto(s)

--- a/etc/qualidade/codigo-cheiros/latest/ultimo-snapshot.json
+++ b/etc/qualidade/codigo-cheiros/latest/ultimo-snapshot.json
@@ -1,31 +1,31 @@
 {
-  "geradoEm": "2026-04-05T15:52:10.408Z",
-  "base": "/Users/leonardo/sgc",
+  "geradoEm": "2026-04-06T01:26:14.857Z",
+  "base": "/app",
   "pontuacao": {
-    "total": 1382,
+    "total": 1254,
     "faixa": "critico",
     "porEscopo": {
       "backend": 837,
-      "frontend": 226,
-      "frontend_testes": 319
+      "frontend": 102,
+      "frontend_testes": 315
     }
   },
   "contagens": {
     "backend_nullable_dto": 89,
-    "backend_null_checks": 191,
-    "backend_objects_null": 5,
-    "frontend_any_producao": 38,
-    "frontend_any_testes": 319,
-    "frontend_catch_any": 4,
+    "backend_null_checks": 192,
+    "backend_objects_null": 4,
+    "frontend_any_producao": 10,
+    "frontend_any_testes": 315,
+    "frontend_catch_any": 0,
     "frontend_null_checks": 19,
     "frontend_fallback_or": 24
   },
   "deltas": {
-    "backend_nullable_dto": 7,
-    "backend_null_checks": -4,
+    "backend_nullable_dto": 0,
+    "backend_null_checks": 0,
     "backend_objects_null": 0,
-    "frontend_any_producao": 0,
-    "frontend_any_testes": 0,
+    "frontend_any_producao": -9,
+    "frontend_any_testes": -3,
     "frontend_catch_any": 0,
     "frontend_null_checks": 0,
     "frontend_fallback_or": 0
@@ -47,7 +47,7 @@
       }
     },
     {
-      "arquivo": "backend/src/main/java/sgc/processo/service/ProcessoService.java",
+      "arquivo": "backend/src/main/java/sgc/organizacao/ValidadorDadosOrganizacionais.java",
       "pontuacao": 30,
       "categorias": {
         "backend_null_checks": 14,
@@ -71,11 +71,11 @@
       }
     },
     {
-      "arquivo": "backend/src/main/java/sgc/organizacao/ValidadorDadosOrganizacionais.java",
-      "pontuacao": 28,
+      "arquivo": "backend/src/main/java/sgc/processo/service/ProcessoService.java",
+      "pontuacao": 26,
       "categorias": {
         "backend_null_checks": 12,
-        "backend_objects_null": 2
+        "backend_objects_null": 1
       }
     },
     {
@@ -83,6 +83,13 @@
       "pontuacao": 25,
       "categorias": {
         "backend_nullable_dto": 5
+      }
+    },
+    {
+      "arquivo": "backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java",
+      "pontuacao": 22,
+      "categorias": {
+        "backend_null_checks": 11
       }
     },
     {
@@ -118,13 +125,6 @@
       "pontuacao": 20,
       "categorias": {
         "backend_nullable_dto": 4
-      }
-    },
-    {
-      "arquivo": "backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java",
-      "pontuacao": 20,
-      "categorias": {
-        "backend_null_checks": 10
       }
     },
     {

--- a/frontend/src/axios-setup.ts
+++ b/frontend/src/axios-setup.ts
@@ -19,7 +19,7 @@ export const apiClient = axios.create({
     },
 });
 
-const handleResponseError = (error: any) => {
+const handleResponseError = (error: unknown) => {
     const normalized = normalizeError(error);
 
     // Caso especial: 401 - redirecionar para login

--- a/frontend/src/components/comum/TreeRowItem.vue
+++ b/frontend/src/components/comum/TreeRowItem.vue
@@ -11,7 +11,7 @@
         v-for="(column, index) in columns"
         :key="column.key"
         :style="index === 0 ? { paddingLeft: (level * 1.25) + 'rem' } : {}"
-        :title="item[column.key + 'Tooltip'] || ''"
+        :title="(item[column.key + 'Tooltip'] as string) || ''"
     >
       <BButton
           v-if="index === 0 && item.children && item.children.length > 0"
@@ -45,7 +45,7 @@ interface TreeItem {
   clickable?: boolean;
   level?: number;
 
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 const props = defineProps<{

--- a/frontend/src/components/comum/TreeTable.vue
+++ b/frontend/src/components/comum/TreeTable.vue
@@ -81,13 +81,13 @@ import {computed, nextTick, ref, toRaw, watch} from "vue";
 import TreeRowItem from "./TreeRowItem.vue";
 import EmptyState from "@/components/comum/EmptyState.vue";
 
-interface TreeItem {
+export interface TreeItem {
   codigo: number | string;
   expanded?: boolean;
   children?: TreeItem[];
   level?: number;
 
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface FlattenedTreeItem extends TreeItem {
@@ -208,7 +208,7 @@ const collapseAll = () => {
 };
 
 const handleTreeRowClick = (clickedItem: TreeItem) => {
-  emit("row-click", clickedItem);
+  emit("row-click", toRaw(clickedItem));
 };
 
 defineExpose({

--- a/frontend/src/components/unidade/UnidadeTreeNode.stories.ts
+++ b/frontend/src/components/unidade/UnidadeTreeNode.stories.ts
@@ -28,9 +28,9 @@ const mockUnidadeRaiz = {
 
 const mockFunctions = {
     isChecked: (codigo: number | string) => codigo === 2,
-    getEstadoSelecao: (unidade: any) => unidade.codigo === 2,
-    isExpanded: (unidade: any) => unidade.codigo === 1,
-    isHabilitado: (_: any) => true,
+    getEstadoSelecao: (unidade: { codigo: number }) => unidade.codigo === 2,
+    isExpanded: (unidade: { codigo: number }) => unidade.codigo === 1,
+    isHabilitado: (_: unknown) => true,
     onToggle: vi.fn(),
     onToggleExpand: vi.fn(),
 };

--- a/frontend/src/composables/__tests__/useFluxoMapa.spec.ts
+++ b/frontend/src/composables/__tests__/useFluxoMapa.spec.ts
@@ -71,9 +71,10 @@ describe("useFluxoMapa", () => {
         const resposta = {codigo: 1, competencias: []} as any;
         vi.mocked(service.salvarMapaCompleto).mockResolvedValue(resposta);
 
-        const resultado = await fluxoMapa.salvarMapa(10, {dados: "teste"});
+        const dados = {competencias: []};
+        const resultado = await fluxoMapa.salvarMapa(10, dados);
 
-        expect(service.salvarMapaCompleto).toHaveBeenCalledWith(10, {dados: "teste"});
+        expect(service.salvarMapaCompleto).toHaveBeenCalledWith(10, dados);
         expect(resultado).toEqual(resposta);
     });
 
@@ -83,9 +84,10 @@ describe("useFluxoMapa", () => {
         const service = await import("@/services/subprocessoService");
         vi.mocked(service.salvarMapaAjuste).mockResolvedValue(undefined);
 
-        await fluxoMapa.salvarAjustes(10, {dados: "ajuste"});
+        const dados = {competencias: [], atividades: [], sugestoes: "ajuste"};
+        await fluxoMapa.salvarAjustes(10, dados);
 
-        expect(service.salvarMapaAjuste).toHaveBeenCalledWith(10, {dados: "ajuste"});
+        expect(service.salvarMapaAjuste).toHaveBeenCalledWith(10, dados);
     });
 
     it("deve propagar erro se salvarAjustes falhar", async () => {
@@ -94,7 +96,8 @@ describe("useFluxoMapa", () => {
         const service = await import("@/services/subprocessoService");
         vi.mocked(service.salvarMapaAjuste).mockRejectedValue(new Error("Erro ajuste"));
 
-        await expect(fluxoMapa.salvarAjustes(10, {})).rejects.toThrow("Erro ajuste");
+        const dados = {competencias: [], atividades: [], sugestoes: ""};
+        await expect(fluxoMapa.salvarAjustes(10, dados)).rejects.toThrow("Erro ajuste");
     });
 
     it("deve propagar erro se salvarMapa falhar", async () => {
@@ -103,7 +106,8 @@ describe("useFluxoMapa", () => {
         const service = await import("@/services/subprocessoService");
         vi.mocked(service.salvarMapaCompleto).mockRejectedValue(new Error("Erro grave"));
 
-        await expect(fluxoMapa.salvarMapa(10, {})).rejects.toThrow("Erro grave");
+        const dados = {competencias: []};
+        await expect(fluxoMapa.salvarMapa(10, dados)).rejects.toThrow("Erro grave");
         expect(fluxoMapa.erro.value).toBe("Erro grave");
     });
 });

--- a/frontend/src/composables/useFluxoMapa.ts
+++ b/frontend/src/composables/useFluxoMapa.ts
@@ -6,7 +6,13 @@ import {
     salvarMapaAjuste,
     salvarMapaCompleto,
 } from "@/services/subprocessoService";
-import type {DisponibilizarMapaRequest, MapaCompleto, SalvarCompetenciaRequest} from "@/types/tipos";
+import type {
+    DisponibilizarMapaRequest,
+    MapaCompleto,
+    SalvarAjustesRequest,
+    SalvarCompetenciaRequest,
+    SalvarMapaRequest
+} from "@/types/tipos";
 import {useAsyncAction} from "@/composables/useAsyncAction";
 import {useErrorHandler} from "@/composables/useErrorHandler";
 
@@ -14,13 +20,13 @@ export function useFluxoMapa() {
     const {lastError, clearError} = useErrorHandler();
     const {carregando, erro, executar} = useAsyncAction();
 
-    async function salvarMapa(codSubprocesso: number, dados: any): Promise<MapaCompleto | undefined> {
+    async function salvarMapa(codSubprocesso: number, dados: SalvarMapaRequest): Promise<MapaCompleto | undefined> {
         return executar(async () => {
             return await salvarMapaCompleto(codSubprocesso, dados);
         }, "Erro ao salvar mapa completo.");
     }
 
-    async function salvarAjustes(codSubprocesso: number, request: any) {
+    async function salvarAjustes(codSubprocesso: number, request: SalvarAjustesRequest) {
         await executar(async () => {
             await salvarMapaAjuste(codSubprocesso, request);
         }, "Erro ao salvar ajustes do mapa.");

--- a/frontend/src/services/painelService.ts
+++ b/frontend/src/services/painelService.ts
@@ -24,7 +24,7 @@ export async function listarProcessos(
     params: ListarParams<keyof ProcessoResumo> = {}
 ): Promise<Page<ProcessoResumo>> {
     const { codUnidade, page = 0, size = 20, sort, order } = params;
-    const queryParams: any = {
+    const queryParams: Record<string, string | number> = {
         page,
         size,
     };
@@ -44,7 +44,7 @@ export async function listarAlertas(
     params: ListarParams<"dataHora" | "processo"> = {}
 ): Promise<Page<Alerta>> {
     const { codUnidade, page = 0, size = 20, sort, order } = params;
-    const queryParams: any = {
+    const queryParams: Record<string, string | number> = {
         page,
         size,
     };

--- a/frontend/src/services/usuarioService.ts
+++ b/frontend/src/services/usuarioService.ts
@@ -55,7 +55,7 @@ export function mapUsuarioToFrontend(usuarioDto: UsuarioDto): Usuario {
             nome: usuarioDto.unidade.nome,
             sigla: usuarioDto.unidade.sigla,
         },
-        perfis: usuarioDto.perfis as any[], // Casting to match generic array if needed, or specific
+        perfis: usuarioDto.perfis as unknown[], // Casting to match generic array if needed, or specific
     } as Usuario; // Force cast to match potentially looser frontend type
 }
 
@@ -105,7 +105,22 @@ export function perfisUnidadesParaDominio(
     }));
 }
 
-export function mapVWUsuarioToUsuario(vw: any): Usuario {
+export interface VWUsuario {
+    codigo?: number;
+    titulo?: string;
+    nome?: string;
+    nome_completo?: string;
+    nome_usuario?: string;
+    unidade?: unknown;
+    unidade_sigla?: string;
+    unidade_codigo?: number;
+    email?: string | null;
+    ramal?: string | null;
+    ramal_telefone?: string | null;
+    titulo_eleitoral?: string;
+}
+
+export function mapVWUsuarioToUsuario(vw: VWUsuario): Usuario {
     const candidateId =
         vw?.codigo ??
         (typeof vw?.titulo === "string" && /^\d+$/.test(vw.titulo)
@@ -117,14 +132,14 @@ export function mapVWUsuarioToUsuario(vw: any): Usuario {
     return {
         codigo,
         nome: vw?.nome ?? vw?.nome_completo ?? vw?.nome_usuario ?? "",
-        unidade: vw?.unidade ?? vw?.unidade_sigla ?? vw?.unidade_codigo ?? "",
+        unidade: (vw?.unidade ?? vw?.unidade_sigla ?? vw?.unidade_codigo ?? "") as any,
         email: vw?.email ?? null,
         ramal: vw?.ramal ?? vw?.ramal_telefone ?? null,
         tituloEleitoral: vw?.titulo_eleitoral ?? vw?.titulo ?? "",
     } as Usuario;
 }
 
-export function mapVWUsuariosArray(arr: any[] = []): Usuario[] {
+export function mapVWUsuariosArray(arr: VWUsuario[] = []): Usuario[] {
     return arr.map(mapVWUsuarioToUsuario);
 }
 

--- a/frontend/src/stores/perfil.ts
+++ b/frontend/src/stores/perfil.ts
@@ -86,7 +86,7 @@ export const usePerfilStore = defineStore("perfil", () => {
             }
 
             return fluxoLogin;
-        }).catch((error: any) => {
+        }).catch((error: { response?: { status: number } }) => {
             if (error?.response?.status === 404 || error?.response?.status === 401) {
                 return {
                     autenticado: false,

--- a/frontend/src/test-utils/serviceTestHelpers.ts
+++ b/frontend/src/test-utils/serviceTestHelpers.ts
@@ -32,9 +32,9 @@ export function setupServiceTest() {
  * Testa chamada GET
  */
 export function testGetEndpoint(
-    action: () => Promise<any>,
+    action: () => Promise<unknown>,
     url: string,
-    response: any = {}
+    response: unknown = {}
 ) {
     it(`deve fazer GET em ${url}`, async () => {
         mockApi.get.mockResolvedValue({data: response});
@@ -48,10 +48,10 @@ export function testGetEndpoint(
  * Testa chamada POST
  */
 export function testPostEndpoint(
-    action: () => Promise<any>,
+    action: () => Promise<unknown>,
     url: string,
-    payload?: any,
-    response: any = {}
+    payload?: unknown,
+    response: unknown = {}
 ) {
     it(`deve fazer POST em ${url}`, async () => {
         mockApi.post.mockResolvedValue({data: response});
@@ -69,7 +69,7 @@ export function testPostEndpoint(
  * Testa tratamento de erros comuns
  */
 export function testErrorHandling(
-    action: () => Promise<any>,
+    action: () => Promise<unknown>,
     method: 'get' | 'post' | 'put' | 'delete' = 'get'
 ) {
     it(`deve lidar com erro 404`, async () => {

--- a/frontend/src/test-utils/storeTestHelpers.ts
+++ b/frontend/src/test-utils/storeTestHelpers.ts
@@ -21,9 +21,9 @@ export function setupStoreTest<T>(useStore: () => T) {
  */
 export function testServiceCall<T>(
     action: () => Promise<T>,
-    service: any,
+    service: Record<string, any>,
     method: string,
-    expectedArgs: any[]
+    expectedArgs: unknown[]
 ) {
     it("deve chamar o service com os parâmetros corretos", async () => {
         await action();
@@ -36,7 +36,7 @@ export function testServiceCall<T>(
  */
 export function testErrorHandling<T>(
     action: () => Promise<T>,
-    errorType?: Error | any
+    errorType?: Error | unknown
 ) {
     it("deve lançar um erro em caso de falha", async () => {
         if (errorType) {

--- a/frontend/src/types/dtos.ts
+++ b/frontend/src/types/dtos.ts
@@ -75,7 +75,7 @@ export interface ProcessoDetalheDto {
     dataFinalizacao?: string;
     unidades?: UnidadeParticipanteDto[];
 
-    [key: string]: any; // Para campos adicionais do spread
+    [key: string]: unknown; // Para campos adicionais do spread
 }
 
 // DTOs para SGRH (autenticação e login)
@@ -132,5 +132,5 @@ export interface AtividadeOperacaoResponseDto {
     atividade: AtividadeDto | null;
     subprocesso: SubprocessoSituacaoDto;
     atividadesAtualizadas: AtividadeDto[];
-    permissoes?: any;
+    permissoes?: unknown;
 }

--- a/frontend/src/types/tipos.ts
+++ b/frontend/src/types/tipos.ts
@@ -333,7 +333,7 @@ export interface SubprocessoDetalhe {
     isEmAndamento: boolean;
     etapaAtual: number;
     movimentacoes: Movimentacao[];
-    elementosProcesso: any[];
+    elementosProcesso: unknown[];
     permissoes: PermissoesSubprocesso;
 }
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -39,7 +39,7 @@ function parseStringDate(s: string): Date | null {
     return null;
 }
 
-export function parseDate(dateInput: any): Date | null {
+export function parseDate(dateInput: unknown): Date | null {
     if (dateInput === null || dateInput === undefined || dateInput === "") {
         return null;
     }

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -457,8 +457,8 @@ async function confirmarRemocao() {
     });
     mostrarModalConfirmacaoRemocao.value = false;
     dadosRemocao.value = null;
-  } catch (e: any) {
-    const err = lastError.value?.message || e.message;
+  } catch (e: unknown) {
+    const err = lastError.value?.message || (e as Error).message;
     notify(err || TEXTOS.atividades.ERRO_REMOVER, 'danger');
     mostrarModalConfirmacaoRemocao.value = false;
   }

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -244,7 +244,7 @@ const performInitialLogin = async () => {
       } else {
         notify(TEXTOS.login.ERRO_CREDENCIAIS, 'danger');
       }
-  } catch (error: any) {
+  } catch (error: unknown) {
     const erroNormalizado = normalizeError(error);
     if (erroNormalizado.kind === 'unexpected') {
       logger.error("Erro interno no login:", erroNormalizado.message);
@@ -255,7 +255,7 @@ const performInitialLogin = async () => {
       logger.error("Erro no login:", error instanceof Error ? error.message : "Erro desconhecido");
     }
 
-    if (error.response?.status === 404 || error.response?.status === 401) {
+    if (erroNormalizado.kind === 'notFound' || erroNormalizado.kind === 'unauthorized') {
       notify(TEXTOS.login.ERRO_CREDENCIAIS, 'danger');
     } else {
       notify(TEXTOS.login.ERRO_GENERICO, 'danger');

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -133,6 +133,7 @@ import {useMapas} from "@/composables/useMapas";
 import {useSubprocessos} from "@/composables/useSubprocessos";
 import {useToastStore} from "@/stores/toast";
 import type {Atividade, Competencia, MapaCompleto, SalvarCompetenciaRequest, Unidade} from "@/types/tipos";
+import type {NormalizedError} from "@/utils/apiError";
 import ModalConfirmacao from "@/components/comum/ModalConfirmacao.vue";
 import {TEXTOS} from "@/constants/textos";
 
@@ -259,8 +260,8 @@ const {errors: fieldErrors, setFromNormalizedError, clearErrors} = useFormErrors
   'generic'
 ]);
 
-function handleErrors(store: any) {
-  setFromNormalizedError(store.lastError);
+function handleErrors(store: { lastError: unknown }) {
+  setFromNormalizedError(store.lastError as NormalizedError | null);
   if (fieldErrors.value.atividadesAssociadas) fieldErrors.value.atividades = fieldErrors.value.atividadesAssociadas;
   if (fieldErrors.value.atividadesIds) fieldErrors.value.atividades = fieldErrors.value.atividadesIds;
 }

--- a/frontend/src/views/PainelView.vue
+++ b/frontend/src/views/PainelView.vue
@@ -194,7 +194,7 @@ function abrirDetalhesProcesso(processo: ProcessoResumo | undefined) {
 }
 
 const camposAlertas = [
-  {key: "dataHora", label: TEXTOS.painel.CAMPOS_ALERTAS.DATA_HORA, sortable: false, formatter: (v: any) => formatDateTimeBR(v)},
+  {key: "dataHora", label: TEXTOS.painel.CAMPOS_ALERTAS.DATA_HORA, sortable: false, formatter: (v: unknown) => formatDateTimeBR(v as string | Date)},
   {key: "mensagem", label: TEXTOS.painel.CAMPOS_ALERTAS.DESCRICAO},
   {key: "processo", label: TEXTOS.painel.CAMPOS_ALERTAS.PROCESSO, sortable: false},
   {key: "origem", label: TEXTOS.painel.CAMPOS_ALERTAS.ORIGEM},

--- a/frontend/src/views/UnidadeView.vue
+++ b/frontend/src/views/UnidadeView.vue
@@ -114,7 +114,7 @@ import LayoutPadrao from '@/components/layout/LayoutPadrao.vue';
 import {computed, onMounted, ref, watch} from "vue";
 import {useRouter} from "vue-router";
 import type {Unidade, Usuario} from "@/types/tipos";
-import TreeTable from "@/components/comum/TreeTable.vue";
+import TreeTable, { type TreeItem } from "@/components/comum/TreeTable.vue";
 import PageHeader from "@/components/layout/PageHeader.vue";
 import EmptyState from "@/components/comum/EmptyState.vue";
 import {
@@ -156,8 +156,9 @@ async function carregarDados() {
     if (unidade.value?.tituloTitular) {
       titularDetalhes.value = await buscarUsuarioPorTitulo(unidade.value.tituloTitular);
     }
-  } catch (error: any) {
-    lastError.value = {message: error.message || TEXTOS.unidade.ERRO_CARREGAR};
+  } catch (error: unknown) {
+    const err = error as Error;
+    lastError.value = {message: err.message || TEXTOS.unidade.ERRO_CARREGAR};
     logger.error("Erro ao carregar dados da unidade:", error);
   }
 }
@@ -166,7 +167,7 @@ function irParaCriarAtribuicao() {
   router.push({path: `/unidade/${props.codUnidade}/atribuicao`});
 }
 
-function navegarParaUnidadeSubordinada(row: any) {
+function navegarParaUnidadeSubordinada(row: TreeItem) {
   router.push({path: `/unidade/${row.codigo}`});
 }
 
@@ -198,6 +199,7 @@ interface UnidadeFormatada {
   nome: string;
   expanded: boolean;
   children?: UnidadeFormatada[];
+  [key: string]: unknown;
 }
 
 function formatarDadosParaArvore(dados: Unidade[]): UnidadeFormatada[] {


### PR DESCRIPTION
This PR focuses on improving the overall quality and type safety of the frontend project, aligning it with the standards defined in AGENTS.md.

Key changes:
1.  **Elimination of 'any'**: Significantly reduced the usage of 'any' in production code. Replaced it with specific interfaces (e.g., `VWUsuario`, `SalvarMapaRequest`, `SalvarAjustesRequest`) or `unknown` where appropriate.
2.  **Type-Safe Error Handling**: Updated `catch` blocks in `LoginView.vue`, `UnidadeView.vue`, and `CadastroView.vue` to use `unknown`. Leveraged the `normalizeError` utility to ensure errors are processed safely.
3.  **Component Refactoring**: Updated `TreeTable.vue` and `TreeRowItem.vue` to use `[key: string]: unknown` index signatures. Property access in templates was updated with explicit casting (e.g., `as string`) to maintain type safety without sacrificing flexibility.
4.  **Test Utilities & Stories**: Improved type definitions in `serviceTestHelpers.ts` and `storeTestHelpers.ts`. Refactored `UnidadeTreeNode.stories.ts` to reduce 'any' usage.
5.  **Audit Compliance**: Confirmed that the project's quality suite (typecheck, lint, unit tests) passes with zero errors. The 'Frontend explicit any' smell count has been reduced substantially.
6.  **Addressing Review Feedback**: Removed automation scripts and refined manual casts (e.g., in `MapaView.vue` and `InlineEditor.vue`) to satisfy review requirements.

---
*PR created automatically by Jules for task [7699198361463971720](https://jules.google.com/task/7699198361463971720) started by @lgalvao*