### PR TITLE
Fix frontend quality check errors (typecheck, lint, and tests)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import {computed, KeepAlive} from "vue";
+import {computed} from "vue";
 import {useRoute} from "vue-router";
 import {BOrchestrator} from "bootstrap-vue-next";
 import pkg from "../package.json";

--- a/frontend/src/components/__tests__/TreeTable.spec.ts
+++ b/frontend/src/components/__tests__/TreeTable.spec.ts
@@ -386,13 +386,6 @@ describe("TreeTable.vue", () => {
 
         expect((wrapper.vm as any).internalData).toEqual([
             {
-                codigo: 1,
-                sigla: "GP",
-                unidade: "GP - Gabinete da Presidencia",
-                expanded: false,
-                children: [],
-            },
-            {
                 codigo: "raiz-zonas-eleitorais",
                 unidade: "ZONAS ELEITORAIS",
                 expanded: true,
@@ -414,6 +407,13 @@ describe("TreeTable.vue", () => {
                     },
                 ],
             },
+            {
+                codigo: 1,
+                sigla: "GP",
+                unidade: "GP - Gabinete da Presidencia",
+                expanded: false,
+                children: [],
+            },
         ]);
     });
 
@@ -431,7 +431,7 @@ describe("TreeTable.vue", () => {
             global: {stubs: {TreeRowItem: mockTreeRow}},
         });
 
-        expect((wrapper.vm as any).internalData.map((item: any) => item.codigo)).toEqual([2, 3, 1, 4]);
+        expect((wrapper.vm as any).internalData.map((item: any) => item.codigo)).toEqual([2, 3, 4, 1]);
     });
 
     it("deve ordenar em blocos: secretarias, zonas eleitorais e demais em ordem alfabetica", () => {

--- a/frontend/src/components/comum/TreeTable.vue
+++ b/frontend/src/components/comum/TreeTable.vue
@@ -182,7 +182,7 @@ const agruparZonasEleitorais = (
     const children = item.children
         ? agruparZonasEleitorais(item.children, `unidade-${item.codigo}`)
         : [];
-    const itemNormalizado = {
+    const itemNormalizado: TreeItem = {
       ...item,
       children,
     };
@@ -208,7 +208,7 @@ const priorizarSecretarias = (items: TreeItem[]): TreeItem[] => {
 
   for (const item of items) {
     const children = item.children ? priorizarSecretarias(item.children) : [];
-    const itemNormalizado = {
+    const itemNormalizado: TreeItem = {
       ...item,
       children,
     };
@@ -227,8 +227,8 @@ const priorizarSecretarias = (items: TreeItem[]): TreeItem[] => {
   }
 
   demais.sort((a, b) => {
-    const textoA = typeof a.unidade === "string" ? a.unidade : "";
-    const textoB = typeof b.unidade === "string" ? b.unidade : "";
+    const textoA = typeof a.unidade === "string" ? (a.unidade as string) : "";
+    const textoB = typeof b.unidade === "string" ? (b.unidade as string) : "";
     return textoA.localeCompare(textoB, "pt-BR", {sensitivity: "base"});
   });
 

--- a/frontend/src/views/__tests__/PainelView.spec.ts
+++ b/frontend/src/views/__tests__/PainelView.spec.ts
@@ -96,7 +96,7 @@ describe('PainelView', () => {
     const toastStore = useToastStore(pinia);
     toastStore.consumePending = vi.fn().mockReturnValue({ body: 'Sucesso' });
 
-    const wrapper = mount(PainelView, options);
+    mount(PainelView, options);
     await flushPromises();
 
     expect(painelService.listarProcessos).toHaveBeenCalledWith({codUnidade: 1, page: 0, size: 10});


### PR DESCRIPTION
This PR resolves several issues identified during a frontend quality check:

1. **TypeScript**: Fixed a type-checking error in `TreeTable.vue` where the `unidade` property was not being recognized on an inferred object type. Explicitly typing the object as `TreeItem` resolved the issue.
2. **Linting**: Removed an unused `KeepAlive` import in `App.vue` and an unused `wrapper` variable in `PainelView.spec.ts`, ensuring a clean lint report.
3. **Unit Tests**: Corrected expectations in `TreeTable.spec.ts` for tests related to unit grouping and sorting. The tests now correctly reflect the intended logic where 'Secretarias' and the 'ZONAS ELEITORAIS' group are prioritized before other units are sorted alphabetically.

All checks (typecheck, lint, and unit tests) now pass successfully.

---
*PR created automatically by Jules for task [7704469539884268351](https://jules.google.com/task/7704469539884268351) started by @lgalvao*