### PR TITLE
Refactor processo startup & validations; improve breadcrumbs and UI behaviors; cleanups

### DIFF
--- a/backend/src/main/java/sgc/processo/service/ProcessoService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoService.java
@@ -235,42 +235,32 @@ public class ProcessoService {
             throw new ErroValidacao(Mensagens.PROCESSO_SO_INICIAVEL_EM_CRIADO);
         }
 
-        TipoProcesso tipo = processo.getTipo();
-        List<Long> codigosUnidades;
-        Set<Unidade> unidadesParaProcessar;
-
-        if (tipo == REVISAO) {
-            if (codsUnidadesParam.isEmpty()) {
-                throw new ErroValidacao(Mensagens.LISTA_UNIDADES_OBRIGATORIA_REVISAO);
-            }
-            codigosUnidades = codsUnidadesParam;
-            unidadesParaProcessar = new HashSet<>(unidadeService.buscarPorCodigos(codigosUnidades));
-            processo.sincronizarParticipantes(carregarArvoreUnidades(unidadesParaProcessar));
-        } else {
-            codigosUnidades = processo.getCodigosParticipantes();
-            if (codigosUnidades.isEmpty()) {
-                throw new ErroValidacao(Mensagens.SEM_UNIDADES_PARTICIPANTES);
-            }
-            unidadesParaProcessar = new HashSet<>(unidadeService.buscarPorCodigos(codigosUnidades));
-        }
-
-        List<String> erros = validarUnidadesInicio(tipo, codigosUnidades, unidadesParaProcessar);
+        ContextoInicioProcesso contexto = resolverContextoInicio(processo, codsUnidadesParam);
+        List<String> erros = validarUnidadesInicio(contexto.tipo(), contexto.codigosUnidades(), contexto.unidadesParaProcessar());
         if (!erros.isEmpty()) {
             throw new ErroValidacao(String.join(", ", erros));
         }
 
-        List<UnidadeMapa> unidadesMapas = (tipo == REVISAO || tipo == DIAGNOSTICO)
-                ? unidadeService.buscarMapasPorUnidades(codigosUnidades)
+        List<UnidadeMapa> unidadesMapas = (contexto.tipo() == REVISAO || contexto.tipo() == DIAGNOSTICO)
+                ? unidadeService.buscarMapasPorUnidades(contexto.codigosUnidades())
                 : List.of();
 
         Unidade admin = unidadeService.buscarAdmin();
-        efetivarInicioSubprocessos(processo, tipo, codigosUnidades, unidadesParaProcessar, unidadesMapas, admin, usuario);
-        
+        efetivarInicioSubprocessos(
+                processo,
+                contexto.tipo(),
+                contexto.codigosUnidades(),
+                contexto.unidadesParaProcessar(),
+                unidadesMapas,
+                admin,
+                usuario
+        );
+
         processo.setSituacao(EM_ANDAMENTO);
         processoRepo.save(processo);
-        notificarInicioProcesso(processo, new ArrayList<>(unidadesParaProcessar));
+        notificarInicioProcesso(processo, new ArrayList<>(contexto.unidadesParaProcessar()));
 
-        log.info("Processo {} iniciado para {} unidades.", codigo, codigosUnidades.size());
+        log.info("Processo {} iniciado para {} unidades.", codigo, contexto.codigosUnidades().size());
     }
 
     public void finalizar(Long codigo) {
@@ -304,7 +294,7 @@ public class ProcessoService {
             return;
         }
 
-        processarAcoesBlocoAceiteHomologacao((ProcessarAnaliseEmBlocoCommand) command, usuario, subprocessos);
+        processarAcoesBlocoAceiteHomologacao((ProcessarAnaliseEmBlocoCommand) command, subprocessos);
     }
 
 
@@ -362,20 +352,11 @@ public class ProcessoService {
             throw new ErroValidacao(Mensagens.UNIDADE_NAO_PARTICIPA);
         }
 
-        LocalDateTime dataLimite = processo.getDataLimite();
-        String dataLimiteText;
-        if (dataLimite != null) {
-            dataLimiteText = dataLimite.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
-        } else {
-            throw new IllegalStateException("Processo %d sem data limite para envio de lembrete".formatted(codProcesso));
-        }
+        LocalDateTime dataLimite = obterDataLimiteObrigatoria(processo, codProcesso);
+        String dataLimiteText = dataLimite.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
         String corpoHtml = emailModelosService.criarEmailLembretePrazo(unidade.getSigla(), processo.getDescricao(), dataLimite);
 
-        String tituloTitular = unidade.getTituloTitular();
-        if (tituloTitular == null || tituloTitular.isBlank()) {
-            throw new IllegalStateException("Unidade %d sem titular oficial para envio de lembrete".formatted(unidadeCodigo));
-        }
-        Usuario titular = usuarioService.buscarPorLogin(tituloTitular);
+        Usuario titular = buscarTitularObrigatorio(unidade, unidadeCodigo);
         emailService.enviarEmailHtml(titular.getEmail(), "SGC: Lembrete - " + processo.getDescricao(), corpoHtml);
         servicoAlertas.criarAlertaAdmin(processo, unidade,
                 "Lembrete: Prazo do processo " + processo.getDescricao() + " encerra em " + dataLimiteText);
@@ -847,7 +828,7 @@ public class ProcessoService {
         transicaoService.disponibilizarMapaEmBloco(subprocessos.stream().map(Subprocesso::getCodigo).toList(), dispReq);
     }
 
-    private void processarAcoesBlocoAceiteHomologacao(ProcessarAnaliseEmBlocoCommand req, Usuario user, List<Subprocesso> list) {
+    private void processarAcoesBlocoAceiteHomologacao(ProcessarAnaliseEmBlocoCommand req, List<Subprocesso> list) {
         Map<Boolean, List<Long>> separacao = list.stream()
                 .collect(Collectors.partitioningBy(
                         sp -> isSituacaoCadastro(sp.getSituacao()),
@@ -857,13 +838,34 @@ public class ProcessoService {
         List<Long> cadastro = separacao.getOrDefault(true, List.of());
         List<Long> validacao = separacao.getOrDefault(false, List.of());
 
-        if (req.acao() == ACEITAR) {
-            if (!cadastro.isEmpty()) transicaoService.aceitarCadastroEmBloco(cadastro);
-            if (!validacao.isEmpty()) transicaoService.aceitarValidacaoEmBloco(validacao);
-        } else if (req.acao() == HOMOLOGAR) {
-            if (!cadastro.isEmpty()) transicaoService.homologarCadastroEmBloco(cadastro);
-            if (!validacao.isEmpty()) transicaoService.homologarValidacaoEmBloco(validacao);
+        switch (req.acao()) {
+            case ACEITAR -> {
+                if (!cadastro.isEmpty()) {
+                    transicaoService.aceitarCadastroEmBloco(cadastro);
+                }
+                if (!validacao.isEmpty()) {
+                    transicaoService.aceitarValidacaoEmBloco(validacao);
+                }
+            }
+            case HOMOLOGAR -> {
+                if (!cadastro.isEmpty()) {
+                    transicaoService.homologarCadastroEmBloco(cadastro);
+                }
+                if (!validacao.isEmpty()) {
+                    transicaoService.homologarValidacaoEmBloco(validacao);
+                }
+            }
+            default -> log.debug("Ação em bloco {} sem processamento no fluxo de análise", req.acao());
         }
+    }
+
+    @SuppressWarnings("unused")
+    private void processarAcoesBlocoAceiteHomologacao(
+            ProcessarAnaliseEmBlocoCommand req,
+            Usuario user,
+            List<Subprocesso> list
+    ) {
+        processarAcoesBlocoAceiteHomologacao(req, list);
     }
 
     private boolean isSituacaoCadastro(SituacaoSubprocesso s) {
@@ -891,4 +893,54 @@ public class ProcessoService {
             throw new ErroValidacao(Mensagens.UNIDADES_SEM_SUBPROCESSOS.formatted(faltando));
         }
     }
+
+    private ContextoInicioProcesso resolverContextoInicio(Processo processo, List<Long> codsUnidadesParam) {
+        TipoProcesso tipo = processo.getTipo();
+        List<Long> codigosUnidades = tipo == REVISAO
+                ? validarCodigosRevisao(codsUnidadesParam)
+                : validarCodigosParticipantes(processo.getCodigosParticipantes());
+        Set<Unidade> unidadesParaProcessar = new HashSet<>(unidadeService.buscarPorCodigos(codigosUnidades));
+
+        if (tipo == REVISAO) {
+            processo.sincronizarParticipantes(carregarArvoreUnidades(unidadesParaProcessar));
+        }
+
+        return new ContextoInicioProcesso(tipo, codigosUnidades, unidadesParaProcessar);
+    }
+
+    private List<Long> validarCodigosRevisao(List<Long> codsUnidadesParam) {
+        if (codsUnidadesParam.isEmpty()) {
+            throw new ErroValidacao(Mensagens.LISTA_UNIDADES_OBRIGATORIA_REVISAO);
+        }
+        return codsUnidadesParam;
+    }
+
+    private List<Long> validarCodigosParticipantes(List<Long> codigosParticipantes) {
+        if (codigosParticipantes.isEmpty()) {
+            throw new ErroValidacao(Mensagens.SEM_UNIDADES_PARTICIPANTES);
+        }
+        return codigosParticipantes;
+    }
+
+    private LocalDateTime obterDataLimiteObrigatoria(Processo processo, Long codProcesso) {
+        LocalDateTime dataLimite = processo.getDataLimite();
+        if (dataLimite == null) {
+            throw new IllegalStateException("Processo %d sem data limite para envio de lembrete".formatted(codProcesso));
+        }
+        return dataLimite;
+    }
+
+    private Usuario buscarTitularObrigatorio(Unidade unidade, Long unidadeCodigo) {
+        String tituloTitular = unidade.getTituloTitular();
+        if (tituloTitular == null || tituloTitular.isBlank()) {
+            throw new IllegalStateException("Unidade %d sem titular oficial para envio de lembrete".formatted(unidadeCodigo));
+        }
+        return usuarioService.buscarPorLogin(tituloTitular);
+    }
+
+    private record ContextoInicioProcesso(
+            TipoProcesso tipo,
+            List<Long> codigosUnidades,
+            Set<Unidade> unidadesParaProcessar
+    ) {}
 }

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoConsultaService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoConsultaService.java
@@ -153,6 +153,9 @@ public class SubprocessoConsultaService {
     }
 
     public List<Subprocesso> listarPorProcessoEUnidadeCodigosESituacoes(Long codProcesso, List<Long> codigosUnidades, List<SituacaoSubprocesso> situacoes) {
+        if (codigosUnidades.isEmpty() || situacoes.isEmpty()) {
+            return List.of();
+        }
         return subprocessoRepo.listarPorProcessoEUnidadesComUnidade(codProcesso, codigosUnidades).stream()
                 .filter(sp -> situacoes.contains(sp.getSituacao()))
                 .toList();
@@ -174,8 +177,7 @@ public class SubprocessoConsultaService {
 
     public SubprocessoDetalheResponse obterDetalhes(Subprocesso sp) {
         List<Movimentacao> movimentacoes = listarMovimentacoes(sp);
-        ContextoConsultaSubprocesso contexto = montarContextoConsulta(sp, movimentacoes);
-        return construirDetalhe(contexto, movimentacoes);
+        return construirDetalhe(montarContextoConsulta(sp, movimentacoes), movimentacoes);
     }
 
     public ContextoEdicaoResponse obterContextoEdicao(Long codSubprocesso) {
@@ -467,14 +469,14 @@ public class SubprocessoConsultaService {
         ContextoUsuarioAutenticado contextoUsuario = obterContextoUsuarioAutenticado();
         Unidade unidadeUsuario = unidadeService.buscarPorCodigoComSuperior(contextoUsuario.unidadeAtivaCodigo());
         Unidade unidadeAlvo = sp.getUnidade();
+        Long unidadeAtivaCodigo = contextoUsuario.unidadeAtivaCodigo();
         Unidade localizacaoAtual = resolverLocalizacaoAtual(sp, movimentacoes);
         boolean processoFinalizado = processoFinalizado(sp);
-        Long unidadeAtivaCodigo = contextoUsuario.unidadeAtivaCodigo();
-        boolean mesmaUnidade = isMesmaUnidadeLocalizacao(unidadeAtivaCodigo, localizacaoAtual, processoFinalizado);
-        boolean mesmaUnidadeAlvo = Objects.equals(contextoUsuario.unidadeAtivaCodigo(), unidadeAlvo.getCodigo());
-        boolean unidadeAlvoNaHierarquiaUsuario = mesmaUnidadeAlvo
-                || hierarquiaService.ehMesmaOuSubordinada(unidadeAlvo, unidadeUsuario);
-        boolean temMapaVigente = !processoFinalizado && unidadeService.temMapaVigente(unidadeAlvo.getCodigo());
+        boolean mesmaUnidadeAlvo = Objects.equals(unidadeAtivaCodigo, unidadeAlvo.getCodigo());
+        boolean mesmaUnidade = mesmaUnidadeLocalizacao(unidadeAtivaCodigo, localizacaoAtual, processoFinalizado);
+        boolean unidadeAlvoNaHierarquiaUsuario = isUnidadeAlvoNaHierarquiaUsuario(unidadeAlvo, unidadeUsuario, mesmaUnidadeAlvo);
+        boolean temMapaVigente = temMapaVigente(unidadeAlvo.getCodigo(), processoFinalizado);
+
         return new ContextoConsultaSubprocesso(
                 sp,
                 contextoUsuario.perfil(),
@@ -492,8 +494,16 @@ public class SubprocessoConsultaService {
         return processo != null && processo.getSituacao() == SituacaoProcesso.FINALIZADO;
     }
 
-    private boolean isMesmaUnidadeLocalizacao(Long unidadeAtivaCodigo, Unidade localizacaoAtual, boolean processoFinalizado) {
+    private boolean mesmaUnidadeLocalizacao(Long unidadeAtivaCodigo, Unidade localizacaoAtual, boolean processoFinalizado) {
         return !processoFinalizado && Objects.equals(unidadeAtivaCodigo, localizacaoAtual.getCodigo());
+    }
+
+    private boolean isUnidadeAlvoNaHierarquiaUsuario(Unidade unidadeAlvo, Unidade unidadeUsuario, boolean mesmaUnidadeAlvo) {
+        return mesmaUnidadeAlvo || hierarquiaService.ehMesmaOuSubordinada(unidadeAlvo, unidadeUsuario);
+    }
+
+    private boolean temMapaVigente(Long unidadeCodigo, boolean processoFinalizado) {
+        return !processoFinalizado && unidadeService.temMapaVigente(unidadeCodigo);
     }
 
     private ContextoUsuarioAutenticado obterContextoUsuarioAutenticado() {
@@ -551,10 +561,6 @@ public class SubprocessoConsultaService {
 
         private boolean isAdmin() {
             return perfil == Perfil.ADMIN;
-        }
-
-        private boolean isServidor() {
-            return perfil == Perfil.SERVIDOR;
         }
 
         private boolean isGestorOuAdmin() {

--- a/frontend/src/__tests__/components/BarraNavegacao.spec.ts
+++ b/frontend/src/__tests__/components/BarraNavegacao.spec.ts
@@ -145,7 +145,10 @@ describe('BarraNavegacao.vue', () => {
             mockRoute.name = 'Unidade';
             mockRoute.params = {codUnidade: '10'};
             const wrapper = mountComponent({
-                perfil: {perfilSelecionado: Perfil.GESTOR},
+                perfil: {
+                    perfilSelecionado: Perfil.GESTOR,
+                    permissoesSessao: {mostrarArvoreCompletaUnidades: false}
+                },
             });
             const items = wrapper.findAllComponents(BBreadcrumbItemStub);
             // Home -> MINHA_UNIDADE -> Minha unidade (Título da pagina)
@@ -160,7 +163,10 @@ describe('BarraNavegacao.vue', () => {
             mockRoute.name = 'Unidade';
             mockRoute.params = {codUnidade: '1'};
             const wrapper = mountComponent({
-                perfil: {perfilSelecionado: Perfil.ADMIN},
+                perfil: {
+                    perfilSelecionado: Perfil.ADMIN,
+                    permissoesSessao: {mostrarArvoreCompletaUnidades: true}
+                },
             });
             const items = wrapper.findAllComponents(BBreadcrumbItemStub);
             // Home -> ADMIN -> Unidades
@@ -169,15 +175,17 @@ describe('BarraNavegacao.vue', () => {
             expect(items[2].text()).toBe('Unidades');
         });
 
-        it('deve usar ID da unidade se sigla não estiver na store', () => {
+        it('deve manter label vazio quando sigla da unidade não estiver carregada', () => {
             mockRoute.name = 'Unidade';
             mockRoute.params = {codUnidade: '99'};
             const wrapper = mountComponent({
-                perfil: {perfilSelecionado: Perfil.GESTOR},
+                perfil: {
+                    perfilSelecionado: Perfil.GESTOR,
+                    permissoesSessao: {mostrarArvoreCompletaUnidades: false}
+                },
             });
             const items = wrapper.findAllComponents(BBreadcrumbItemStub);
-            // Home -> Unidade 99 -> Minha unidade
-            expect(items[1].text()).toBe('Unidade 99');
+            expect(items[1].text()).toBe('');
         });
 
         it('deve usar meta.breadcrumb para rotas genéricas', () => {

--- a/frontend/src/__tests__/views/PainelView.spec.ts
+++ b/frontend/src/__tests__/views/PainelView.spec.ts
@@ -41,7 +41,10 @@ describe("PainelView.vue", () => {
             perfilSelecionado: "ADMIN",
             unidadeSelecionada: 1,
             usuarioCodigo: 100,
-            perfis: [] as string[]
+            perfis: [] as string[],
+            permissoesSessao: {
+                mostrarCriarProcesso: true
+            }
         },
         processos: {
             processosPainel: []
@@ -141,14 +144,20 @@ describe("PainelView.vue", () => {
     it("deve mostrar botão de criar processo apenas para admin", async () => {
         // Admin
         const wrapperAdmin = mount(PainelView, mountOptions({
-            perfil: {perfilSelecionado: "ADMIN"}
+            perfil: {
+                perfilSelecionado: "ADMIN",
+                permissoesSessao: {mostrarCriarProcesso: true}
+            }
         }));
         await flushPromises();
         expect(wrapperAdmin.find('[data-testid="btn-painel-criar-processo"]').exists()).toBe(true);
 
         // Not admin
         const wrapperUser = mount(PainelView, mountOptions({
-            perfil: {perfilSelecionado: "USER"}
+            perfil: {
+                perfilSelecionado: "USER",
+                permissoesSessao: {mostrarCriarProcesso: false}
+            }
         }));
         await flushPromises();
         expect(wrapperUser.find('[data-testid="btn-painel-criar-processo"]').exists()).toBe(false);

--- a/frontend/src/components/__tests__/BarraNavegacao.spec.ts
+++ b/frontend/src/components/__tests__/BarraNavegacao.spec.ts
@@ -5,6 +5,7 @@ import {useRoute} from "vue-router";
 import {Perfil} from "@/types/tipos";
 import BarraNavegacao from "../layout/BarraNavegacao.vue";
 import {getCommonMountOptions, setupComponentTest} from "@/test-utils/componentTestHelpers";
+import {useUnidadeAtual} from "@/composables/useUnidadeAtual";
 
 const mockRouter = {
     back: vi.fn(),
@@ -58,6 +59,8 @@ describe("BarraNavegacao.vue", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        const {definirUnidadeAtual} = useUnidadeAtual();
+        definirUnidadeAtual(null);
     });
 
     describe("Visibilidade dos Elementos", () => {
@@ -130,34 +133,43 @@ describe("BarraNavegacao.vue", () => {
         });
 
         it("deve renderizar breadcrumbs para rotas de unidade (ADMIN vê 'Unidades')", () => {
+            const {definirUnidadeAtual} = useUnidadeAtual();
+            definirUnidadeAtual({codigo: 1, sigla: "UNIDADE_1"} as any);
             vi.mocked(useRoute).mockReturnValue(
                 createMockRoute("/unidade/1", mockMatchedUnidade, "Unidade", {codUnidade: "1"}),
             );
             const wrapper = mount(BarraNavegacao, getCommonMountOptions({
-                perfil: {perfilSelecionado: Perfil.ADMIN}
+                perfil: {
+                    perfilSelecionado: Perfil.ADMIN,
+                    permissoesSessao: {mostrarArvoreCompletaUnidades: true}
+                }
             }, {BButton}));
 
             const items = wrapper.findAllComponents(BBreadcrumbItem);
             expect(items).toHaveLength(3); // Home + sigla/codigo + "Unidades"
             expect(items[0].find('[data-testid="btn-nav-home"]').exists()).toBe(true);
-            // Sem unidade carregada no store, mostra "Unidade X"
-            expect(items[1].text()).toBe("Unidade 1");
+            expect(items[1].text()).toBe("UNIDADE_1");
             // ADMIN vê "Unidades" em vez de "Minha unidade"
             expect(items[2].text()).toBe("Unidades");
         });
 
         it("deve renderizar breadcrumbs para rotas de unidade (não-ADMIN vê 'Minha unidade')", () => {
+            const {definirUnidadeAtual} = useUnidadeAtual();
+            definirUnidadeAtual({codigo: 456, sigla: "UNIDADE_456"} as any);
             vi.mocked(useRoute).mockReturnValue(
                 createMockRoute("/unidade/456", mockMatchedUnidade, "Unidade", {codUnidade: "456"}),
             );
             const wrapper = mount(BarraNavegacao, getCommonMountOptions({
-                perfil: {perfilSelecionado: Perfil.GESTOR}
+                perfil: {
+                    perfilSelecionado: Perfil.GESTOR,
+                    permissoesSessao: {mostrarArvoreCompletaUnidades: false}
+                }
             }, {BButton}));
 
             const items = wrapper.findAllComponents(BBreadcrumbItem);
             expect(items).toHaveLength(3); // Home + sigla/codigo + "Minha unidade"
             expect(items[0].find('[data-testid="btn-nav-home"]').exists()).toBe(true);
-            expect(items[1].text()).toBe("Unidade 456");
+            expect(items[1].text()).toBe("UNIDADE_456");
             // Não-ADMIN vê "Minha unidade"
             expect(items[2].text()).toBe("Minha unidade");
         });

--- a/frontend/src/components/atividades/AtividadeItem.vue
+++ b/frontend/src/components/atividades/AtividadeItem.vue
@@ -156,6 +156,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   habilitarEdicao: true,
+  erroValidacao: "",
 });
 
 const emit = defineEmits<{

--- a/frontend/src/composables/__tests__/useBreadcrumbs.spec.ts
+++ b/frontend/src/composables/__tests__/useBreadcrumbs.spec.ts
@@ -110,7 +110,7 @@ describe("useBreadcrumbs", () => {
         expect(breadcrumbs.value[2].label).toBe("Unidades");
     });
 
-    it("deve usar fallback se a unidade atual não estiver carregada", () => {
+    it("deve manter label da unidade vazia se a unidade atual não estiver carregada", () => {
         perfilStoreMock.perfilSelecionado = Perfil.CHEFE;
         usePerfilMock.mostrarArvoreCompletaUnidades.value = false;
         unidadeAtualMock.unidadeAtual.value = null;
@@ -121,7 +121,7 @@ describe("useBreadcrumbs", () => {
         } as any;
         const {breadcrumbs} = useBreadcrumbs(route);
 
-        expect(breadcrumbs.value[1].label).toBe("Unidade 456");
+        expect(breadcrumbs.value[1].label).toBe("");
     });
 
     it("deve processar metadados de breadcrumb da rota (fallback)", () => {

--- a/frontend/src/composables/useBreadcrumbs.ts
+++ b/frontend/src/composables/useBreadcrumbs.ts
@@ -74,7 +74,7 @@ export function useBreadcrumbs(route: RouteLocationNormalizedLoaded) {
         const crumbs: Breadcrumb[] = [];
         if (codUnidade && isUnidadeRoute) {
             crumbs.push({
-                label: unidadeAtual.value?.sigla || `Unidade ${codUnidade}`,
+                label: unidadeAtual.value?.sigla ?? "",
                 to: routeName === "Unidade" ? undefined : {name: "Unidade", params: {codUnidade}},
             });
 

--- a/frontend/src/views/AtribuicaoTemporariaView.vue
+++ b/frontend/src/views/AtribuicaoTemporariaView.vue
@@ -234,12 +234,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  if (timeoutPesquisaUsuarios) {
-    clearTimeout(timeoutPesquisaUsuarios);
-  }
-  if (timeoutOcultarResultadosUsuarios) {
-    clearTimeout(timeoutOcultarResultadosUsuarios);
-  }
+  limparTimeoutsUsuarios();
 });
 
 function aoAlterarTermoUsuario(valor: string | number | null) {
@@ -247,30 +242,15 @@ function aoAlterarTermoUsuario(valor: string | number | null) {
   mostrarResultadosUsuarios.value = termoPesquisaMinimaAtingida.value;
   indiceUsuarioDestacado.value = -1;
   atualizarUsuarioSelecionadoPorNome(termoUsuario.value);
+  limparTimeoutPesquisaUsuarios();
 
-  if (timeoutPesquisaUsuarios) {
-    clearTimeout(timeoutPesquisaUsuarios);
-  }
-
-  if (!termoPesquisaMinimaAtingida.value) {
-    usuariosEncontrados.value = [];
-    pesquisandoUsuarios.value = false;
-    indiceUsuarioDestacado.value = -1;
+  if (!termoPesquisaMinimaAtingida.value || !termoUsuario.value.trim()) {
+    limparResultadosPesquisaUsuarios();
     return;
   }
 
   timeoutPesquisaUsuarios = setTimeout(async () => {
-    pesquisandoUsuarios.value = true;
-    try {
-      usuariosEncontrados.value = await pesquisarUsuarios(termoUsuario.value.trim());
-      atualizarUsuarioSelecionadoPorNome(termoUsuario.value);
-    } catch (error) {
-      usuariosEncontrados.value = [];
-      logger.error("Erro ao pesquisar usuários:", error);
-      notify(TEXTOS.atribuicaoTemporaria.ERRO_CARREGAR, 'danger');
-    } finally {
-      pesquisandoUsuarios.value = false;
-    }
+    await executarPesquisaUsuarios();
   }, 300);
 }
 
@@ -282,17 +262,13 @@ function atualizarUsuarioSelecionadoPorNome(nome: string) {
 function selecionarUsuario(usuario: UsuarioPesquisa) {
   usuarioSelecionado.value = usuario.tituloEleitoral;
   termoUsuario.value = usuario.nome;
-  mostrarResultadosUsuarios.value = false;
-  indiceUsuarioDestacado.value = -1;
+  ocultarResultadosUsuarios();
 }
 
 function agendarOcultacaoResultadosUsuarios() {
-  if (timeoutOcultarResultadosUsuarios) {
-    clearTimeout(timeoutOcultarResultadosUsuarios);
-  }
+  limparTimeoutOcultarResultadosUsuarios();
   timeoutOcultarResultadosUsuarios = setTimeout(() => {
-    mostrarResultadosUsuarios.value = false;
-    indiceUsuarioDestacado.value = -1;
+    ocultarResultadosUsuarios();
   }, 150);
 }
 
@@ -317,19 +293,13 @@ async function aoPressionarTeclaUsuario(evento: KeyboardEvent) {
 
   if (evento.key === "ArrowDown") {
     evento.preventDefault();
-    const proximoIndice = indiceUsuarioDestacado.value < usuariosEncontrados.value.length - 1
-        ? indiceUsuarioDestacado.value + 1
-        : 0;
-    await destacarUsuario(proximoIndice);
+    await destacarUsuario(calcularProximoIndice(1));
     return;
   }
 
   if (evento.key === "ArrowUp") {
     evento.preventDefault();
-    const proximoIndice = indiceUsuarioDestacado.value > 0
-        ? indiceUsuarioDestacado.value - 1
-        : usuariosEncontrados.value.length - 1;
-    await destacarUsuario(proximoIndice);
+    await destacarUsuario(calcularProximoIndice(-1));
     return;
   }
 
@@ -340,8 +310,7 @@ async function aoPressionarTeclaUsuario(evento: KeyboardEvent) {
   }
 
   if (evento.key === "Escape") {
-    mostrarResultadosUsuarios.value = false;
-    indiceUsuarioDestacado.value = -1;
+    ocultarResultadosUsuarios();
   }
 }
 
@@ -367,22 +336,75 @@ async function criarAtribuicao() {
     });
 
     notify(TEXTOS.atribuicaoTemporaria.SUCESSO, 'success');
-
-    usuarioSelecionado.value = null;
-    termoUsuario.value = "";
-    usuariosEncontrados.value = [];
-    mostrarResultadosUsuarios.value = false;
-    indiceUsuarioDestacado.value = -1;
-    dataInicio.value = "";
-    dataTermino.value = "";
-    justificativa.value = "";
-    validacaoSubmetida.value = false;
+    resetarFormularioAtribuicao();
   } catch (error) {
     logger.error(error);
     notify(TEXTOS.atribuicaoTemporaria.ERRO_CRIAR, 'danger');
   } finally {
     isLoading.value = false;
   }
+}
+
+function limparTimeoutPesquisaUsuarios() {
+  if (timeoutPesquisaUsuarios) {
+    clearTimeout(timeoutPesquisaUsuarios);
+    timeoutPesquisaUsuarios = null;
+  }
+}
+
+function limparTimeoutOcultarResultadosUsuarios() {
+  if (timeoutOcultarResultadosUsuarios) {
+    clearTimeout(timeoutOcultarResultadosUsuarios);
+    timeoutOcultarResultadosUsuarios = null;
+  }
+}
+
+function limparTimeoutsUsuarios() {
+  limparTimeoutPesquisaUsuarios();
+  limparTimeoutOcultarResultadosUsuarios();
+}
+
+function ocultarResultadosUsuarios() {
+  mostrarResultadosUsuarios.value = false;
+  indiceUsuarioDestacado.value = -1;
+}
+
+function limparResultadosPesquisaUsuarios() {
+  usuariosEncontrados.value = [];
+  pesquisandoUsuarios.value = false;
+  ocultarResultadosUsuarios();
+}
+
+async function executarPesquisaUsuarios() {
+  pesquisandoUsuarios.value = true;
+  try {
+    usuariosEncontrados.value = await pesquisarUsuarios(termoUsuario.value.trim());
+    atualizarUsuarioSelecionadoPorNome(termoUsuario.value);
+  } catch (error) {
+    limparResultadosPesquisaUsuarios();
+    logger.error("Erro ao pesquisar usuários:", error);
+    notify(TEXTOS.atribuicaoTemporaria.ERRO_CARREGAR, 'danger');
+  } finally {
+    pesquisandoUsuarios.value = false;
+  }
+}
+
+function calcularProximoIndice(deslocamento: 1 | -1) {
+  const ultimoIndice = usuariosEncontrados.value.length - 1;
+  if (deslocamento === 1) {
+    return indiceUsuarioDestacado.value < ultimoIndice ? indiceUsuarioDestacado.value + 1 : 0;
+  }
+  return indiceUsuarioDestacado.value > 0 ? indiceUsuarioDestacado.value - 1 : ultimoIndice;
+}
+
+function resetarFormularioAtribuicao() {
+  usuarioSelecionado.value = null;
+  termoUsuario.value = "";
+  limparResultadosPesquisaUsuarios();
+  dataInicio.value = "";
+  dataTermino.value = "";
+  justificativa.value = "";
+  validacaoSubmetida.value = false;
 }
 
 defineExpose({

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -42,7 +42,7 @@
         </BButton>
 
         <LoadingButton
-            v-if="podeEditarCadastro"
+            v-if="codSubprocesso && podeDisponibilizarCadastro"
             :disabled="botaoDisponibilizarDesabilitado"
             :loading="loadingValidacao"
             data-testid="btn-cad-atividades-disponibilizar"
@@ -238,13 +238,10 @@ const codSubprocesso = ref<number | null>(null);
 const codMapa = computed(() => mapasStore.mapaCompleto.value?.codigo ?? null);
 const subprocesso = computed(() => subprocessosStore.subprocessoDetalhe);
 const unidade = ref<Unidade | null>(null);
-const {
-  podeEditarCadastro,
-  podeDisponibilizarCadastro,
-  podeVisualizarImpacto,
-  habilitarEditarCadastro,
-  habilitarDisponibilizarCadastro
-} = useAcesso(subprocesso);
+const acesso = useAcesso(subprocesso);
+const {podeEditarCadastro, podeVisualizarImpacto, habilitarEditarCadastro} = acesso;
+const podeDisponibilizarCadastro = computed(() => acesso.podeDisponibilizarCadastro?.value ?? false);
+const habilitarDisponibilizarCadastro = computed(() => acesso.habilitarDisponibilizarCadastro?.value ?? false);
 const isRevisao = computed(() => subprocesso.value?.tipoProcesso === TipoProcesso.REVISAO);
 
 

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -173,13 +173,7 @@ const {
   fecharModalImpacto,
 } = useImpactoMapaModal(codSubprocesso, (codigo) => mapasStore.buscarImpactoMapa(codigo));
 
-function sincronizarMapa(mapaAtualizado: MapaCompleto | null | undefined) {
-  if (mapaAtualizado) {
-    mapasStore.mapaCompleto.value = mapaAtualizado;
-  }
-}
-
-async function atualizarContextoEdicao(codigo: number) {
+async function carregarContextoEdicao(codigo: number) {
   const data = await subprocessosStore.buscarContextoEdicao(codigo);
   if (!data) {
     return null;
@@ -191,8 +185,14 @@ async function atualizarContextoEdicao(codigo: number) {
   return data;
 }
 
+function sincronizarMapa(mapaAtualizado: MapaCompleto | null | undefined) {
+  if (mapaAtualizado) {
+    mapasStore.mapaCompleto.value = mapaAtualizado;
+  }
+}
+
 async function carregarMapaInicial(codigo: number) {
-  const data = await atualizarContextoEdicao(codigo);
+  const data = await carregarContextoEdicao(codigo);
   if (data?.mapa) {
     sincronizarMapa(data.mapa);
     return;
@@ -203,10 +203,11 @@ async function carregarMapaInicial(codigo: number) {
 
 onMounted(async () => {
   const codigo = await subprocessosStore.buscarSubprocessoPorProcessoEUnidade(codProcesso.value, siglaUnidade.value);
-  if (codigo) {
-    codSubprocesso.value = codigo;
-    await carregarMapaInicial(codigo);
+  if (!codigo) {
+    return;
   }
+  codSubprocesso.value = codigo;
+  await carregarMapaInicial(codigo);
 });
 
 const atividades = ref<Atividade[]>([]);
@@ -266,25 +267,14 @@ function handleErrors(store: { lastError: unknown }) {
   if (fieldErrors.value.atividadesIds) fieldErrors.value.atividades = fieldErrors.value.atividadesIds;
 }
 
-function abrirModalDisponibilizar() {
-  mostrarModalDisponibilizar.value = true;
-  clearErrors();
-}
-
-function abrirModalCriarNovaCompetencia(competenciaParaEditar?: Competencia) {
+function abrirModalCriarNovaCompetencia(competenciaParaEditar: Competencia | null = null) {
   mostrarModalCriarNovaCompetencia.value = true;
   clearErrors();
   fluxoMapa.clearError();
-
-  if (competenciaParaEditar) {
-    competenciaSendoEditada.value = competenciaParaEditar;
-  } else {
-    competenciaSendoEditada.value = null;
-  }
+  competenciaSendoEditada.value = competenciaParaEditar;
 }
 
 function abrirModalCriarLimpo() {
-  competenciaSendoEditada.value = null;
   abrirModalCriarNovaCompetencia();
 }
 
@@ -294,12 +284,17 @@ function fecharModalCriarNovaCompetencia() {
 }
 
 function iniciarEdicaoCompetencia(competencia: Competencia) {
-  competenciaSendoEditada.value = competencia;
   abrirModalCriarNovaCompetencia(competencia);
 }
 
+function abrirModalDisponibilizar() {
+  mostrarModalDisponibilizar.value = true;
+  clearErrors();
+}
+
 async function adicionarCompetenciaEFecharModal(dados: { descricao: string; atividadesSelecionadas: number[] }) {
-  if (!codSubprocesso.value) return;
+  const codigoSubprocesso = codSubprocesso.value;
+  if (!codigoSubprocesso) return;
   const request: SalvarCompetenciaRequest = {
     descricao: dados.descricao,
     atividadesIds: dados.atividadesSelecionadas,
@@ -307,12 +302,12 @@ async function adicionarCompetenciaEFecharModal(dados: { descricao: string; ativ
 
   try {
     if (competenciaSendoEditada.value) {
-      sincronizarMapa(await fluxoMapa.atualizarCompetencia(codSubprocesso.value, competenciaSendoEditada.value.codigo, request));
+      sincronizarMapa(await fluxoMapa.atualizarCompetencia(codigoSubprocesso, competenciaSendoEditada.value.codigo, request));
     } else {
-      sincronizarMapa(await fluxoMapa.adicionarCompetencia(codSubprocesso.value, request));
+      sincronizarMapa(await fluxoMapa.adicionarCompetencia(codigoSubprocesso, request));
     }
 
-    await atualizarContextoEdicao(codSubprocesso.value);
+    await carregarContextoEdicao(codigoSubprocesso);
     fecharModalCriarNovaCompetencia();
   } catch {
     handleErrors(fluxoMapa);
@@ -328,20 +323,19 @@ function excluirCompetencia(codigo: number) {
 }
 
 async function confirmarExclusaoCompetencia() {
-  if (competenciaParaExcluir.value && codSubprocesso.value) {
-    loadingExclusao.value = true;
-    try {
-      sincronizarMapa(await fluxoMapa.removerCompetencia(
-          codSubprocesso.value,
-          competenciaParaExcluir.value.codigo,
-      ));
-      await atualizarContextoEdicao(codSubprocesso.value);
-      fecharModalExcluirCompetencia();
-    } catch {
-      handleErrors(fluxoMapa);
-    } finally {
-      loadingExclusao.value = false;
-    }
+  const competencia = competenciaParaExcluir.value;
+  const codigoSubprocesso = codSubprocesso.value;
+  if (!competencia || !codigoSubprocesso) return;
+
+  loadingExclusao.value = true;
+  try {
+    sincronizarMapa(await fluxoMapa.removerCompetencia(codigoSubprocesso, competencia.codigo));
+    await carregarContextoEdicao(codigoSubprocesso);
+    fecharModalExcluirCompetencia();
+  } catch {
+    handleErrors(fluxoMapa);
+  } finally {
+    loadingExclusao.value = false;
   }
 }
 
@@ -351,33 +345,34 @@ function fecharModalExcluirCompetencia() {
 }
 
 async function removerAtividadeAssociada(competenciaId: number, codAtividade: number) {
-  if (!codSubprocesso.value) return;
+  const codigoSubprocesso = codSubprocesso.value;
+  if (!codigoSubprocesso) return;
   const competencia = competencias.value.find(
       (comp) => comp.codigo === competenciaId,
   );
-  if (competencia) {
-    const atividadesIds = (competencia.atividades || []).map((a) => a.codigo).filter((id) => id !== codAtividade);
+  if (!competencia) return;
 
-    const request: SalvarCompetenciaRequest = {
-      descricao: competencia.descricao,
-      atividadesIds: atividadesIds,
-    };
+  const atividadesIds = (competencia.atividades || []).map((a) => a.codigo).filter((id) => id !== codAtividade);
+  const request: SalvarCompetenciaRequest = {
+    descricao: competencia.descricao,
+    atividadesIds: atividadesIds,
+  };
 
-    sincronizarMapa(await fluxoMapa.atualizarCompetencia(
-        codSubprocesso.value,
-        competencia.codigo,
-        request,
-    ));
-  }
+  sincronizarMapa(await fluxoMapa.atualizarCompetencia(
+      codigoSubprocesso,
+      competencia.codigo,
+      request,
+  ));
 }
 
 async function disponibilizarMapa(payload: { dataLimite: string; observacoes: string }) {
-  if (!codSubprocesso.value) return;
+  const codigoSubprocesso = codSubprocesso.value;
+  if (!codigoSubprocesso) return;
   fluxoMapa.clearError();
   loadingDisponibilizacao.value = true;
 
   try {
-    await fluxoMapa.disponibilizarMapa(codSubprocesso.value as number, payload);
+    await fluxoMapa.disponibilizarMapa(codigoSubprocesso, payload);
     fecharModalDisponibilizar();
     toastStore.setPending(TEXTOS.sucesso.MAPA_DISPONIBILIZADO);
     await router.push({name: "Painel"});

--- a/frontend/src/views/MapaVisualizacaoView.vue
+++ b/frontend/src/views/MapaVisualizacaoView.vue
@@ -277,7 +277,6 @@ const codSubprocesso = ref<number | null>(null);
 
 const {
   podeValidarMapa,
-  podeAceitarMapa,
   podeDevolverMapa,
   podeVerSugestoes: podeMostrarVerSugestoes,
   habilitarDevolverMapa,

--- a/frontend/src/views/ProcessoDetalheView.vue
+++ b/frontend/src/views/ProcessoDetalheView.vue
@@ -109,24 +109,12 @@ import ProcessoSubprocessosTable from "@/components/processo/ProcessoSubprocesso
 import {useNotification} from "@/composables/useNotification";
 import {useToastStore} from "@/stores/toast";
 import type {AcaoBlocoProcesso, Processo, SubprocessoElegivel} from "@/types/tipos";
-import {SituacaoProcesso, SituacaoSubprocesso} from "@/types/tipos";
 import {formatSituacaoSubprocesso} from "@/utils/formatters";
 import {logger} from "@/utils";
 import {normalizeError, type NormalizedError} from "@/utils/apiError";
 import * as processoService from "@/services/processoService";
 import {TEXTOS} from "@/constants/textos";
 
-type LinhaParticipante = {
-  clickable?: boolean;
-  sigla?: string;
-  situacaoSubprocesso?: SituacaoSubprocesso;
-  situacao?: SituacaoSubprocesso;
-  unidadeCodigo: number;
-  unidadeSigla: string;
-  unidadeNome: string;
-  ultimaDataLimite?: string;
-  localizacaoCodigo?: number;
-};
 type ModalAcaoBlocoRef = {
   abrir: () => void;
   fechar: () => void;
@@ -175,10 +163,6 @@ const participantesHierarquia = computed(() => processo.value?.unidades || []);
 
 const podeFinalizar = computed(() => {
   return processo.value?.podeFinalizar || false;
-});
-
-const isProcessoFinalizado = computed(() => {
-  return processo.value?.situacao === SituacaoProcesso.FINALIZADO;
 });
 
 const acoesBlocoVisiveis = computed(() => (processo.value?.acoesBloco ?? []).filter(acao => acao.mostrar));

--- a/frontend/src/views/RelatoriosView.vue
+++ b/frontend/src/views/RelatoriosView.vue
@@ -93,7 +93,6 @@ import {BButton, BCard, BCol, BFormGroup, BFormSelect, BRow, BSpinner, BTab, BTa
 import LayoutPadrao from "@/components/layout/LayoutPadrao.vue";
 import PageHeader from "@/components/layout/PageHeader.vue";
 import EmptyState from "@/components/comum/EmptyState.vue";
-import {usePerfil} from "@/composables/usePerfil";
 import {usePerfilStore} from "@/stores/perfil";
 import {useNotification} from "@/composables/useNotification";
 import {useRelatorios} from "@/composables/api/useRelatorios";
@@ -101,7 +100,6 @@ import {TEXTOS} from "@/constants/textos";
 import * as painelService from "@/services/painelService";
 import type {ProcessoResumo} from "@/types/tipos";
 
-const perfil = usePerfil();
 const perfilStore = usePerfilStore();
 const { notify } = useNotification();
 const { obterRelatorioAndamento, downloadRelatorioAndamentoPdf, downloadRelatorioMapasPdf } = useRelatorios();

--- a/frontend/src/views/__tests__/UnidadeView.spec.ts
+++ b/frontend/src/views/__tests__/UnidadeView.spec.ts
@@ -96,6 +96,7 @@ describe('UnidadeView.vue', () => {
                 {
                     perfil: {
                         perfilSelecionado: 'USER',
+                        permissoesSessao: {mostrarCriarAtribuicaoTemporaria: false},
                     },
                     ...initialStateOverride
                 },
@@ -154,10 +155,12 @@ describe('UnidadeView.vue', () => {
         const {wrapper, perfilStore} = createWrapper();
         await flushPromises();
         perfilStore.perfilSelecionado = 'ADMIN';
+        perfilStore.permissoesSessao = {mostrarCriarAtribuicaoTemporaria: true};
         await wrapper.vm.$nextTick();
         expect(wrapper.find('[data-testid="unidade-view__btn-criar-atribuicao"]').exists()).toBe(true);
 
         perfilStore.perfilSelecionado = 'USER';
+        perfilStore.permissoesSessao = {mostrarCriarAtribuicaoTemporaria: false};
         await wrapper.vm.$nextTick();
         expect(wrapper.find('[data-testid="unidade-view__btn-criar-atribuicao"]').exists()).toBe(false);
     });
@@ -166,6 +169,7 @@ describe('UnidadeView.vue', () => {
         const {wrapper, perfilStore} = createWrapper();
         await flushPromises();
         perfilStore.perfilSelecionado = 'ADMIN';
+        perfilStore.permissoesSessao = {mostrarCriarAtribuicaoTemporaria: true};
         await wrapper.vm.$nextTick();
 
         await wrapper.find('[data-testid="unidade-view__btn-criar-atribuicao"]').trigger('click');


### PR DESCRIPTION
### Motivation

- Centralize and simplify the logic that prepares and validates the context when starting a `Processo`, and make related validations explicit and reusable.
- Make breadcrumb rendering deterministic when unit sigla is not loaded and surface session-level permission flags to control UI visibility.
- Improve robustness and maintainability of several UI flows (user search/timeouts, mapa/cadastro flows) by extracting helpers and removing fragile inline logic.
- Remove unused variables and tidy up small backend/frontend inconsistencies for clearer code paths.

### Description

- Backend: refactored `ProcessoService` to extract `resolverContextoInicio`, `validarCodigosRevisao`, `validarCodigosParticipantes`, `obterDataLimiteObrigatoria`, `buscarTitularObrigatorio` and introduced the `ContextoInicioProcesso` record, simplifying `iniciar` and centralizing validations; refactored `processarAcoesBlocoAceiteHomologacao` to a `switch`-based implementation and added a compatibility overload; added small guards and helpers to `SubprocessoConsultaService` (input guards, renamed helper methods, moved logic into small functions and removed unused flags).
- Frontend: changed breadcrumb behavior in `useBreadcrumbs` to show an empty label when unit sigla is not loaded and started honoring `permissoesSessao` flags in various components; updated multiple views/components (`AtribuicaoTemporariaView`, `MapaView`, `CadastroView`, `MapaVisualizacaoView`, `AtividadeItem.vue`, etc.) to extract helper functions, improve null checks, manage timeouts and form reset logic, and compute access flags more safely; removed unused imports/variables.
- Tests and fixtures: updated unit tests and test setups to match permission-driven UI changes and the breadcrumb fallback behavior (`BarraNavegacao.spec.ts`, `PainelView.spec.ts`, `useBreadcrumbs.spec.ts`, `UnidadeView.spec.ts`, and others), and adjusted initial state stubs and mocks accordingly.

### Testing

- Ran backend unit tests (`mvn test`) covering modified services and they completed successfully.
- Ran frontend unit tests with `vitest` and the updated specs including `BarraNavegacao.spec.ts`, `PainelView.spec.ts`, `useBreadcrumbs.spec.ts`, and `UnidadeView.spec.ts` passed.
- No automated integration/end-to-end tests were modified in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d82d1a1884832b84afbdcf196d6dfd)