### PR TITLE
Refactor processo/subprocesso startup and permission logic; simplify frontend views

### DIFF
--- a/backend/src/main/java/sgc/processo/service/ProcessoService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoService.java
@@ -245,16 +245,14 @@ public class ProcessoService {
                 ? unidadeService.buscarMapasPorUnidades(contexto.codigosUnidades())
                 : List.of();
 
-        Unidade admin = unidadeService.buscarAdmin();
-        efetivarInicioSubprocessos(
+        efetivarInicioSubprocessos(new InicioSubprocessosContexto(
                 processo,
                 contexto.tipo(),
                 contexto.codigosUnidades(),
                 contexto.unidadesParaProcessar(),
                 unidadesMapas,
-                admin,
-                usuario
-        );
+                unidadeService.buscarAdmin()
+        ));
 
         processo.setSituacao(EM_ANDAMENTO);
         processoRepo.save(processo);
@@ -469,28 +467,49 @@ public class ProcessoService {
         return arvore;
     }
 
-    private void efetivarInicioSubprocessos(Processo processo, TipoProcesso tipo, List<Long> cods, Set<Unidade> pars, List<UnidadeMapa> ums, Unidade adm, Usuario user) {
-        Map<Long, UnidadeMapa> mapUm = ums.stream().collect(Collectors.toMap(UnidadeMapa::getUnidadeCodigoPersistido, m -> m));
-        Map<Long, Unidade> unidadesPorCodigo = pars.stream()
+    private void efetivarInicioSubprocessos(InicioSubprocessosContexto contexto) {
+        Map<Long, UnidadeMapa> mapUm = contexto.unidadesMapas().stream()
+                .collect(Collectors.toMap(UnidadeMapa::getUnidadeCodigoPersistido, mapa -> mapa));
+        Map<Long, Unidade> unidadesPorCodigo = contexto.unidadesParaProcessar().stream()
                 .collect(Collectors.toMap(Unidade::getCodigo, unidade -> unidade));
-        if (tipo == MAPEAMENTO) {
+        if (contexto.tipo() == MAPEAMENTO) {
             subprocessoService.criarParaMapeamento(new SubprocessoService.CriarSubprocessosMapeamentoCommand(
-                    processo, pars, adm));
-        } else if (tipo == REVISAO) {
-            cods.forEach(c -> subprocessoService.criarParaRevisao(new SubprocessoService.CriarSubprocessoComMapaCommand(
-                    processo,
-                    obterUnidadeObrigatoria(unidadesPorCodigo, c),
-                    obterUnidadeMapaObrigatorio(mapUm, c),
-                    adm
+                    contexto.processo(), contexto.unidadesParaProcessar(), contexto.unidadeAdmin()));
+        } else if (contexto.tipo() == REVISAO) {
+            contexto.codigosUnidades().forEach(codigoUnidade -> subprocessoService.criarParaRevisao(new SubprocessoService.CriarSubprocessoComMapaCommand(
+                    contexto.processo(),
+                    obterUnidadeObrigatoria(unidadesPorCodigo, codigoUnidade),
+                    obterUnidadeMapaObrigatorio(mapUm, codigoUnidade),
+                    contexto.unidadeAdmin()
             )));
-        } else if (tipo == DIAGNOSTICO) {
-            pars.forEach(u -> subprocessoService.criarParaDiagnostico(new SubprocessoService.CriarSubprocessoComMapaCommand(
-                    processo,
-                    u,
-                    obterUnidadeMapaObrigatorio(mapUm, u.getCodigo()),
-                    adm
+        } else if (contexto.tipo() == DIAGNOSTICO) {
+            contexto.unidadesParaProcessar().forEach(unidade -> subprocessoService.criarParaDiagnostico(new SubprocessoService.CriarSubprocessoComMapaCommand(
+                    contexto.processo(),
+                    unidade,
+                    obterUnidadeMapaObrigatorio(mapUm, unidade.getCodigo()),
+                    contexto.unidadeAdmin()
             )));
         }
+    }
+
+    @SuppressWarnings("unused")
+    private void efetivarInicioSubprocessos(
+            Processo processo,
+            TipoProcesso tipo,
+            List<Long> cods,
+            Set<Unidade> pars,
+            List<UnidadeMapa> ums,
+            Unidade adm,
+            Usuario user
+    ) {
+        efetivarInicioSubprocessos(new InicioSubprocessosContexto(
+                processo,
+                tipo,
+                cods,
+                pars,
+                ums,
+                adm
+        ));
     }
 
     private void montarHierarquiaNoDto(
@@ -839,23 +858,33 @@ public class ProcessoService {
         List<Long> validacao = separacao.getOrDefault(false, List.of());
 
         switch (req.acao()) {
-            case ACEITAR -> {
-                if (!cadastro.isEmpty()) {
-                    transicaoService.aceitarCadastroEmBloco(cadastro);
-                }
-                if (!validacao.isEmpty()) {
-                    transicaoService.aceitarValidacaoEmBloco(validacao);
-                }
-            }
-            case HOMOLOGAR -> {
-                if (!cadastro.isEmpty()) {
-                    transicaoService.homologarCadastroEmBloco(cadastro);
-                }
-                if (!validacao.isEmpty()) {
-                    transicaoService.homologarValidacaoEmBloco(validacao);
-                }
-            }
+            case ACEITAR -> executarTransicoesEmBloco(
+                    cadastro,
+                    validacao,
+                    transicaoService::aceitarCadastroEmBloco,
+                    transicaoService::aceitarValidacaoEmBloco
+            );
+            case HOMOLOGAR -> executarTransicoesEmBloco(
+                    cadastro,
+                    validacao,
+                    transicaoService::homologarCadastroEmBloco,
+                    transicaoService::homologarValidacaoEmBloco
+            );
             default -> log.debug("Ação em bloco {} sem processamento no fluxo de análise", req.acao());
+        }
+    }
+
+    private void executarTransicoesEmBloco(
+            List<Long> codigosCadastro,
+            List<Long> codigosValidacao,
+            java.util.function.Consumer<List<Long>> acaoCadastro,
+            java.util.function.Consumer<List<Long>> acaoValidacao
+    ) {
+        if (!codigosCadastro.isEmpty()) {
+            acaoCadastro.accept(codigosCadastro);
+        }
+        if (!codigosValidacao.isEmpty()) {
+            acaoValidacao.accept(codigosValidacao);
         }
     }
 
@@ -942,5 +971,14 @@ public class ProcessoService {
             TipoProcesso tipo,
             List<Long> codigosUnidades,
             Set<Unidade> unidadesParaProcessar
+    ) {}
+
+    private record InicioSubprocessosContexto(
+            Processo processo,
+            TipoProcesso tipo,
+            List<Long> codigosUnidades,
+            Set<Unidade> unidadesParaProcessar,
+            List<UnidadeMapa> unidadesMapas,
+            Unidade unidadeAdmin
     ) {}
 }

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoConsultaService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoConsultaService.java
@@ -303,20 +303,27 @@ public class SubprocessoConsultaService {
         }
 
         boolean cadastroDisponibilizado = verificarCadastroDisponibilizadoParaVisualizacao(contexto.situacao());
+        if (!cadastroDisponibilizado) {
+            return false;
+        }
+
         return switch (contexto.perfil()) {
-            case Perfil.ADMIN -> cadastroDisponibilizado;
-            case Perfil.GESTOR -> cadastroDisponibilizado && contexto.isUnidadeAlvoNaHierarquiaUsuario();
-            case Perfil.SERVIDOR -> cadastroDisponibilizado && contexto.isMesmaUnidadeAlvo();
+            case Perfil.ADMIN -> true;
+            case Perfil.GESTOR -> contexto.isUnidadeAlvoNaHierarquiaUsuario();
+            case Perfil.SERVIDOR -> contexto.isMesmaUnidadeAlvo();
             default -> false;
         };
     }
 
     private boolean verificarAcessoMapaHabilitado(ContextoConsultaSubprocesso contexto) {
         boolean mapaDisponibilizado = verificarMapaDisponibilizadoParaVisualizacao(contexto.situacao());
+        boolean mesmaHierarquia = contexto.isUnidadeAlvoNaHierarquiaUsuario();
+        boolean mesmaUnidadeAlvo = contexto.isMesmaUnidadeAlvo();
+
         return switch (contexto.perfil()) {
             case Perfil.ADMIN -> verificarMapaHabilitadoParaAdmin(contexto.situacao());
-            case Perfil.GESTOR -> mapaDisponibilizado && contexto.isUnidadeAlvoNaHierarquiaUsuario();
-            case Perfil.CHEFE, Perfil.SERVIDOR -> mapaDisponibilizado && contexto.isMesmaUnidadeAlvo();
+            case Perfil.GESTOR -> mapaDisponibilizado && mesmaHierarquia;
+            case Perfil.CHEFE, Perfil.SERVIDOR -> mapaDisponibilizado && mesmaUnidadeAlvo;
         };
     }
 
@@ -466,26 +473,36 @@ public class SubprocessoConsultaService {
     }
 
     private ContextoConsultaSubprocesso montarContextoConsulta(Subprocesso sp, List<Movimentacao> movimentacoes) {
-        ContextoUsuarioAutenticado contextoUsuario = obterContextoUsuarioAutenticado();
-        Unidade unidadeUsuario = unidadeService.buscarPorCodigoComSuperior(contextoUsuario.unidadeAtivaCodigo());
-        Unidade unidadeAlvo = sp.getUnidade();
-        Long unidadeAtivaCodigo = contextoUsuario.unidadeAtivaCodigo();
-        Unidade localizacaoAtual = resolverLocalizacaoAtual(sp, movimentacoes);
-        boolean processoFinalizado = processoFinalizado(sp);
+        DadosContextoConsulta dadosContexto = resolverDadosContexto(sp, movimentacoes);
+        Long unidadeAtivaCodigo = dadosContexto.unidadeAtivaCodigo();
+        Unidade unidadeAlvo = dadosContexto.unidadeAlvo();
         boolean mesmaUnidadeAlvo = Objects.equals(unidadeAtivaCodigo, unidadeAlvo.getCodigo());
-        boolean mesmaUnidade = mesmaUnidadeLocalizacao(unidadeAtivaCodigo, localizacaoAtual, processoFinalizado);
-        boolean unidadeAlvoNaHierarquiaUsuario = isUnidadeAlvoNaHierarquiaUsuario(unidadeAlvo, unidadeUsuario, mesmaUnidadeAlvo);
-        boolean temMapaVigente = temMapaVigente(unidadeAlvo.getCodigo(), processoFinalizado);
+        boolean mesmaUnidade = mesmaUnidadeLocalizacao(unidadeAtivaCodigo, dadosContexto.localizacaoAtual(), dadosContexto.processoFinalizado());
+        boolean unidadeAlvoNaHierarquiaUsuario = isUnidadeAlvoNaHierarquiaUsuario(unidadeAlvo, dadosContexto.unidadeUsuario(), mesmaUnidadeAlvo);
+        boolean temMapaVigente = temMapaVigente(unidadeAlvo.getCodigo(), dadosContexto.processoFinalizado());
 
         return new ContextoConsultaSubprocesso(
                 sp,
-                contextoUsuario.perfil(),
-                localizacaoAtual,
-                processoFinalizado,
+                dadosContexto.perfil(),
+                dadosContexto.localizacaoAtual(),
+                dadosContexto.processoFinalizado(),
                 mesmaUnidade,
                 mesmaUnidadeAlvo,
                 unidadeAlvoNaHierarquiaUsuario,
                 temMapaVigente
+        );
+    }
+
+    private DadosContextoConsulta resolverDadosContexto(Subprocesso sp, List<Movimentacao> movimentacoes) {
+        ContextoUsuarioAutenticado contextoUsuario = obterContextoUsuarioAutenticado();
+        Long unidadeAtivaCodigo = contextoUsuario.unidadeAtivaCodigo();
+        return new DadosContextoConsulta(
+                contextoUsuario.perfil(),
+                unidadeService.buscarPorCodigoComSuperior(unidadeAtivaCodigo),
+                sp.getUnidade(),
+                unidadeAtivaCodigo,
+                resolverLocalizacaoAtual(sp, movimentacoes),
+                processoFinalizado(sp)
         );
     }
 
@@ -511,10 +528,9 @@ public class SubprocessoConsultaService {
     }
 
     private Unidade resolverLocalizacaoAtual(Subprocesso sp, List<Movimentacao> movimentacoes) {
-        if (!movimentacoes.isEmpty()) {
-            return movimentacoes.getFirst().getUnidadeDestino();
-        }
-        return localizacaoSubprocessoService.obterLocalizacaoAtual(sp);
+        return movimentacoes.isEmpty()
+                ? localizacaoSubprocessoService.obterLocalizacaoAtual(sp)
+                : movimentacoes.getFirst().getUnidadeDestino();
     }
 
     private PermissoesSubprocessoDto resolverPermissoes(ContextoConsultaSubprocesso contexto) {
@@ -567,6 +583,15 @@ public class SubprocessoConsultaService {
             return isGestor() || isAdmin();
         }
     }
+
+    private record DadosContextoConsulta(
+            Perfil perfil,
+            Unidade unidadeUsuario,
+            Unidade unidadeAlvo,
+            Long unidadeAtivaCodigo,
+            Unidade localizacaoAtual,
+            boolean processoFinalizado
+    ) {}
 
     private record PermissoesFluxo(
             boolean podeEditarCadastro,

--- a/frontend/src/views/AtribuicaoTemporariaView.vue
+++ b/frontend/src/views/AtribuicaoTemporariaView.vue
@@ -198,6 +198,14 @@ let timeoutOcultarResultadosUsuarios: ReturnType<typeof setTimeout> | null = nul
 const erroUsuario = ref("");
 const validacaoSubmetida = ref(false);
 const termoPesquisaMinimaAtingida = computed(() => termoUsuario.value.trim().length >= 2);
+const formularioValido = computed(() => {
+  return Boolean(
+      usuarioSelecionado.value
+      && dataInicio.value
+      && dataTermino.value
+      && justificativa.value.trim()
+  );
+});
 
 watch(usuariosEncontrados, (usuarios) => {
   indiceUsuarioDestacado.value = usuarios.length > 0 ? 0 : -1;
@@ -239,19 +247,17 @@ onBeforeUnmount(() => {
 
 function aoAlterarTermoUsuario(valor: string | number | null) {
   termoUsuario.value = valor == null ? "" : String(valor);
-  mostrarResultadosUsuarios.value = termoPesquisaMinimaAtingida.value;
+  mostrarResultadosUsuarios.value = podeExibirResultadosPesquisa();
   indiceUsuarioDestacado.value = -1;
   atualizarUsuarioSelecionadoPorNome(termoUsuario.value);
-  limparTimeoutPesquisaUsuarios();
+  cancelarPesquisaUsuariosPendente();
 
-  if (!termoPesquisaMinimaAtingida.value || !termoUsuario.value.trim()) {
+  if (!devePesquisarUsuarios()) {
     limparResultadosPesquisaUsuarios();
     return;
   }
 
-  timeoutPesquisaUsuarios = setTimeout(async () => {
-    await executarPesquisaUsuarios();
-  }, 300);
+  agendarPesquisaUsuarios();
 }
 
 function atualizarUsuarioSelecionadoPorNome(nome: string) {
@@ -284,33 +290,32 @@ async function destacarUsuario(indice: number) {
 }
 
 async function aoPressionarTeclaUsuario(evento: KeyboardEvent) {
-  if (!mostrarResultadosUsuarios.value || usuariosEncontrados.value.length === 0) {
+  if (!podeNavegarResultadosUsuarios()) {
     if (evento.key === "ArrowDown" && termoPesquisaMinimaAtingida.value) {
       mostrarResultadosUsuarios.value = true;
     }
     return;
   }
 
-  if (evento.key === "ArrowDown") {
-    evento.preventDefault();
-    await destacarUsuario(calcularProximoIndice(1));
-    return;
-  }
-
-  if (evento.key === "ArrowUp") {
-    evento.preventDefault();
-    await destacarUsuario(calcularProximoIndice(-1));
-    return;
-  }
-
-  if (evento.key === "Enter" && indiceUsuarioDestacado.value >= 0) {
-    evento.preventDefault();
-    selecionarUsuario(usuariosEncontrados.value[indiceUsuarioDestacado.value]!);
-    return;
-  }
-
-  if (evento.key === "Escape") {
-    ocultarResultadosUsuarios();
+  switch (evento.key) {
+    case "ArrowDown":
+      evento.preventDefault();
+      await destacarUsuario(calcularProximoIndice(1));
+      return;
+    case "ArrowUp":
+      evento.preventDefault();
+      await destacarUsuario(calcularProximoIndice(-1));
+      return;
+    case "Enter":
+      if (indiceUsuarioDestacado.value < 0) return;
+      evento.preventDefault();
+      selecionarUsuario(usuariosEncontrados.value[indiceUsuarioDestacado.value]!);
+      return;
+    case "Escape":
+      ocultarResultadosUsuarios();
+      return;
+    default:
+      return;
   }
 }
 
@@ -320,7 +325,13 @@ async function criarAtribuicao() {
   validacaoSubmetida.value = true;
   erroUsuario.value = "";
 
-  if (!usuarioSelecionado.value || !dataInicio.value || !dataTermino.value || !justificativa.value.trim()) {
+  if (!formularioValido.value) {
+    notify(TEXTOS.atribuicaoTemporaria.ERRO_PREENCHIMENTO, 'danger');
+    return;
+  }
+
+  const tituloEleitoralUsuario = usuarioSelecionado.value;
+  if (!tituloEleitoralUsuario) {
     notify(TEXTOS.atribuicaoTemporaria.ERRO_PREENCHIMENTO, 'danger');
     return;
   }
@@ -329,7 +340,7 @@ async function criarAtribuicao() {
 
   try {
     await criarAtribuicaoTemporaria(unidadeAtual.codigo, {
-      tituloEleitoralUsuario: usuarioSelecionado.value,
+      tituloEleitoralUsuario,
       dataInicio: dataInicio.value,
       dataTermino: dataTermino.value,
       justificativa: justificativa.value
@@ -350,6 +361,10 @@ function limparTimeoutPesquisaUsuarios() {
     clearTimeout(timeoutPesquisaUsuarios);
     timeoutPesquisaUsuarios = null;
   }
+}
+
+function cancelarPesquisaUsuariosPendente() {
+  limparTimeoutPesquisaUsuarios();
 }
 
 function limparTimeoutOcultarResultadosUsuarios() {
@@ -373,6 +388,24 @@ function limparResultadosPesquisaUsuarios() {
   usuariosEncontrados.value = [];
   pesquisandoUsuarios.value = false;
   ocultarResultadosUsuarios();
+}
+
+function agendarPesquisaUsuarios() {
+  timeoutPesquisaUsuarios = setTimeout(async () => {
+    await executarPesquisaUsuarios();
+  }, 300);
+}
+
+function devePesquisarUsuarios() {
+  return termoPesquisaMinimaAtingida.value && Boolean(termoUsuario.value.trim());
+}
+
+function podeExibirResultadosPesquisa() {
+  return termoPesquisaMinimaAtingida.value;
+}
+
+function podeNavegarResultadosUsuarios() {
+  return mostrarResultadosUsuarios.value && usuariosEncontrados.value.length > 0;
 }
 
 async function executarPesquisaUsuarios() {

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -185,6 +185,14 @@ async function carregarContextoEdicao(codigo: number) {
   return data;
 }
 
+async function executarComSubprocesso(
+    callback: (codigoSubprocesso: number) => Promise<void>
+) {
+  const codigoSubprocesso = codSubprocesso.value;
+  if (!codigoSubprocesso) return;
+  await callback(codigoSubprocesso);
+}
+
 function sincronizarMapa(mapaAtualizado: MapaCompleto | null | undefined) {
   if (mapaAtualizado) {
     mapasStore.mapaCompleto.value = mapaAtualizado;
@@ -213,18 +221,19 @@ onMounted(async () => {
 const atividades = ref<Atividade[]>([]);
 
 const competencias = computed(() => mapaCompleto.value?.competencias || []);
+const codigosAtividadesAssociadas = computed(() => {
+  return new Set(
+      competencias.value.flatMap((competencia) =>
+          (competencia.atividades || []).map((atividade) => atividade.codigo)
+      )
+  );
+});
 const atividadesSemCompetencia = computed(() => {
   if (atividades.value.length === 0) {
     return [];
   }
 
-  const atividadesAssociadas = new Set(
-      competencias.value.flatMap((competencia) =>
-          (competencia.atividades || []).map((atividade) => atividade.codigo)
-      )
-  );
-
-  return atividades.value.filter((atividade) => !atividadesAssociadas.has(atividade.codigo));
+  return atividades.value.filter((atividade) => !codigosAtividadesAssociadas.value.has(atividade.codigo));
 });
 
 const existeCompetenciaSemAtividade = computed(() => {
@@ -293,25 +302,25 @@ function abrirModalDisponibilizar() {
 }
 
 async function adicionarCompetenciaEFecharModal(dados: { descricao: string; atividadesSelecionadas: number[] }) {
-  const codigoSubprocesso = codSubprocesso.value;
-  if (!codigoSubprocesso) return;
-  const request: SalvarCompetenciaRequest = {
-    descricao: dados.descricao,
-    atividadesIds: dados.atividadesSelecionadas,
-  };
+  await executarComSubprocesso(async (codigoSubprocesso) => {
+    const request: SalvarCompetenciaRequest = {
+      descricao: dados.descricao,
+      atividadesIds: dados.atividadesSelecionadas,
+    };
 
-  try {
-    if (competenciaSendoEditada.value) {
-      sincronizarMapa(await fluxoMapa.atualizarCompetencia(codigoSubprocesso, competenciaSendoEditada.value.codigo, request));
-    } else {
-      sincronizarMapa(await fluxoMapa.adicionarCompetencia(codigoSubprocesso, request));
+    try {
+      if (competenciaSendoEditada.value) {
+        sincronizarMapa(await fluxoMapa.atualizarCompetencia(codigoSubprocesso, competenciaSendoEditada.value.codigo, request));
+      } else {
+        sincronizarMapa(await fluxoMapa.adicionarCompetencia(codigoSubprocesso, request));
+      }
+
+      await carregarContextoEdicao(codigoSubprocesso);
+      fecharModalCriarNovaCompetencia();
+    } catch {
+      handleErrors(fluxoMapa);
     }
-
-    await carregarContextoEdicao(codigoSubprocesso);
-    fecharModalCriarNovaCompetencia();
-  } catch {
-    handleErrors(fluxoMapa);
-  }
+  });
 }
 
 function excluirCompetencia(codigo: number) {
@@ -324,19 +333,20 @@ function excluirCompetencia(codigo: number) {
 
 async function confirmarExclusaoCompetencia() {
   const competencia = competenciaParaExcluir.value;
-  const codigoSubprocesso = codSubprocesso.value;
-  if (!competencia || !codigoSubprocesso) return;
+  if (!competencia) return;
 
-  loadingExclusao.value = true;
-  try {
-    sincronizarMapa(await fluxoMapa.removerCompetencia(codigoSubprocesso, competencia.codigo));
-    await carregarContextoEdicao(codigoSubprocesso);
-    fecharModalExcluirCompetencia();
-  } catch {
-    handleErrors(fluxoMapa);
-  } finally {
-    loadingExclusao.value = false;
-  }
+  await executarComSubprocesso(async (codigoSubprocesso) => {
+    loadingExclusao.value = true;
+    try {
+      sincronizarMapa(await fluxoMapa.removerCompetencia(codigoSubprocesso, competencia.codigo));
+      await carregarContextoEdicao(codigoSubprocesso);
+      fecharModalExcluirCompetencia();
+    } catch {
+      handleErrors(fluxoMapa);
+    } finally {
+      loadingExclusao.value = false;
+    }
+  });
 }
 
 function fecharModalExcluirCompetencia() {
@@ -345,42 +355,41 @@ function fecharModalExcluirCompetencia() {
 }
 
 async function removerAtividadeAssociada(competenciaId: number, codAtividade: number) {
-  const codigoSubprocesso = codSubprocesso.value;
-  if (!codigoSubprocesso) return;
-  const competencia = competencias.value.find(
-      (comp) => comp.codigo === competenciaId,
-  );
+  const competencia = competencias.value.find((comp) => comp.codigo === competenciaId);
   if (!competencia) return;
 
-  const atividadesIds = (competencia.atividades || []).map((a) => a.codigo).filter((id) => id !== codAtividade);
-  const request: SalvarCompetenciaRequest = {
-    descricao: competencia.descricao,
-    atividadesIds: atividadesIds,
-  };
+  await executarComSubprocesso(async (codigoSubprocesso) => {
+    const atividadesIds = (competencia.atividades || []).map((atividade) => atividade.codigo)
+        .filter((codigoAtividade) => codigoAtividade !== codAtividade);
+    const request: SalvarCompetenciaRequest = {
+      descricao: competencia.descricao,
+      atividadesIds: atividadesIds,
+    };
 
-  sincronizarMapa(await fluxoMapa.atualizarCompetencia(
-      codigoSubprocesso,
-      competencia.codigo,
-      request,
-  ));
+    sincronizarMapa(await fluxoMapa.atualizarCompetencia(
+        codigoSubprocesso,
+        competencia.codigo,
+        request,
+    ));
+  });
 }
 
 async function disponibilizarMapa(payload: { dataLimite: string; observacoes: string }) {
-  const codigoSubprocesso = codSubprocesso.value;
-  if (!codigoSubprocesso) return;
-  fluxoMapa.clearError();
-  loadingDisponibilizacao.value = true;
+  await executarComSubprocesso(async (codigoSubprocesso) => {
+    fluxoMapa.clearError();
+    loadingDisponibilizacao.value = true;
 
-  try {
-    await fluxoMapa.disponibilizarMapa(codigoSubprocesso, payload);
-    fecharModalDisponibilizar();
-    toastStore.setPending(TEXTOS.sucesso.MAPA_DISPONIBILIZADO);
-    await router.push({name: "Painel"});
-  } catch {
-    handleErrors(fluxoMapa);
-  } finally {
-    loadingDisponibilizacao.value = false;
-  }
+    try {
+      await fluxoMapa.disponibilizarMapa(codigoSubprocesso, payload);
+      fecharModalDisponibilizar();
+      toastStore.setPending(TEXTOS.sucesso.MAPA_DISPONIBILIZADO);
+      await router.push({name: "Painel"});
+    } catch {
+      handleErrors(fluxoMapa);
+    } finally {
+      loadingDisponibilizacao.value = false;
+    }
+  });
 }
 
 function fecharModalDisponibilizar() {

--- a/plano-simplificacao.md
+++ b/plano-simplificacao.md
@@ -258,6 +258,60 @@ O frontend de produção não está crítico por tipagem (`any` em produção ze
 * `./gradlew :backend:jacocoTestReport`
 * `node etc/scripts/sgc.js backend cobertura complexidade`
 
+---
+
+## Progresso executado em 10/04/2026
+
+### Rodada A — `ProcessoService` (P1)
+
+* aplicado recorte de contexto para início de subprocessos via `InicioSubprocessosContexto`, removendo assinatura com muitos parâmetros no miolo do fluxo e deixando o ponto de entrada do caso de uso mais linear;
+* reduzida duplicação no processamento de ações em bloco (`ACEITAR`/`HOMOLOGAR`) com função única de aplicação condicional de transições;
+* mantido contrato funcional (mesmas chamadas para `SubprocessoService` e `SubprocessoTransicaoService`, sem alteração de DTO externo ou regras de permissão).
+
+**Aprendizados desta rodada**
+
+* extrações locais com `record` privado funcionam bem para reduzir carga cognitiva sem introduzir camada nova;
+* trechos de switch com ramos espelhados dão ganho rápido de legibilidade quando isolamos apenas a variação (qual transição chamar), preservando o fluxo principal.
+
+### Rodada B — `MapaView.vue` (P1)
+
+* consolidado padrão repetido de guarda de `codSubprocesso` em um executor único (`executarComSubprocesso`) para operações assíncronas da tela;
+* extraído cálculo derivado de atividades associadas para `computed` dedicado, reduzindo reconstrução incidental no fluxo de filtragem;
+* mantido comportamento de erro (`handleErrors`), atualização de mapa e navegação pós-disponibilização.
+
+**Aprendizados desta rodada**
+
+* a maior fonte de complexidade da view estava na repetição de pré-condições e não em regra de negócio;
+* pequenos utilitários locais no `<script setup>` trazem simplificação mensurável sem mover lógica para composables genéricos.
+
+### Próximos passos recomendados (mantendo backlog original)
+
+1. avançar em `SubprocessoConsultaService` (P1), com pipeline interno explícito de contexto/permissão/resposta;
+2. executar rodada dedicada em `AtribuicaoTemporariaView.vue` (P2) para separar estado transitório de regras de habilitação;
+3. rodar nova coleta (`qa dashboard` + complexidade backend) ao fim da próxima onda para comparar tendência com o snapshot de 09/04/2026.
+
+### Rodada C — `SubprocessoConsultaService` (P1)
+
+* iniciado pipeline interno de contexto com `DadosContextoConsulta`, reduzindo acoplamento no método `montarContextoConsulta`;
+* simplificadas verificações de acesso de cadastro/mapa com early return para estados indisponíveis, mantendo as mesmas regras de perfil;
+* padronizada resolução de localização atual por expressão única, reduzindo branch incidental.
+
+**Aprendizados desta rodada**
+
+* o maior ganho de legibilidade veio da separação entre “coleta de dados do contexto” e “cálculo de permissões”;
+* early return nas verificações de acesso elimina combinações redundantes sem alterar política de autorização.
+
+### Rodada D — `AtribuicaoTemporariaView.vue` (P2)
+
+* consolidada validação de submissão em `computed` único (`formularioValido`), removendo condição longa repetida no submit;
+* padronizado fluxo de pesquisa incremental de usuários com funções de intenção (`devePesquisarUsuarios`, `agendarPesquisaUsuarios`, `cancelarPesquisaUsuariosPendente`);
+* simplificada navegação por teclado da busca com `switch` e guarda única para cenário sem resultados.
+
+**Aprendizados desta rodada**
+
+* no front, a redução de complexidade veio mais de nomear intenções de fluxo do que de extrair composables;
+* helpers pequenos para “estado de pesquisa” diminuem risco de drift entre eventos de input, blur e teclado.
+
 ### Frontend
 
 * `npm run typecheck`


### PR DESCRIPTION
### Motivation

- Reduce cognitive load and parameter bloat when starting subprocesses by encapsulating inputs in a context object and centralizing the creation logic.
- Remove duplicated branching for bulk transitions and permission checks to improve readability and maintainability.
- Simplify front-end view flows to centralize precondition checks, schedule/cancel async searches, and avoid repeated guards for `codSubprocesso`.

### Description

- Introduced `InicioSubprocessosContexto` record and updated `ProcessoService.efetivarInicioSubprocessos` to accept the context, keeping a backward-compatible wrapper and preserving existing `SubprocessoService` calls. 
- Added `executarTransicoesEmBloco` to consolidate duplicated logic for `ACEITAR`/`HOMOLOGAR` bulk transitions and replaced duplicated branches with calls to this helper. 
- In `SubprocessoConsultaService` extracted `DadosContextoConsulta` and `resolverDadosContexto` to centralize context collection, simplified several permission checks with early returns, and normalized `resolverLocalizacaoAtual` logic.
- In `AtribuicaoTemporariaView.vue` added `formularioValido` computed, refactored user-search flow into intent-named helpers (`devePesquisarUsuarios`, `agendarPesquisaUsuarios`, `cancelarPesquisaUsuariosPendente`, `podeNavegarResultadosUsuarios`), and simplified keyboard navigation with a `switch` statement.
- In `MapaView.vue` added `executarComSubprocesso` helper to guard/centralize `codSubprocesso` usage, extracted `codigosAtividadesAssociadas` computed and refactored multiple map-related async operations to use the helper for clearer control flow.
- Updated `plano-simplificacao.md` with progress notes documenting the refactor rounds and rationale.

### Testing

- Ran backend checks `./gradlew :backend:compileTestJava` and `./gradlew :backend:test` and they passed. 
- Generated coverage with `./gradlew :backend:jacocoTestReport` and ran complexity tooling via `node etc/scripts/sgc.js backend cobertura complexidade` without failures. 
- Ran frontend static checks and tests with `npm run typecheck`, `npm run lint`, and `npm run test:unit`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d6490378832b8b25548a63653018)