### PR TITLE
Correção do bug da issue 1503

### DIFF
--- a/backend/src/main/java/sgc/processo/service/ProcessoService.java
+++ b/backend/src/main/java/sgc/processo/service/ProcessoService.java
@@ -980,7 +980,30 @@ public class ProcessoService {
         if (codsUnidadesParam.isEmpty()) {
             throw new ErroValidacao(Mensagens.LISTA_UNIDADES_OBRIGATORIA_REVISAO);
         }
-        return codsUnidadesParam;
+        // Em revisão, se vierem pai e filho juntos, mantemos apenas os mais específicos (folhas selecionadas).
+        // Isso evita criar subprocessos redundantes em unidades ancestrais que não deveriam participar da execução.
+        Map<Long, Long> mapaFilhoPai = unidadeHierarquiaService.buscarMapaFilhoPai();
+        return removerAncestraisRedundantesRevisao(codsUnidadesParam, mapaFilhoPai);
+    }
+
+    private List<Long> removerAncestraisRedundantesRevisao(List<Long> codigosSelecionados, Map<Long, Long> mapaFilhoPai) {
+        LinkedHashSet<Long> codigosUnicos = new LinkedHashSet<>(codigosSelecionados);
+        Set<Long> codigosParaRemover = new HashSet<>();
+
+        for (Long codigoSelecionado : codigosUnicos) {
+            // Navega pelo mapa filho->pai já carregado para evitar múltiplas leituras de hierarquia.
+            Long codigoSuperior = mapaFilhoPai.get(codigoSelecionado);
+            while (codigoSuperior != null) {
+                if (codigosUnicos.contains(codigoSuperior)) {
+                    codigosParaRemover.add(codigoSuperior);
+                }
+                codigoSuperior = mapaFilhoPai.get(codigoSuperior);
+            }
+        }
+
+        return codigosUnicos.stream()
+                .filter(codigo -> !codigosParaRemover.contains(codigo))
+                .toList();
     }
 
     private List<Long> validarCodigosParticipantes(List<Long> codigosParticipantes) {

--- a/backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java
+++ b/backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java
@@ -212,6 +212,44 @@ class ProcessoServiceTest {
         }
 
         @Test
+        @DisplayName("Deve iniciar revisao ignorando unidade ancestral selecionada junto com a descendente")
+        void deveIniciarRevisaoIgnorandoAncestralRedundante() {
+            Long id = 101L;
+            Usuario usuario = new Usuario();
+            when(usuarioService.usuarioAutenticado()).thenReturn(usuario);
+
+            Processo processo = new Processo();
+            processo.setCodigo(id);
+            processo.setSituacao(SituacaoProcesso.CRIADO);
+            processo.setTipo(TipoProcesso.REVISAO);
+
+            Unidade unidadePai = criarUnidadeValida(10L);
+            Unidade unidadeFilha = criarUnidadeValida(20L);
+            processo.adicionarParticipantes(Set.of(unidadePai, unidadeFilha));
+
+            when(repo.buscar(Processo.class, id)).thenReturn(processo);
+            when(unidadeHierarquiaService.buscarMapaFilhoPai()).thenReturn(Map.of(20L, 10L));
+            when(unidadeHierarquiaService.buscarCodigosSuperiores(20L)).thenReturn(List.of(10L));
+            when(unidadeService.buscarPorCodigos(List.of(20L))).thenReturn(List.of(unidadeFilha));
+            when(unidadeService.buscarTodosCodigosUnidadesComMapa()).thenReturn(List.of(20L));
+            when(unidadeService.buscarMapasPorUnidades(List.of(20L))).thenReturn(List.of(
+                    UnidadeMapa.builder().unidadeCodigo(20L).build()
+            ));
+            when(unidadeService.buscarPorCodigos(List.of(10L))).thenReturn(List.of(unidadePai));
+            Unidade admin = criarUnidadeValida(999L);
+            when(unidadeService.buscarAdmin()).thenReturn(admin);
+            mockarResponsaveisEfetivos();
+
+            processoService.iniciar(id, List.of(10L, 20L));
+
+            verify(subprocessoService, times(1)).criarParaRevisao(any());
+            verify(subprocessoService).criarParaRevisao(argThat(command ->
+                    command.processo() == processo
+                            && command.unidade().getCodigo().equals(20L)
+            ));
+        }
+
+        @Test
         @DisplayName("Deve falhar ao iniciar processo se houver unidades em processo ativo")
         void deveFalharAoIniciarSeHouverUnidadesEmProcessoAtivo() {
             Long id = 100L;


### PR DESCRIPTION
## Contexto

Correção do **#1503**: em processos de **Revisão** com fluxo de “Disponibilizar sem mudanças”, o botão **Finalizar** não aparecia ao final porque existia subprocesso redundante em unidade ancestral (ex.: SECRETARIA) ficando em `NAO_INICIADO`.

## Causa raiz

No início da Revisão, quando a seleção vinha com unidade **pai e filha** ao mesmo tempo (ex.: `SECRETARIA_1` e `ASSESSORIA_12`), o backend criava subprocessos para ambas.  
Com isso, mesmo após a homologação da unidade alvo, o processo não atendia ao critério “todos homologados” para finalização.

## O que foi alterado

1. **Normalização de unidades na inicialização da Revisão**
   - Em `validarCodigosRevisao`, os códigos selecionados agora passam por uma etapa que remove ancestrais redundantes.
   - Regra: se pai e filho vierem juntos, mantém apenas a unidade mais específica (filha).
   - **Desempenho (crítico):** a montagem foi feita com **uma única carga da hierarquia** (`buscarMapaFilhoPai`) e processamento em memória, evitando múltiplas chamadas graduais às views hierárquicas.
   - Arquivo:
     - `backend/src/main/java/sgc/processo/service/ProcessoService.java`

2. **Teste unitário de proteção contra regressão**
   - Novo teste cobrindo o cenário de seleção com pai+filho e validando que apenas a unidade filha gera subprocesso de revisão.
   - Arquivo:
     - `backend/src/test/java/sgc/processo/service/ProcessoServiceTest.java`

## Resultado esperado

- Processo de Revisão iniciado sem subprocessos redundantes de unidades ancestrais.
- No fim do fluxo (mapa homologado), o botão **Finalizar** volta a aparecer corretamente quando todas as unidades efetivamente participantes concluírem.
