### PR TITLE
test(backend): add test classes for uncovered DTOs and models

### DIFF
--- a/backend/src/test/java/sgc/mapa/dto/AtualizarMapaRequestTest.java
+++ b/backend/src/test/java/sgc/mapa/dto/AtualizarMapaRequestTest.java
@@ -1,0 +1,28 @@
+package sgc.mapa.dto;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AtualizarMapaRequestTest {
+
+    @Test
+    void deveConverterParaCommand() {
+        var dataDisp = LocalDateTime.of(2023, 1, 1, 10, 0);
+        var dataHomol = LocalDateTime.of(2023, 1, 2, 10, 0);
+
+        var request = AtualizarMapaRequest.builder()
+                .dataHoraDisponibilizado(dataDisp)
+                .observacoesDisponibilizacao("obs")
+                .sugestoes("sugestoes")
+                .dataHoraHomologado(dataHomol)
+                .build();
+
+        var command = request.paraCommand();
+
+        assertThat(command.dataHoraDisponibilizado()).isEqualTo(dataDisp);
+        assertThat(command.observacoesDisponibilizacao()).isEqualTo("obs");
+        assertThat(command.sugestoes()).isEqualTo("sugestoes");
+        assertThat(command.dataHoraHomologado()).isEqualTo(dataHomol);
+    }
+}

--- a/backend/src/test/java/sgc/mapa/dto/CriarMapaRequestTest.java
+++ b/backend/src/test/java/sgc/mapa/dto/CriarMapaRequestTest.java
@@ -1,0 +1,31 @@
+package sgc.mapa.dto;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CriarMapaRequestTest {
+
+    @Test
+    void deveConverterParaCommand() {
+        var dataDisp = LocalDateTime.of(2023, 1, 1, 10, 0);
+        var dataHomol = LocalDateTime.of(2023, 1, 2, 10, 0);
+
+        var request = CriarMapaRequest.builder()
+                .subprocessoCodigo(100L)
+                .dataHoraDisponibilizado(dataDisp)
+                .observacoesDisponibilizacao("obs")
+                .sugestoes("sugestoes")
+                .dataHoraHomologado(dataHomol)
+                .build();
+
+        var command = request.paraCommand();
+
+        assertThat(command.subprocessoCodigo()).isEqualTo(100L);
+        assertThat(command.estadoInicial()).isNotNull();
+        assertThat(command.estadoInicial().dataHoraDisponibilizado()).isEqualTo(dataDisp);
+        assertThat(command.estadoInicial().observacoesDisponibilizacao()).isEqualTo("obs");
+        assertThat(command.estadoInicial().sugestoes()).isEqualTo("sugestoes");
+        assertThat(command.estadoInicial().dataHoraHomologado()).isEqualTo(dataHomol);
+    }
+}

--- a/backend/src/test/java/sgc/organizacao/dto/DiagnosticoOrganizacionalDtoTest.java
+++ b/backend/src/test/java/sgc/organizacao/dto/DiagnosticoOrganizacionalDtoTest.java
@@ -1,0 +1,18 @@
+package sgc.organizacao.dto;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DiagnosticoOrganizacionalDtoTest {
+
+    @Test
+    void deveCriarDiagnosticoSemViolacoes() {
+        var diagnostico = DiagnosticoOrganizacionalDto.semViolacoes();
+
+        assertThat(diagnostico.possuiViolacoes()).isFalse();
+        assertThat(diagnostico.resumo()).isEmpty();
+        assertThat(diagnostico.quantidadeTiposViolacao()).isZero();
+        assertThat(diagnostico.quantidadeOcorrencias()).isZero();
+        assertThat(diagnostico.grupos()).isEmpty();
+    }
+}

--- a/backend/src/test/java/sgc/organizacao/dto/UnidadeResumoDtoTest.java
+++ b/backend/src/test/java/sgc/organizacao/dto/UnidadeResumoDtoTest.java
@@ -1,0 +1,69 @@
+package sgc.organizacao.dto;
+
+import org.junit.jupiter.api.Test;
+import sgc.organizacao.model.TipoUnidade;
+import sgc.organizacao.model.Unidade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UnidadeResumoDtoTest {
+
+    @Test
+    void deveCriarAPartirDeEntidade() {
+        var unidade = Unidade.builder()
+                .codigo(1L)
+                .nome("Nome da Unidade")
+                .sigla("SIG")
+                .tipo(TipoUnidade.OPERACIONAL)
+                .tituloTitular("Chefe")
+                .build();
+
+        var dto = UnidadeResumoDto.fromEntityObrigatoria(unidade);
+
+        assertThat(dto.codigo()).isEqualTo(1L);
+        assertThat(dto.nome()).isEqualTo("Nome da Unidade");
+        assertThat(dto.sigla()).isEqualTo("SIG");
+        assertThat(dto.tipo()).isEqualTo("OPERACIONAL");
+        assertThat(dto.tituloTitular()).isEqualTo("Chefe");
+    }
+
+    @Test
+    void deveCriarAPartirDeEntidadeComCamposNulos() {
+        var unidade = Unidade.builder()
+                .codigo(1L)
+                .nome("Nome da Unidade")
+                .sigla("SIG")
+                .build();
+
+        var dto = UnidadeResumoDto.fromEntityObrigatoria(unidade);
+
+        assertThat(dto.codigo()).isEqualTo(1L);
+        assertThat(dto.nome()).isEqualTo("Nome da Unidade");
+        assertThat(dto.sigla()).isEqualTo("SIG");
+        assertThat(dto.tipo()).isNull();
+        assertThat(dto.tituloTitular()).isNull();
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoEntidadeForNula() {
+        assertThatThrownBy(() -> UnidadeResumoDto.fromEntityObrigatoria(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Unidade obrigatoria para resumo");
+    }
+
+    @Test
+    void deveLancarExcecaoQuandoCamposObrigatoriosFaltarem() {
+        assertThatThrownBy(() -> UnidadeResumoDto.fromResumoObrigatorio(null, "Nome", "SIG", TipoUnidade.OPERACIONAL, "Chefe"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Codigo da unidade obrigatorio");
+
+        assertThatThrownBy(() -> UnidadeResumoDto.fromResumoObrigatorio(1L, null, "SIG", TipoUnidade.OPERACIONAL, "Chefe"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Nome da unidade obrigatorio");
+
+        assertThatThrownBy(() -> UnidadeResumoDto.fromResumoObrigatorio(1L, "Nome", null, TipoUnidade.OPERACIONAL, "Chefe"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Sigla da unidade obrigatoria");
+    }
+}

--- a/backend/src/test/java/sgc/organizacao/model/UnidadeElegibilidadeInfoTest.java
+++ b/backend/src/test/java/sgc/organizacao/model/UnidadeElegibilidadeInfoTest.java
@@ -1,0 +1,31 @@
+package sgc.organizacao.model;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnidadeElegibilidadeInfoTest {
+
+    @Test
+    void deveRetornarTrueQuandoPossuiResponsavelEfetivo() {
+        var info = new UnidadeElegibilidadeInfo(1L, TipoUnidade.OPERACIONAL, "Chefe");
+        assertThat(info.possuiResponsavelEfetivo()).isTrue();
+    }
+
+    @Test
+    void deveRetornarFalseQuandoResponsavelForNulo() {
+        var info = new UnidadeElegibilidadeInfo(1L, TipoUnidade.OPERACIONAL, null);
+        assertThat(info.possuiResponsavelEfetivo()).isFalse();
+    }
+
+    @Test
+    void deveRetornarFalseQuandoResponsavelForVazio() {
+        var info = new UnidadeElegibilidadeInfo(1L, TipoUnidade.OPERACIONAL, "");
+        assertThat(info.possuiResponsavelEfetivo()).isFalse();
+    }
+
+    @Test
+    void deveRetornarFalseQuandoResponsavelForApenasEspacos() {
+        var info = new UnidadeElegibilidadeInfo(1L, TipoUnidade.OPERACIONAL, "   ");
+        assertThat(info.possuiResponsavelEfetivo()).isFalse();
+    }
+}

--- a/backend/src/test/java/sgc/processo/dto/AcaoEmBlocoRequestTest.java
+++ b/backend/src/test/java/sgc/processo/dto/AcaoEmBlocoRequestTest.java
@@ -1,0 +1,56 @@
+package sgc.processo.dto;
+
+import org.junit.jupiter.api.Test;
+import sgc.comum.Mensagens;
+import sgc.comum.erros.ErroValidacao;
+import sgc.processo.model.AcaoProcesso;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AcaoEmBlocoRequestTest {
+
+    @Test
+    void deveRetornarDisponibilizarMapaEmBlocoCommandParaAcaoDisponibilizar() {
+        var dataLimite = LocalDate.of(2023, 1, 1);
+        var request = new AcaoEmBlocoRequest(List.of(1L, 2L), AcaoProcesso.DISPONIBILIZAR, dataLimite);
+
+        var command = request.paraCommand();
+
+        assertThat(command).isInstanceOf(DisponibilizarMapaEmBlocoCommand.class);
+        var disponibilizarCommand = (DisponibilizarMapaEmBlocoCommand) command;
+        assertThat(disponibilizarCommand.unidadeCodigos()).containsExactly(1L, 2L);
+        assertThat(disponibilizarCommand.dataLimite()).isEqualTo(dataLimite);
+    }
+
+    @Test
+    void deveLancarErroValidacaoSeDataLimiteNaoInformadaAoDisponibilizar() {
+        var request = new AcaoEmBlocoRequest(List.of(1L), AcaoProcesso.DISPONIBILIZAR, null);
+
+        assertThatThrownBy(request::paraCommand)
+                .isInstanceOf(ErroValidacao.class)
+                .hasMessage(Mensagens.DATA_LIMITE_OBRIGATORIA);
+    }
+
+    @Test
+    void deveRetornarProcessarAnaliseEmBlocoCommandParaOutrasAcoes() {
+        var requestAceitar = new AcaoEmBlocoRequest(List.of(1L), AcaoProcesso.ACEITAR, null);
+        var commandAceitar = requestAceitar.paraCommand();
+
+        assertThat(commandAceitar).isInstanceOf(ProcessarAnaliseEmBlocoCommand.class);
+        var processarCommand = (ProcessarAnaliseEmBlocoCommand) commandAceitar;
+        assertThat(processarCommand.unidadeCodigos()).containsExactly(1L);
+        assertThat(processarCommand.acao()).isEqualTo(AcaoProcesso.ACEITAR);
+
+        var requestHomologar = new AcaoEmBlocoRequest(List.of(2L), AcaoProcesso.HOMOLOGAR, null);
+        var commandHomologar = requestHomologar.paraCommand();
+
+        assertThat(commandHomologar).isInstanceOf(ProcessarAnaliseEmBlocoCommand.class);
+        var processarCommand2 = (ProcessarAnaliseEmBlocoCommand) commandHomologar;
+        assertThat(processarCommand2.unidadeCodigos()).containsExactly(2L);
+        assertThat(processarCommand2.acao()).isEqualTo(AcaoProcesso.HOMOLOGAR);
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/dto/AtualizarSubprocessoRequestTest.java
+++ b/backend/src/test/java/sgc/subprocesso/dto/AtualizarSubprocessoRequestTest.java
@@ -1,0 +1,61 @@
+package sgc.subprocesso.dto;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDateTime;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AtualizarSubprocessoRequestTest {
+
+    @Test
+    void deveConverterParaCommandComTodosCampos() {
+        var dataLim1 = LocalDateTime.of(2023, 1, 1, 10, 0);
+        var dataFim1 = LocalDateTime.of(2023, 1, 2, 10, 0);
+        var dataLim2 = LocalDateTime.of(2023, 1, 3, 10, 0);
+        var dataFim2 = LocalDateTime.of(2023, 1, 4, 10, 0);
+
+        var request = AtualizarSubprocessoRequest.builder()
+                .codUnidade(1L)
+                .codMapa(2L)
+                .dataLimiteEtapa1(dataLim1)
+                .dataFimEtapa1(dataFim1)
+                .dataLimiteEtapa2(dataLim2)
+                .dataFimEtapa2(dataFim2)
+                .build();
+
+        var command = request.paraCommand();
+
+        assertThat(command.vinculos()).isNotNull();
+        assertThat(command.vinculos().codUnidade()).isEqualTo(1L);
+        assertThat(command.vinculos().codMapa()).isEqualTo(2L);
+
+        assertThat(command.prazos()).isNotNull();
+        assertThat(command.prazos().dataLimiteEtapa1()).isPresent().contains(dataLim1);
+        assertThat(command.prazos().dataFimEtapa1()).isPresent().contains(dataFim1);
+        assertThat(command.prazos().dataLimiteEtapa2()).isPresent().contains(dataLim2);
+        assertThat(command.prazos().dataFimEtapa2()).isPresent().contains(dataFim2);
+    }
+
+    @Test
+    void deveConverterParaCommandComCamposNulos() {
+        var request = AtualizarSubprocessoRequest.builder()
+                .codUnidade(null)
+                .codMapa(null)
+                .dataLimiteEtapa1(null)
+                .dataFimEtapa1(null)
+                .dataLimiteEtapa2(null)
+                .dataFimEtapa2(null)
+                .build();
+
+        var command = request.paraCommand();
+
+        assertThat(command.vinculos()).isNotNull();
+        assertThat(command.vinculos().codUnidade()).isNull();
+        assertThat(command.vinculos().codMapa()).isNull();
+
+        assertThat(command.prazos()).isNotNull();
+        assertThat(command.prazos().dataLimiteEtapa1()).isEmpty();
+        assertThat(command.prazos().dataFimEtapa1()).isEmpty();
+        assertThat(command.prazos().dataLimiteEtapa2()).isEmpty();
+        assertThat(command.prazos().dataFimEtapa2()).isEmpty();
+    }
+}


### PR DESCRIPTION
I have added dedicated unit tests for 7 classes to ensure 100% coverage based on the real backlog. The classes tested are: `UnidadeElegibilidadeInfo`, `AtualizarMapaRequest`, `CriarMapaRequest`, `DiagnosticoOrganizacionalDto`, `UnidadeResumoDto`, `AcaoEmBlocoRequest`, and `AtualizarSubprocessoRequest`. I have verified these changes by running `./gradlew test jacocoTestCoverageVerification --no-build-cache --rerun-tasks` and checking the analysis tool script output.

---
*PR created automatically by Jules for task [663232349006169151](https://jules.google.com/task/663232349006169151) started by @lgalvao*