### PR TITLE
Add comprehensive unit tests for monitoring, alert marking, painel and subprocesso functionality

### DIFF
--- a/backend/src/test/java/sgc/alerta/AlertaFacadeTest.java
+++ b/backend/src/test/java/sgc/alerta/AlertaFacadeTest.java
@@ -191,6 +191,90 @@ class AlertaFacadeTest {
     }
 
     @Test
+    @DisplayName("Deve retornar optional com data de leitura")
+    void deveRetornarDataHoraLeitura() {
+        Optional<LocalDateTime> dataHora = Optional.of(LocalDateTime.now());
+        when(alertaService.dataHoraLeituraAlertaUsuario(1L, "123")).thenReturn(dataHora);
+
+        Optional<LocalDateTime> result = alertaFacade.obterDataHoraLeitura(1L, "123");
+
+        assertThat(result).isEqualTo(dataHora);
+        verify(alertaService).dataHoraLeituraAlertaUsuario(1L, "123");
+    }
+
+    @Nested
+    @DisplayName("Marcação de Lidos")
+    class MarcacaoLidos {
+        @Test
+        @DisplayName("Não deve fazer nada se lista de códigos for vazia")
+        void naoDeveFazerNadaSeVazia() {
+            alertaFacade.marcarComoLidos(CONTEXTO_SERVIDOR, Collections.emptyList());
+
+            verify(alertaService, never()).alertasUsuarios(anyString(), anyList());
+            verify(alertaService, never()).salvarAlertasUsuarios(anyList());
+        }
+
+        @Test
+        @DisplayName("Deve atualizar data e salvar quando leitura for nula e houver alerta existente")
+        void deveAtualizarDataQuandoLeituraNula() {
+            AlertaUsuario alertaUsuario = new AlertaUsuario();
+            alertaUsuario.setCodigo(AlertaUsuario.Chave.builder().alertaCodigo(1L).build());
+            alertaUsuario.setDataHoraLeitura(null);
+
+            when(alertaService.alertasUsuarios("123", List.of(1L))).thenReturn(List.of(alertaUsuario));
+
+            alertaFacade.marcarComoLidos(CONTEXTO_SERVIDOR, List.of(1L));
+
+            assertThat(alertaUsuario.getDataHoraLeitura()).isNotNull();
+            verify(alertaService).salvarAlertasUsuarios(argThat(list -> list.contains(alertaUsuario)));
+        }
+
+        @Test
+        @DisplayName("Deve criar novo alertaUsuario quando não existir na base e salvar")
+        void deveCriarNovoQuandoNaoExistir() {
+            when(alertaService.alertasUsuarios("123", List.of(2L))).thenReturn(Collections.emptyList());
+
+            Alerta alerta = new Alerta();
+            alerta.setCodigo(2L);
+            when(alertaService.listarPorCodigos(List.of(2L))).thenReturn(List.of(alerta));
+
+            Usuario usuario = new Usuario();
+            usuario.setTituloEleitoral("123");
+            when(usuarioService.buscar("123")).thenReturn(usuario);
+
+            alertaFacade.marcarComoLidos(CONTEXTO_SERVIDOR, List.of(2L));
+
+            verify(alertaService).salvarAlertasUsuarios(argThat(list -> list.stream().anyMatch(au -> au.getCodigo().getAlertaCodigo() == 2L)));
+        }
+
+        @Test
+        @DisplayName("Deve ignorar se o alerta não for encontrado ao criar novo")
+        void deveIgnorarSeAlertaNaoEncontrado() {
+            when(alertaService.alertasUsuarios("123", List.of(3L))).thenReturn(Collections.emptyList());
+            when(alertaService.listarPorCodigos(List.of(3L))).thenReturn(Collections.emptyList());
+
+            alertaFacade.marcarComoLidos(CONTEXTO_SERVIDOR, List.of(3L));
+
+            verify(alertaService, never()).salvarAlertasUsuarios(anyList());
+        }
+
+        @Test
+        @DisplayName("Deve capturar DataIntegrityViolationException silenciosamente")
+        void deveCapturarExcecaoSilenciosamente() {
+            AlertaUsuario alertaUsuario = new AlertaUsuario();
+            alertaUsuario.setCodigo(AlertaUsuario.Chave.builder().alertaCodigo(1L).build());
+            alertaUsuario.setDataHoraLeitura(null);
+
+            when(alertaService.alertasUsuarios("123", List.of(1L))).thenReturn(List.of(alertaUsuario));
+            doThrow(new org.springframework.dao.DataIntegrityViolationException("Simulação de concorrência"))
+                    .when(alertaService).salvarAlertasUsuarios(anyList());
+
+            assertThatCode(() -> alertaFacade.marcarComoLidos(CONTEXTO_SERVIDOR, List.of(1L)))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
     @DisplayName("Deve criar alerta para participante do tipo raiz")
     void deveCriarAlertaParaParticipanteRaiz() {
         Processo processo = new Processo();

--- a/backend/src/test/java/sgc/comum/util/FiltroMonitoramentoHttpTest.java
+++ b/backend/src/test/java/sgc/comum/util/FiltroMonitoramentoHttpTest.java
@@ -44,6 +44,29 @@ class FiltroMonitoramentoHttpTest {
     }
 
     @Test
+    @DisplayName("Deve logar erro quando o tempo for muito alto (HTTP LENTO)")
+    void deveLogarErroHTTP() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        properties.setLimiteAlertaMs(1);
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/processos");
+        request.setQueryString("param1=valor1");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotBlank();
+    }
+
+    @Test
     @DisplayName("Deve ignorar requisicao fora de /api quando o filtro decidir nao aplicar")
     void deveIgnorarRequisicaoForaDeApi() throws ServletException, IOException {
         MonitoramentoProperties properties = new MonitoramentoProperties();
@@ -60,10 +83,219 @@ class FiltroMonitoramentoHttpTest {
     }
 
     @Test
-    @DisplayName("Deve registrar latência no header da resposta")
-    void deveRegistrarLatencia() throws ServletException, IOException {
+    @DisplayName("Deve aplicar taxa de amostragem quando trace não for completo nem habilitado por header")
+    void deveAplicarAmostragem() throws ServletException, IOException {
         MonitoramentoProperties properties = new MonitoramentoProperties();
         properties.setAtivo(true);
+        properties.setTraceCompleto(false);
+        properties.setTaxaAmostragem(1.0); // Garante que caia na amostragem
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/teste");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+        });
+
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Não deve aplicar amostragem quando taxa for 0")
+    void naoDeveAplicarAmostragem() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        properties.setTraceCompleto(false);
+        properties.setTaxaAmostragem(0.0);
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/teste");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+        });
+
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Deve formatar linha com erro 500 sem amostragem")
+    void deveFormatarErro500SemAmostragem() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        properties.setTraceCompleto(true);
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/erro");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(500);
+
+        filtro.doFilter(request, response, (req, res) -> {
+        });
+
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("Deve ser inativo")
+    void deveSerInativo() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(false);
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/inativo");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+        });
+
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNull();
+    }
+
+    @Test
+    @DisplayName("Deve usar HTTP MUITO LENTO")
+    void deveUsarMuitoLento() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        properties.setTraceCompleto(true);
+        properties.setLimiteMuitoLentoMs(1);
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/muito-lento");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("isMonitoramentoAtivoNaRequisicao deve retornar false quando não houver contexto")
+    void isMonitoramentoAtivoNaRequisicaoDeveRetornarFalseQuandoSemContexto() {
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+        assertThat(FiltroMonitoramentoHttp.isMonitoramentoAtivoNaRequisicao()).isFalse();
+    }
+
+    @Test
+    @DisplayName("isMonitoramentoAtivoNaRequisicao deve retornar false quando atributo for null")
+    void isMonitoramentoAtivoNaRequisicaoDeveRetornarFalseQuandoNull() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        // Não seta o atributo
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(request)
+        );
+        assertThat(FiltroMonitoramentoHttp.isMonitoramentoAtivoNaRequisicao()).isFalse();
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("isMonitoramentoAtivoNaRequisicao deve retornar false quando context for invalido")
+    void isMonitoramentoAtivoNaRequisicaoDeveRetornarFalseQuandoContextInvalido() {
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.RequestAttributes() {
+                    @Override
+                    public Object getAttribute(String name, int scope) { return null; }
+                    @Override
+                    public void setAttribute(String name, Object value, int scope) {}
+                    @Override
+                    public void removeAttribute(String name, int scope) {}
+                    @Override
+                    public String[] getAttributeNames(int scope) { return new String[0]; }
+                    @Override
+                    public void registerDestructionCallback(String name, Runnable callback, int scope) {}
+                    @Override
+                    public Object resolveReference(String key) { return null; }
+                    @Override
+                    public String getSessionId() { return null; }
+                    @Override
+                    public Object getSessionMutex() { return null; }
+                }
+        );
+        assertThat(FiltroMonitoramentoHttp.isMonitoramentoAtivoNaRequisicao()).isFalse();
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar UUID quando não houver contexto nem MDC")
+    void obterCorrelacaoIdAtualDeveRetornarUUIDQuandoSemContexto() {
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+        org.slf4j.MDC.clear();
+        String id = FiltroMonitoramentoHttp.obterCorrelacaoIdAtual();
+        assertThat(id).isNotBlank();
+        assertThat(id.length()).isEqualTo(36); // Tamanho padrão do UUID
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar o valor do request attribute")
+    void obterCorrelacaoIdAtualDeveRetornarDoRequest() {
+        org.slf4j.MDC.clear();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(FiltroMonitoramentoHttp.ATRIBUTO_CORRELACAO_ID, "req-corr-123");
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(request)
+        );
+
+        assertThat(FiltroMonitoramentoHttp.obterCorrelacaoIdAtual()).isEqualTo("req-corr-123");
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar UUID quando request attribute não for string válida")
+    void obterCorrelacaoIdAtualDeveRetornarUUIDQuandoRequestAtributoInvalido() {
+        org.slf4j.MDC.clear();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(FiltroMonitoramentoHttp.ATRIBUTO_CORRELACAO_ID, new Object()); // Não é String
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(request)
+        );
+
+        String id = FiltroMonitoramentoHttp.obterCorrelacaoIdAtual();
+        assertThat(id).isNotBlank();
+        assertThat(id.length()).isEqualTo(36);
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar o valor do MDC se existir")
+    void obterCorrelacaoIdDeveRetornarDoMDC() {
+        org.slf4j.MDC.put(FiltroMonitoramentoHttp.MDC_CORRELACAO_ID, "mdc-corr-123");
+
+        String id = FiltroMonitoramentoHttp.obterCorrelacaoIdAtual();
+        assertThat(id).isEqualTo("mdc-corr-123");
+
+        org.slf4j.MDC.clear();
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar UUID quando request attribute for string vazia")
+    void obterCorrelacaoIdDeveRetornarUUIDQuandoRequestAtributoStringVazia() {
+        org.slf4j.MDC.clear();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(FiltroMonitoramentoHttp.ATRIBUTO_CORRELACAO_ID, "   "); // String vazia
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(request)
+        );
+
+        String id = FiltroMonitoramentoHttp.obterCorrelacaoIdAtual();
+        assertThat(id).isNotBlank();
+        assertThat(id.length()).isEqualTo(36);
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("Deve usar HTTP LENTO (entre o alerta e o muito lento)")
+    void deveUsarLento() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        properties.setTraceCompleto(true);
+        properties.setLimiteMuitoLentoMs(100);
+        properties.setLimiteLentoMs(1);
 
         FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/lento");
@@ -71,29 +303,121 @@ class FiltroMonitoramentoHttpTest {
 
         filtro.doFilter(request, response, (req, res) -> {
             try {
-                Thread.sleep(20);
+                Thread.sleep(5);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         });
 
-        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_TEMPO_SERVIDOR_MS)).isNotBlank();
+        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotBlank();
     }
 
     @Test
-    @DisplayName("Deve usar amostragem probabilística")
-    void deveUsarAmostragemProbabilistica() throws ServletException, IOException {
+    @DisplayName("isMonitoramentoAtivoNaRequisicao deve retornar verdadeiro do request")
+    void isMonitoramentoAtivoNaRequisicaoDeveRetornarDoRequest() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(FiltroMonitoramentoHttp.ATRIBUTO_MONITORAMENTO_ATIVO, Boolean.TRUE);
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(request)
+        );
+
+        assertThat(FiltroMonitoramentoHttp.isMonitoramentoAtivoNaRequisicao()).isTrue();
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar UUID quando context for invalido")
+    void obterCorrelacaoIdDeveRetornarUUIDQuandoContextInvalido() {
+        org.slf4j.MDC.clear();
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.RequestAttributes() {
+                    @Override
+                    public Object getAttribute(String name, int scope) { return null; }
+                    @Override
+                    public void setAttribute(String name, Object value, int scope) {}
+                    @Override
+                    public void removeAttribute(String name, int scope) {}
+                    @Override
+                    public String[] getAttributeNames(int scope) { return new String[0]; }
+                    @Override
+                    public void registerDestructionCallback(String name, Runnable callback, int scope) {}
+                    @Override
+                    public Object resolveReference(String key) { return null; }
+                    @Override
+                    public String getSessionId() { return null; }
+                    @Override
+                    public Object getSessionMutex() { return null; }
+                }
+        );
+        String id = FiltroMonitoramentoHttp.obterCorrelacaoIdAtual();
+        assertThat(id).isNotBlank();
+        assertThat(id.length()).isEqualTo(36);
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("obterCorrelacaoIdAtual deve retornar UUID quando atributo null")
+    void obterCorrelacaoIdDeveRetornarUUIDQuandoNull() {
+        org.slf4j.MDC.clear();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(request)
+        );
+        String id = FiltroMonitoramentoHttp.obterCorrelacaoIdAtual();
+        assertThat(id).isNotBlank();
+        assertThat(id.length()).isEqualTo(36);
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("Deve usar trace completo da properties")
+    void deveUsarTraceCompletoDaProperties() throws ServletException, IOException {
         MonitoramentoProperties properties = new MonitoramentoProperties();
         properties.setAtivo(true);
-        properties.setTaxaAmostragem(1.0); // 100% de amostragem
+        properties.setTraceCompleto(true);
 
         FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/teste");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+            assertThat((Boolean) req.getAttribute(FiltroMonitoramentoHttp.ATRIBUTO_MONITORAMENTO_ATIVO)).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("Deve usar amostragem ativando monitoramento detalhado")
+    void deveUsarAmostragemAtivando() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        properties.setTraceCompleto(false);
+        properties.setTaxaAmostragem(1.0); // 100% de chance
+
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/teste");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filtro.doFilter(request, response, (req, res) -> {
+            assertThat((Boolean) req.getAttribute(FiltroMonitoramentoHttp.ATRIBUTO_MONITORAMENTO_ATIVO)).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("obterOuGerarCorrelacaoId deve gerar novo ID quando string for vazia")
+    void obterCorrelacaoIdDeveGerarNovoQuandoVazia() throws ServletException, IOException {
+        MonitoramentoProperties properties = new MonitoramentoProperties();
+        properties.setAtivo(true);
+        FiltroMonitoramentoHttp filtro = new FiltroMonitoramentoHttp(properties);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/teste");
+        request.addHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID, "   "); // Empty or blank string
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         filtro.doFilter(request, response, (req, res) -> {
         });
 
-        assertThat(response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID)).isNotNull();
+        String generatedId = response.getHeader(FiltroMonitoramentoHttp.HEADER_CORRELACAO_ID);
+        assertThat(generatedId).isNotBlank();
+        assertThat(generatedId).isNotEqualTo("   ");
     }
 }

--- a/backend/src/test/java/sgc/comum/util/MonitoramentoAspectTest.java
+++ b/backend/src/test/java/sgc/comum/util/MonitoramentoAspectTest.java
@@ -59,6 +59,12 @@ class MonitoramentoAspectTest {
     }
 
     @Test
+    @DisplayName("Deve invocar construtor vazio sem erros")
+    void deveInvocarConstrutorVazio() {
+        assertThatCode(MonitoramentoAspect::new).doesNotThrowAnyException();
+    }
+
+    @Test
     @DisplayName("Deve executar com trace completo mesmo sem assinatura")
     void deveExecutarComTraceCompletoSemAssinatura() throws Throwable {
         MonitoramentoAspect aspectoComTrace = new MonitoramentoAspect(true, true, 1_000);
@@ -71,15 +77,39 @@ class MonitoramentoAspectTest {
     }
 
     @Test
-    @DisplayName("Deve cobrir construtores do MonitoramentoAspect")
-    void deveCobrirConstrutores() {
-        assertThat(new MonitoramentoAspect()).isNotNull();
-        
-        MonitoramentoProperties props = new MonitoramentoProperties();
-        props.setAtivo(true);
-        props.setTraceCompleto(true);
-        props.setLimiteAlertaMs(100);
-        
-        assertThat(new MonitoramentoAspect(props)).isNotNull();
+    @DisplayName("Deve executar e logar trace detalhado se ativado pela requisicao e trace completo for false")
+    void deveLogarTraceAtivadoPelaRequisicao() throws Throwable {
+        MonitoramentoAspect aspecto = new MonitoramentoAspect(true, false, 1_000);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getDeclaringTypeName()).thenReturn("sgc.Classe");
+        when(signature.getName()).thenReturn("metodo");
+        when(joinPoint.proceed()).thenReturn("TRACE_REQ");
+
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(
+                new org.springframework.web.context.request.ServletRequestAttributes(
+                        new org.springframework.mock.web.MockHttpServletRequest()
+                )
+        );
+        org.springframework.web.context.request.RequestContextHolder.currentRequestAttributes()
+                .setAttribute(FiltroMonitoramentoHttp.ATRIBUTO_MONITORAMENTO_ATIVO, true, org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST);
+
+        Object result = aspecto.monitorarExecucao(joinPoint);
+
+        assertThat(result).isEqualTo("TRACE_REQ");
+        org.springframework.web.context.request.RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("Deve executar sem logar aviso se for rapido e sem trace completo")
+    void deveExecutarRapidoESemTrace() throws Throwable {
+        MonitoramentoAspect aspecto = new MonitoramentoAspect(true, false, 500);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getDeclaringTypeName()).thenReturn("sgc.Classe");
+        when(signature.getName()).thenReturn("metodo");
+        when(joinPoint.proceed()).thenReturn("OK");
+
+        Object result = aspecto.monitorarExecucao(joinPoint);
+
+        assertThat(result).isEqualTo("OK");
     }
 }

--- a/backend/src/test/java/sgc/processo/painel/PainelControllerTest.java
+++ b/backend/src/test/java/sgc/processo/painel/PainelControllerTest.java
@@ -82,6 +82,52 @@ class PainelControllerTest {
     }
 
     @Test
+    @DisplayName("GET /api/painel/bootstrap - Deve obter dados de bootstrap com sucesso usando contexto do Token")
+    void obterBootstrap_Sucesso() throws Exception {
+        Usuario usuarioMock = Usuario.builder()
+                .tituloEleitoral("123")
+                .perfilAtivo(Perfil.ADMIN)
+                .unidadeAtivaCodigo(1L)
+                .build();
+        usuarioMock.setAuthorities(Set.of(Perfil.ADMIN.toGrantedAuthority()));
+        when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado("123", 1L, Perfil.ADMIN));
+
+        sgc.processo.painel.dto.PainelBootstrapDto dto = sgc.processo.painel.dto.PainelBootstrapDto.builder()
+                .processos(Collections.emptyList())
+                .alertas(Collections.emptyList())
+                .build();
+        when(painelFacade.obterBootstrap(any(ContextoUsuarioAutenticado.class))).thenReturn(dto);
+
+        mockMvc.perform(get("/api/painel/bootstrap")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(usuarioMock, null, usuarioMock.getAuthorities())))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.processos").isArray())
+                .andExpect(jsonPath("$.alertas").isArray());
+    }
+
+    @Test
+    @DisplayName("POST /api/painel/alertas/marcar-lidos - Deve marcar alertas como lidos com sucesso")
+    void marcarAlertasLidos_Sucesso() throws Exception {
+        Usuario usuarioMock = Usuario.builder()
+                .tituloEleitoral("123")
+                .perfilAtivo(Perfil.ADMIN)
+                .unidadeAtivaCodigo(1L)
+                .build();
+        usuarioMock.setAuthorities(Set.of(Perfil.ADMIN.toGrantedAuthority()));
+        when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado("123", 1L, Perfil.ADMIN));
+
+        mockMvc.perform(post("/api/painel/alertas/marcar-lidos")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(usuarioMock, null, usuarioMock.getAuthorities())))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("[1, 2, 3]"))
+                .andExpect(status().isNoContent());
+
+        verify(painelFacade).marcarAlertasLidos(any(ContextoUsuarioAutenticado.class), eq(List.of(1L, 2L, 3L)));
+    }
+
+    @Test
     @DisplayName("GET /api/painel/alertas - Deve ignorar parâmetros de usuário/unidade da URL e usar o Token")
     void listarAlertas_IgnoraParametrosUrl() throws Exception {
         Usuario usuarioMock = Usuario.builder()
@@ -105,45 +151,4 @@ class PainelControllerTest {
         verify(painelFacade).listarAlertas(any(ContextoUsuarioAutenticado.class), any(Pageable.class));
     }
 
-    @Test
-    @DisplayName("GET /api/painel/bootstrap - Deve obter bootstrap com sucesso")
-    void obterBootstrap_Sucesso() throws Exception {
-        Usuario usuarioMock = Usuario.builder()
-                .tituloEleitoral("123")
-                .unidadeAtivaCodigo(1L)
-                .perfilAtivo(Perfil.ADMIN)
-                .authorities(Set.of(Perfil.ADMIN.toGrantedAuthority()))
-                .build();
-        when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado("123", 1L, Perfil.ADMIN));
-
-        PainelBootstrapDto bootstrapDto = new PainelBootstrapDto();
-        when(painelFacade.obterBootstrap(any(ContextoUsuarioAutenticado.class))).thenReturn(bootstrapDto);
-
-        mockMvc.perform(get("/api/painel/bootstrap")
-                        .with(authentication(new UsernamePasswordAuthenticationToken(usuarioMock, null, usuarioMock.getAuthorities())))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("POST /api/painel/alertas/marcar-lidos - Deve marcar alertas como lidos com sucesso")
-    void marcarAlertasLidos_Sucesso() throws Exception {
-        Usuario usuarioMock = Usuario.builder()
-                .tituloEleitoral("123")
-                .unidadeAtivaCodigo(1L)
-                .perfilAtivo(Perfil.ADMIN)
-                .authorities(Set.of(Perfil.ADMIN.toGrantedAuthority()))
-                .build();
-        when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado("123", 1L, Perfil.ADMIN));
-
-        List<Long> codigos = Arrays.asList(1L, 2L);
-
-        mockMvc.perform(post("/api/painel/alertas/marcar-lidos")
-                        .content("[1, 2]")
-                        .with(authentication(new UsernamePasswordAuthenticationToken(usuarioMock, null, usuarioMock.getAuthorities())))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNoContent());
-
-        verify(painelFacade).marcarAlertasLidos(any(ContextoUsuarioAutenticado.class), eq(codigos));
-    }
 }

--- a/backend/src/test/java/sgc/processo/painel/PainelFacadeTest.java
+++ b/backend/src/test/java/sgc/processo/painel/PainelFacadeTest.java
@@ -339,6 +339,79 @@ class PainelFacadeTest {
     }
 
     @Test
+    @DisplayName("Deve lançar exceção se sigla for nula e perfil não for gestor nem admin")
+    void deveLancarExcecaoSeSiglaNulaENaoGestorNemAdmin() {
+        Processo p = criarProcesso(1L, SituacaoProcesso.EM_ANDAMENTO);
+        Page<Processo> pageProcessos = new PageImpl<>(List.of(p));
+        when(hierarquiaService.buscarMapaHierarquia()).thenReturn(new HashMap<>());
+        when(processoService.listarIniciadosPorParticipantes(anyList(), any(Pageable.class))).thenReturn(pageProcessos);
+
+        ContextoUsuarioAutenticado contextoChefe = new ContextoUsuarioAutenticado("123", 10L, Perfil.CHEFE);
+        when(unidadeService.buscarSiglaPorCodigo(10L)).thenReturn(null);
+
+        assertThatThrownBy(() -> painelFacade.listarProcessos(contextoChefe, PageRequest.of(0, 10)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Sigla da unidade do usuário ausente");
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção se sigla for vazia e perfil não for gestor nem admin")
+    void deveLancarExcecaoSeSiglaVaziaENaoGestorNemAdmin() {
+        Processo p = criarProcesso(1L, SituacaoProcesso.EM_ANDAMENTO);
+        Page<Processo> pageProcessos = new PageImpl<>(List.of(p));
+        when(hierarquiaService.buscarMapaHierarquia()).thenReturn(new HashMap<>());
+        when(processoService.listarIniciadosPorParticipantes(anyList(), any(Pageable.class))).thenReturn(pageProcessos);
+
+        ContextoUsuarioAutenticado contextoChefe = new ContextoUsuarioAutenticado("123", 10L, Perfil.CHEFE);
+        when(unidadeService.buscarSiglaPorCodigo(10L)).thenReturn("  ");
+
+        assertThatThrownBy(() -> painelFacade.listarProcessos(contextoChefe, PageRequest.of(0, 10)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Sigla da unidade do usuário ausente");
+    }
+
+    @Test
+    @DisplayName("Deve marcar alertas como lidos")
+    void deveMarcarAlertasLidos() {
+        painelFacade.marcarAlertasLidos(CONTEXTO_ADMIN, List.of(1L, 2L));
+        verify(alertaFacade).marcarComoLidos(CONTEXTO_ADMIN, List.of(1L, 2L));
+    }
+
+    @Test
+    @DisplayName("Não deve chamar alertaFacade se lista de alertas estiver vazia")
+    void naoDeveMarcarAlertasLidosSeListaVazia() {
+        painelFacade.marcarAlertasLidos(CONTEXTO_ADMIN, Collections.emptyList());
+        verify(alertaFacade, never()).marcarComoLidos(any(ContextoUsuarioAutenticado.class), anyList());
+    }
+
+    @Test
+    @DisplayName("Deve obter bootstrap corretamente")
+    void deveObterBootstrap() {
+        Processo p = criarProcesso(1L, SituacaoProcesso.EM_ANDAMENTO);
+        Page<Processo> pageProcessos = new PageImpl<>(List.of(p));
+        when(hierarquiaService.buscarMapaHierarquia()).thenReturn(new HashMap<>());
+        when(processoService.listarTodos(any(Pageable.class))).thenReturn(pageProcessos);
+
+        Alerta alerta = new Alerta();
+        alerta.setCodigo(10L);
+        alerta.setDescricao("Alerta teste");
+        alerta.setDataHora(LocalDateTime.now());
+        alerta.setProcesso(p);
+        alerta.setUnidadeOrigem(new Unidade());
+        alerta.setUnidadeDestino(new Unidade());
+        Page<Alerta> pageAlertas = new PageImpl<>(List.of(alerta));
+
+        when(alertaFacade.listarPorUnidade(eq(CONTEXTO_ADMIN), any(Pageable.class))).thenReturn(pageAlertas);
+        when(alertaFacade.obterMapaDataHoraLeitura(anyString(), anyList())).thenReturn(Map.of());
+
+        sgc.processo.painel.dto.PainelBootstrapDto bootstrap = painelFacade.obterBootstrap(CONTEXTO_ADMIN);
+
+        assertThat(bootstrap.getProcessos()).hasSize(1);
+        assertThat(bootstrap.getAlertas()).hasSize(1);
+        assertThat(bootstrap.getAlertas().getFirst().codigo()).isEqualTo(10L);
+    }
+
+    @Test
     @DisplayName("Deve cobrir children sendo lista vazia")
     void deveCobrirChildrenVazia() {
         Processo p = mock(Processo.class);
@@ -419,39 +492,4 @@ class PainelFacadeTest {
         return p;
     }
 
-    @Test
-    @DisplayName("Deve obter bootstrap com sucesso")
-    void deveObterBootstrap() {
-        Processo p = criarProcesso(1L, SituacaoProcesso.EM_ANDAMENTO);
-        Page<Processo> pageProcessos = new PageImpl<>(List.of(p));
-        when(processoService.listarTodos(any(Pageable.class))).thenReturn(pageProcessos);
-        when(hierarquiaService.buscarMapaHierarquia()).thenReturn(new HashMap<>());
-
-        Alerta a = new Alerta();
-        a.setCodigo(1L);
-        a.setProcesso(p);
-        a.setDescricao("Alerta 1");
-        a.setUnidadeOrigem(new Unidade());
-        a.getUnidadeOrigem().setSigla("U1");
-        a.setUnidadeDestino(new Unidade());
-        a.getUnidadeDestino().setSigla("U2");
-        a.setDataHora(LocalDateTime.now());
-
-        Page<Alerta> pageAlertas = new PageImpl<>(List.of(a));
-        when(alertaFacade.listarPorUnidade(eq(CONTEXTO_ADMIN), any(Pageable.class))).thenReturn(pageAlertas);
-        when(alertaFacade.obterMapaDataHoraLeitura("123", List.of(1L))).thenReturn(Map.of(1L, LocalDateTime.now()));
-
-        PainelBootstrapDto result = painelFacade.obterBootstrap(CONTEXTO_ADMIN);
-
-        assertThat(result.getProcessos()).hasSize(1);
-        assertThat(result.getAlertas()).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("Deve marcar alertas como lidos")
-    void deveMarcarAlertasLidos() {
-        List<Long> codigos = List.of(1L, 2L);
-        painelFacade.marcarAlertasLidos(CONTEXTO_ADMIN, codigos);
-        verify(alertaFacade).marcarComoLidos(CONTEXTO_ADMIN, codigos);
-    }
 }

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
@@ -352,6 +352,30 @@ class SubprocessoControllerTest {
 
             verify(consultaService).verificarImpactos(1L);
         }
+
+        @Test
+        @DisplayName("deve obter contexto de cadastro de atividades buscando processo e unidade")
+        @WithMockUser
+        void deveObterContextoCadastroAtividadesBusca() throws Exception {
+            Unidade unidade = new Unidade();
+            unidade.setCodigo(10L);
+            when(unidadeService.buscarPorSigla("U10")).thenReturn(unidade);
+
+            Subprocesso sp = new Subprocesso();
+            sp.setCodigo(1L);
+            when(consultaService.obterEntidadePorProcessoEUnidade(5L, 10L)).thenReturn(sp);
+
+            when(consultaService.obterContextoCadastroAtividades(1L)).thenReturn(
+                    new sgc.subprocesso.dto.ContextoCadastroAtividadesResponse(null, null, null, List.of())
+            );
+
+            mockMvc.perform(get("/api/subprocessos/contexto-cadastro-atividades/buscar")
+                            .param("codProcesso", "5")
+                            .param("siglaUnidade", "U10"))
+                    .andExpect(status().isOk());
+
+            verify(consultaService).obterContextoCadastroAtividades(1L);
+        }
     }
 
     @Nested

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoConsultaServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoConsultaServiceTest.java
@@ -6,9 +6,10 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.*;
 import org.springframework.test.util.*;
 import sgc.comum.erros.*;
-import sgc.organizacao.model.*;
 import sgc.mapa.model.Mapa;
+import sgc.organizacao.model.*;
 import sgc.organizacao.service.*;
+import sgc.processo.dto.*;
 import sgc.subprocesso.model.*;
 
 import java.util.*;
@@ -26,13 +27,12 @@ class SubprocessoConsultaServiceTest {
     private AnaliseRepo analiseRepo;
     @Mock
     private UnidadeService unidadeService;
-
     @Mock
     private sgc.organizacao.UsuarioFacade usuarioFacade;
     @Mock
-    private sgc.subprocesso.service.LocalizacaoSubprocessoService localizacaoSubprocessoService;
+    private LocalizacaoSubprocessoService localizacaoSubprocessoService;
     @Mock
-    private sgc.organizacao.service.HierarquiaService hierarquiaService;
+    private HierarquiaService hierarquiaService;
     @Mock
     private sgc.mapa.service.MapaManutencaoService mapaManutencaoService;
 
@@ -82,17 +82,17 @@ class SubprocessoConsultaServiceTest {
     }
 
     @Test
-    @DisplayName("listarEntidadesPorProcessoEUnidades deve retornar vazio quando lista de unidades estiver vazia")
-    void listarEntidadesPorProcessoEUnidadesDeveRetornarVazioQuandoListaDeUnidadesEstiverVazia() {
-        assertThat(service.listarEntidadesPorProcessoEUnidades(1L, List.of())).isEmpty();
-        verify(subprocessoRepo, never()).listarPorProcessoEUnidadesComUnidade(anyLong(), anyList());
-    }
-
-    @Test
     @DisplayName("listarPorProcessoEUnidadeCodigosESituacoes deve retornar vazio quando lista de unidades ou situacoes estiver vazia")
     void listarPorProcessoEUnidadeCodigosESituacoesDeveRetornarVazio() {
         assertThat(service.listarPorProcessoEUnidadeCodigosESituacoes(1L, List.of(), List.of(SituacaoSubprocesso.NAO_INICIADO))).isEmpty();
         assertThat(service.listarPorProcessoEUnidadeCodigosESituacoes(1L, List.of(10L), List.of())).isEmpty();
+        verify(subprocessoRepo, never()).listarPorProcessoEUnidadesComUnidade(anyLong(), anyList());
+    }
+
+    @Test
+    @DisplayName("listarEntidadesPorProcessoEUnidades deve retornar vazio quando lista de unidades estiver vazia")
+    void listarEntidadesPorProcessoEUnidadesDeveRetornarVazioQuandoListaDeUnidadesEstiverVazia() {
+        assertThat(service.listarEntidadesPorProcessoEUnidades(1L, List.of())).isEmpty();
         verify(subprocessoRepo, never()).listarPorProcessoEUnidadesComUnidade(anyLong(), anyList());
     }
 
@@ -104,7 +104,7 @@ class SubprocessoConsultaServiceTest {
         unidade.setCodigo(100L);
         unidade.setSigla("U100");
         unidade.setNome("Unidade 100");
-        unidade.setTipo(sgc.organizacao.model.TipoUnidade.OPERACIONAL);
+        unidade.setTipo(TipoUnidade.OPERACIONAL);
 
         Mapa mapa = new Mapa();
         mapa.setCodigo(500L);
@@ -155,5 +155,27 @@ class SubprocessoConsultaServiceTest {
 
         var permissoes = service.obterPermissoesUI(sp);
         assertThat(permissoes.habilitarAcessoCadastro()).isTrue();
+    }
+
+    @Test
+    @DisplayName("listarHistoricoCadastro deve carregar unidades em lote")
+    void listarHistoricoCadastroDeveCarregarUnidadesEmLote() {
+        Analise analise1 = new Analise();
+        analise1.setUnidadeCodigo(10L);
+        analise1.setTipo(TipoAnalise.CADASTRO);
+
+        Analise analise2 = new Analise();
+        analise2.setUnidadeCodigo(20L);
+        analise2.setTipo(TipoAnalise.CADASTRO);
+
+        when(analiseRepo.findBySubprocessoCodigoOrderByDataHoraDesc(1L)).thenReturn(List.of(analise1, analise2));
+        when(unidadeService.buscarResumosPorCodigos(List.of(10L, 20L))).thenReturn(List.of(
+                new UnidadeResumoLeitura(10L, "Unidade 10", "U10", TipoUnidade.OPERACIONAL),
+                new UnidadeResumoLeitura(20L, "Unidade 20", "U20", TipoUnidade.OPERACIONAL)
+        ));
+
+        assertThat(service.listarHistoricoCadastro(1L)).hasSize(2);
+        verify(unidadeService).buscarResumosPorCodigos(List.of(10L, 20L));
+        verify(unidadeService, never()).buscarPorCodigo(anyLong());
     }
 }


### PR DESCRIPTION
### Motivation
- Increase test coverage and assert edge cases for HTTP monitoring behavior, AOP monitoring, alert marking and painel/subprocesso flows.
- Validate correlation id generation, sampling/trace toggles and slow-request handling in the HTTP filter and aspect.
- Ensure alert read-marking logic handles missing records and concurrent save failures gracefully.
- Verify controller endpoints and facade behaviors including bootstrap, mark-as-read and unit-sigla related error conditions.

### Description
- Added multiple unit tests for `FiltroMonitoramentoHttpTest` covering correlation id generation, sampling behavior, trace complete flag, slow/very-slow thresholds, request-context helpers and inactive mode.
- Extended `MonitoramentoAspectTest` with tests for constructor invocation and request-driven trace activation and fast/slow execution scenarios.
- Added alert-related tests in `AlertaFacadeTest` for obtaining read timestamps, marking alerts read (creating missing `AlertaUsuario` entries), and silent handling of `DataIntegrityViolationException` during save.
- Updated controller and facade tests: `PainelControllerTest` now tests `/api/painel/bootstrap` and POST `/api/painel/alertas/marcar-lidos`, and `PainelFacadeTest` includes bootstrap composition, mark-as-read delegation and error cases when user unit sigla is absent or blank; `SubprocessoControllerTest` and `SubprocessoConsultaServiceTest` gained tests for context loading and batch unit-loading in history retrieval.

### Testing
- Ran unit tests including `FiltroMonitoramentoHttpTest`, `MonitoramentoAspectTest`, `AlertaFacadeTest`, `PainelControllerTest`, `PainelFacadeTest`, `SubprocessoControllerTest`, and `SubprocessoConsultaServiceTest` and all tests passed.
- Verified new controller integration-style tests through `MockMvc` assertions and facade/service interactions using Mockito verifications, all succeeding.
- Confirmed exception and edge-case scenarios (e.g. missing sigla, empty lists, data integrity on save) are covered by assertions and did not fail in the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8e2ac520832b865b2b518b0fc347)