### PR TITLE
Racionaliza backlog e evita requisições duplicadas de contexto

### DIFF
--- a/backlog-racionalizacao.md
+++ b/backlog-racionalizacao.md
@@ -1,419 +1,94 @@
-# Backlog inicial de racionalização
+# Backlog de racionalização (pendências)
 
 ## Contexto
 
-Este backlog deriva de:
+Este backlog mantém **apenas** o que ainda falta executar a partir do plano de racionalização.
 
-- [plano-racionalizacao.md](/Users/leonardo/sgc/plano-racionalizacao.md)
+## Estado atual resumido
 
-## Hotspots observados
+- Painel (`/painel/processos` e `/painel/alertas`): frente estabilizada.
+- Contexto de processo e subprocesso: cache de sessão e invalidação explícita já implantados nas telas principais.
+- Diagnóstico organizacional e elegibilidade: frente estabilizada.
 
-### Hotspot 1: painel [RESOLVIDO]
+## Pendências prioritárias
 
-#### Evidência
+## Bloco A — fluxo de leitura e composição de tela
 
-- `GET /api/painel/processos?page=0&size=10&unidade=1`
-- `GET /api/painel/alertas?page=0&size=10&unidade=1&sort=dataHora,desc`
+### Item A.1 — consolidar sequência de abertura de processo/subprocesso
 
-Esses endpoints apareceram como os mais frequentes da amostra monitorada e se repetem em praticamente toda entrada de fluxo autenticado.
+**Objetivo**
 
-## Hotspot 2: contexto de processo [OTIMIZADO]
+Reduzir round-trips na abertura de tela quando ainda há composição por múltiplas chamadas em cadeia.
 
-#### Evidência
+**Escopo pendente**
 
-- `GET /api/processos/{codigo}/contexto-completo`
-- `GET /api/processos/{codigo}/detalhes`
+- mapear sequência canônica de requests em produção para:
+  - `GET /api/processos/{codigo}/contexto-completo`
+  - `GET /api/subprocessos/buscar`
+  - `GET /api/subprocessos/{codigo}/contexto-edicao`
+- confirmar pontos em que a UI depende de dados que já existem no payload anterior.
 
-Essas rotas aparecem repetidamente em múltiplos fluxos de processo.
+**Saída esperada**
 
-#### Sinais
+- grafo final por tela (detalhe de processo, detalhe de subprocesso, visualização de cadastro);
+- proposta concreta de contrato consolidado (bootstrap por caso de uso) **ou** justificativa para manter endpoints separados.
 
-- entram várias vezes na mesma jornada
-- convivem com outras chamadas complementares para subprocessos e árvore de unidades
-- podem estar entregando mais informação que a tela usa imediatamente
-- `GET /api/processos/400/contexto-completo` apareceu 26 vezes na execução integral
-- no reality check, `GET /api/processos/400/contexto-completo` apareceu 4 vezes só na jornada do ciclo completo
+### Item A.2 — revisar sobreposição entre `contexto-completo` e `detalhes`
 
-#### Hipóteses
+**Objetivo**
 
-- contexto excessivamente abrangente
-- reentrada em tela disparando recarga integral
-- oportunidade de segmentação por aba/estado ou cache local
+Eliminar sobreposição funcional e payload redundante no domínio de processo.
 
-## Hotspot 3: contexto de subprocesso [RESOLVIDO]
+**Escopo pendente**
 
-#### Evidência
+- inventariar campos realmente consumidos por cada tela;
+- separar o que é necessário na primeira renderização do que pode ser carregado sob demanda.
 
-- `GET /api/subprocessos/{codigo}/contexto-edicao`
-- `GET /api/subprocessos/buscar?...`
-- `GET /api/subprocessos/contexto-cadastro-atividades/buscar?...`
+**Saída esperada**
 
-Essas rotas aparecem em cascata e com repetição em várias jornadas.
+- tabela de consumo por tela;
+- recomendação de enxugamento de DTO/endpoint.
 
-#### Sinais
+## Bloco B — workflow com custo elevado
 
-- buscas e contextos são refeitos várias vezes na mesma navegação
-- navegação por cards/modais parece recompor contexto já conhecido
-- `GET /api/subprocessos/400/contexto-edicao` apareceu 33 vezes na execução integral
-- a repetição em poucos códigos sugere reabertura do mesmo contexto dentro do mesmo fluxo
-- no reality check, `GET /api/subprocessos/buscar?codProcesso=400&siglaUnidade=ASSESSORIA_11` apareceu 9 vezes em `jornada.spec.ts`
-- no reality check, `GET /api/subprocessos/400/contexto-edicao` apareceu 7 vezes em `jornada.spec.ts`
-- o mesmo padrão reaparece para o processo de revisão `401`
+### Item B.1 — abrir cadeia interna de `cadastro/disponibilizar`
 
-#### Hipóteses
+**Objetivo**
 
-- falta de cache ou reuso no frontend
-- design de tela pedindo dados fragmentados demais
-- possível consolidação de contratos orientados à edição/visualização
+Entender o outlier de latência e identificar simplificações de regra/persistência.
 
-## Hotspot 4: ações de workflow específicas
+**Escopo pendente**
 
-#### Evidência
+- rastrear validações, atualizações, notificações e recomputações;
+- medir tempo relativo por etapa com tracing interno.
 
-- `POST /api/subprocessos/{codigo}/cadastro/disponibilizar`
-- `POST /api/processos/{codigo}/iniciar`
-- `POST /api/processos/{codigo}/acao-em-bloco`
-- `POST /api/processos/{codigo}/finalizar`
+**Saída esperada**
 
-#### Sinais
+- top 3 gargalos com evidência;
+- lista de simplificações implementáveis em baixa complexidade.
 
-- `cadastro/disponibilizar` apareceu como outlier relevante
-- outras ações de workflow ficaram em geral rápidas, mas devem ser revisitadas com tracing interno
-- no reality check, o outlier mais claro de `captura.spec.ts` foi `POST /api/subprocessos/405/cadastro/disponibilizar` com 143 ms
-- no reality check, o ponto mais suspeito de `jornada.spec.ts` foi `GET /api/subprocessos/401/validar-cadastro` com 92 ms
+### Item B.2 — medir ações de workflow correlatas
 
-#### Hipóteses
+**Objetivo**
 
-- regra de negócio concentrada
-- muitas atualizações encadeadas
-- notificações, validações ou recomputações excessivas
+Comparar custo de `iniciar`, `acao-em-bloco`, `finalizar` e ações de subprocesso para priorização por impacto.
 
-## Hipóteses prioritárias
+**Saída esperada**
 
-## Hipótese A: telas recarregam mais do que precisam
+- matriz de latência por ação;
+- ordem de ataque para próxima rodada.
 
-### Descrição
+## Próximas rodadas (execução)
 
-Parte do custo percebido pode vir de recomposição repetida de estado no frontend.
+### Rodada 3 (em andamento)
 
-### Sinais a confirmar
+- concluir mapeamento de composição de requests por tela (Bloco A.1);
+- fechar inventário de sobreposição entre `contexto-completo` e `detalhes` (Bloco A.2).
 
-- mesma chamada disparada mais de uma vez na mesma rota sem mudança material
-- recarga total após ação pontual
-- watcher e mount acionando a mesma carga
-- `onMounted` e `onActivated` já confirmados em [PainelView.vue](/Users/leonardo/sgc/frontend/src/views/PainelView.vue) e [UnidadesView.vue](/Users/leonardo/sgc/frontend/src/views/UnidadesView.vue)
+### Rodada 4
 
-### Como validar
+- atacar outlier `cadastro/disponibilizar` com tracing e simplificações iniciais (Bloco B.1).
 
-- revisar `views`, `stores` e `composables` do painel
-- mapear triggers de fetch
-- identificar duplicatas consecutivas no log monitorado
+### Rodada 5
 
-## Hipótese B: `painel/alertas` faz trabalho mais pesado que `painel/processos`
-
-### Descrição
-
-`alertas` parece consistentemente mais caro e muito frequente.
-
-### Sinais a confirmar
-
-- joins extras
-- ordenação custosa
-- pós-processamento na camada de serviço
-- regras de permissão ou enriquecimento por item
-- há efeito colateral na mesma request: [PainelFacade.java](/Users/leonardo/sgc/backend/src/main/java/sgc/processo/painel/PainelFacade.java) também marca alertas como lidos
-
-### Como validar
-
-- abrir controller/service/repo relacionados
-- medir cadeia interna com `MonitoramentoAspect`
-- revisar eventual N+1 ou montagem excessiva de DTO
-
-## Hipótese C: `contexto-completo` e `contexto-edicao` entregam payload demais
-
-### Descrição
-
-Os contextos parecem ser chamados várias vezes e podem estar retornando mais do que a tela usa imediatamente.
-
-### Sinais a confirmar
-
-- payload grande
-- blocos da resposta não usados na primeira renderização
-- telas que pedem contexto integral e depois ainda fazem requests adicionais
-
-### Como validar
-
-- inspecionar contratos e consumo no frontend
-- verificar quais campos da resposta são usados por etapa da tela
-- avaliar segmentação do endpoint
-
-## Hipótese D: existem oportunidades de consolidação de API
-
-### Descrição
-
-Algumas telas parecem depender de múltiplos endpoints estáveis para montar um mesmo estado visual.
-
-### Como validar
-
-- mapear requests por tela
-- identificar grupos recorrentes disparados juntos
-- avaliar endpoint de bootstrap por caso de uso
-
-## Backlog executável
-
-## Bloco 1: painel
-
-### Item 1.1
-
-Mapear toda a cadeia de carregamento do painel no frontend.
-
-### Objetivo
-
-Descobrir quem dispara:
-
-- `painel/processos`
-- `painel/alertas`
-- `diagnostico-organizacional`
-
-### Saída esperada
-
-- lista de componentes/composables/stores envolvidos
-- gatilhos de recarga
-- duplicações observadas
-
-### Status atual
-
-- confirmado que o painel não chama `diagnostico-organizacional`
-- confirmado que o painel chama apenas `painel/processos` e `painel/alertas`
-- confirmado que o retorno para a rota pode recarregar ambos os blocos por `onActivated`
-- confirmado pelo reality check que essas chamadas continuam dominando a navegação real, não apenas a suíte completa
-
-### Item 1.2
-
-Mapear cadeia interna do backend para:
-
-- `GET /api/painel/processos`
-- `GET /api/painel/alertas`
-
-### Objetivo
-
-Descobrir onde o tempo é gasto dentro do backend.
-
-### Saída esperada
-
-- controller/facade/service/repo envolvidos
-- top métodos chamados
-- hipótese de N+1 ou enriquecimento excessivo
-
-### Status atual
-
-- controller confirmado: [PainelController.java](/Users/leonardo/sgc/backend/src/main/java/sgc/processo/painel/PainelController.java)
-- facade confirmada: [PainelFacade.java](/Users/leonardo/sgc/backend/src/main/java/sgc/processo/painel/PainelFacade.java)
-- ponto de atenção confirmado em `listarAlertas`: listar e marcar como lidos acontecem na mesma chamada
-- `processos` já trabalha em duas etapas no backend: busca de códigos e depois recarga com participantes em [ProcessoService.java](/Users/leonardo/sgc/backend/src/main/java/sgc/processo/service/ProcessoService.java)
-- `processos` também depende de mapa de hierarquia e eventual busca complementar de siglas na montagem do resumo
-
-### Item 1.2.1
-
-Abrir a cadeia de `processoService`, `alertaFacade` e repositórios usados pelo painel.
-
-### Objetivo
-
-Trocar hipótese genérica de fan-out interno por evidência concreta de consultas, enriquecimentos e possível N+1.
-
-### Saída esperada
-
-- mapa completo da cadeia interna
-- pontos de agregação ou simplificação
-- primeira proposta de otimização backend
-
-### Foco inicial sugerido
-
-- medir o custo relativo de `listarCodigosPorParticipantesESituacaoDiferente` versus `listarPorCodigosComParticipantes`
-- medir o custo de `alertaFacade.listarPorUnidade`, `obterMapaDataHoraLeitura` e `marcarComoLidos`
-- verificar se a montagem de `unidadesParticipantes` no painel está puxando trabalho demais para cada item
-
-## Bloco 2A: sequência de leitura do subprocesso
-
-### Item 2A.1
-
-Rastrear e racionalizar o trio `processos/{codigo}/contexto-completo` + `subprocessos/buscar` + `subprocessos/{codigo}/contexto-edicao`.
-
-### Objetivo
-
-Entender por que a mesma navegação reabre repetidamente o mesmo contexto dentro de `jornada.spec.ts`.
-
-### Saída esperada
-
-- grafo exato de requests por tela
-- identificação de reabertura redundante
-- proposta de cache ou consolidação orientada ao fluxo
-
-### Prioridade
-
-Alta. O padrão apareceu de forma limpa no reality check e não parece ser mero artefato da suíte completa.
-
-### Item 1.3
-
-Avaliar se o painel pode ter endpoint de bootstrap.
-
-### Objetivo
-
-Reduzir round-trips de entrada de tela.
-
-### Saída esperada
-
-- proposta de contrato
-- custo/benefício de adoção
-
-## Bloco 1A: diagnóstico organizacional e elegibilidade [RESOLVIDO]
-
-### Item 1A.1
-
-Racionalizar o carregamento de `diagnostico-organizacional`.
-
-### Objetivo
-
-Reduzir repetição de uma chamada administrativa que já possui cache no backend, mas segue aparecendo com frequência alta na suíte.
-
-### Saída esperada
-
-- mapa de telas chamadoras
-- estratégia de reuso no frontend
-- política explícita de invalidação
-
-### Status atual
-
-- chamadores confirmados: [ProcessoCadastroView.vue](/Users/leonardo/sgc/frontend/src/views/ProcessoCadastroView.vue) e [UnidadesView.vue](/Users/leonardo/sgc/frontend/src/views/UnidadesView.vue)
-- backend já usa cache em [ValidadorDadosOrganizacionais.java](/Users/leonardo/sgc/backend/src/main/java/sgc/organizacao/ValidadorDadosOrganizacionais.java)
-
-### Item 1A.2
-
-Racionalizar o carregamento de `arvore-com-elegibilidade`.
-
-### Objetivo
-
-Evitar recargas repetidas da árvore quando `tipoProcesso` e `codProcesso` não mudaram materialmente.
-
-### Saída esperada
-
-- confirmação dos gatilhos de tela
-- estratégia de reuso no frontend
-- revisão do custo interno no backend
-
-### Status atual
-
-- chamador confirmado: [ProcessoCadastroView.vue](/Users/leonardo/sgc/frontend/src/views/ProcessoCadastroView.vue)
-- já existe memoização local por `ultimaBuscaUnidades`, mas ainda falta validar o comportamento em reentrada de rota e edição
-
-## Bloco 2: processo
-
-### Item 2.1
-
-Inventariar consumo de `processo/{codigo}/contexto-completo` e `processo/{codigo}/detalhes`.
-
-### Objetivo
-
-Entender se há sobreposição funcional entre os dois.
-
-### Saída esperada
-
-- tabela com telas consumidoras
-- dados usados por tela
-- pontos de redundância
-
-### Item 2.2
-
-Rastrear sequência de requests ao abrir detalhes de processo.
-
-### Objetivo
-
-Entender se a tela depende de composição fragmentada demais.
-
-### Saída esperada
-
-- sequência canônica de requests
-- oportunidades de consolidação
-
-## Bloco 3: subprocesso
-
-### Item 3.1
-
-Mapear sequência de requests de abertura e edição de subprocesso.
-
-### Objetivo
-
-Entender o fan-out entre:
-
-- `subprocessos/buscar`
-- `subprocessos/{codigo}/contexto-edicao`
-- `contexto-cadastro-atividades/buscar`
-
-### Saída esperada
-
-- grafo da sequência
-- duplicações
-- oportunidades de cache e consolidação
-
-### Item 3.2
-
-Avaliar endpoint de contexto orientado ao estado atual da tela.
-
-### Objetivo
-
-Reduzir ida e volta para cards, mapas, cadastro e revisão.
-
-## Bloco 4: workflow e ações lentas
-
-### Item 4.1
-
-Abrir fluxo de `cadastro/disponibilizar`.
-
-### Objetivo
-
-Entender por que apareceu como outlier.
-
-### Saída esperada
-
-- cadeia interna
-- hipóteses de custo
-- primeira lista de simplificações possíveis
-
-### Item 4.2
-
-Medir ações de workflow com tracing interno.
-
-### Objetivo
-
-Separar custo de:
-
-- validação
-- atualização de estado
-- persistência
-- notificações
-
-## Sequência sugerida
-
-1. Painel backend
-2. Sequência de leitura do subprocesso
-3. Diagnóstico organizacional e elegibilidade
-4. Processo `contexto-completo`
-5. `cadastro/disponibilizar`
-
-## Entregáveis esperados das próximas rodadas
-
-### Rodada 1
-
-- cadeia interna do painel
-- mapa de chamadores de diagnóstico organizacional e elegibilidade
-- lista curta de ajustes imediatos
-
-### Rodada 2
-
-- revisão de `contexto-completo`
-- revisão de `contexto-edicao`
-- proposta de redução de round-trips
-
-### Rodada 3
-- ajustes de API e frontend
-- validação comparativa antes/depois
+- consolidar medições comparativas das ações de workflow e priorizar nova leva de refatorações (Bloco B.2).

--- a/frontend/src/stores/__tests__/processo.spec.ts
+++ b/frontend/src/stores/__tests__/processo.spec.ts
@@ -77,6 +77,23 @@ describe("processo store", () => {
             expect(context.store.invalido).toBe(false);
         });
 
+        it("deve reutilizar carregamento em andamento para evitar requisições duplicadas", async () => {
+            let resolver!: (valor: any) => void;
+            const promessa = new Promise<any>((resolve) => {
+                resolver = resolve;
+            });
+            vi.mocked(processoService.buscarContextoCompleto).mockReturnValue(promessa);
+
+            const requisicaoA = context.store.garantirContextoCompleto(1);
+            const requisicaoB = context.store.garantirContextoCompleto(1);
+
+            expect(processoService.buscarContextoCompleto).toHaveBeenCalledTimes(1);
+            resolver({codigo: 1});
+
+            await expect(requisicaoA).resolves.toEqual({codigo: 1});
+            await expect(requisicaoB).resolves.toEqual({codigo: 1});
+        });
+
         it("deve lançar erro se o service falhar", async () => {
             const error = new Error("Erro API");
             vi.mocked(processoService.buscarContextoCompleto).mockRejectedValue(error);

--- a/frontend/src/stores/__tests__/subprocesso.spec.ts
+++ b/frontend/src/stores/__tests__/subprocesso.spec.ts
@@ -77,6 +77,23 @@ describe("subprocesso store", () => {
             expect(context.store.invalido).toBe(false);
         });
 
+        it("deve reutilizar carregamento em andamento por código", async () => {
+            let resolver!: (valor: any) => void;
+            const promessa = new Promise<any>((resolve) => {
+                resolver = resolve;
+            });
+            vi.mocked(subprocessoService.buscarContextoEdicao).mockReturnValue(promessa);
+
+            const requisicaoA = context.store.garantirContextoEdicao(1);
+            const requisicaoB = context.store.garantirContextoEdicao(1);
+
+            expect(subprocessoService.buscarContextoEdicao).toHaveBeenCalledTimes(1);
+            resolver({detalhes: {unidade: {sigla: "TEST"}}});
+
+            await expect(requisicaoA).resolves.toEqual({detalhes: {unidade: {sigla: "TEST"}}});
+            await expect(requisicaoB).resolves.toEqual({detalhes: {unidade: {sigla: "TEST"}}});
+        });
+
         it("deve retornar null e logar erro se o service falhar", async () => {
             vi.mocked(subprocessoService.buscarContextoEdicao).mockRejectedValue(new Error("Erro API"));
 
@@ -115,6 +132,36 @@ describe("subprocesso store", () => {
             expect(context.store.contextoEdicao).toEqual(mockContexto);
             expect(context.store.codSubprocessoCarregado).toBe(20);
             expect(context.store.invalido).toBe(false);
+        });
+
+        it("deve reutilizar carregamento em andamento por processo+unidade", async () => {
+            let resolverSubprocesso!: (valor: any) => void;
+            let resolverContexto!: (valor: any) => void;
+            const promessaSubprocesso = new Promise<any>((resolve) => {
+                resolverSubprocesso = resolve;
+            });
+            const promessaContexto = new Promise<any>((resolve) => {
+                resolverContexto = resolve;
+            });
+            vi.mocked(subprocessoService.buscarSubprocessoPorProcessoEUnidade).mockReturnValue(promessaSubprocesso);
+            vi.mocked(subprocessoService.buscarContextoEdicao).mockReturnValue(promessaContexto);
+
+            const requisicaoA = context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
+            const requisicaoB = context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
+
+            expect(subprocessoService.buscarSubprocessoPorProcessoEUnidade).toHaveBeenCalledTimes(1);
+            resolverSubprocesso({codigo: 20});
+            resolverContexto({detalhes: {unidade: {sigla: "TEST"}}});
+
+            await expect(requisicaoA).resolves.toEqual({
+                codigo: 20,
+                contexto: {detalhes: {unidade: {sigla: "TEST"}}}
+            });
+            await expect(requisicaoB).resolves.toEqual({
+                codigo: 20,
+                contexto: {detalhes: {unidade: {sigla: "TEST"}}}
+            });
+            expect(subprocessoService.buscarContextoEdicao).toHaveBeenCalledTimes(1);
         });
 
         it("deve retornar null e logar erro se a busca falhar", async () => {

--- a/frontend/src/stores/processo.ts
+++ b/frontend/src/stores/processo.ts
@@ -18,6 +18,7 @@ export const useProcessoStore = defineStore("processo", () => {
     const contextoCompleto = ref<Processo | null>(null);
     const codProcessoCarregado = ref<number | null>(null);
     const invalido = ref(true);
+    const carregamentosEmAndamento = new Map<number, Promise<Processo>>();
 
     /** Contexto ainda é válido para o processo dado? */
     function dadosValidos(codProcesso: number): boolean {
@@ -27,6 +28,7 @@ export const useProcessoStore = defineStore("processo", () => {
     /** Invalida o cache — deve ser chamado após qualquer ação de workflow que altera o processo. */
     function invalidar(): void {
         invalido.value = true;
+        carregamentosEmAndamento.clear();
     }
 
     /**
@@ -38,8 +40,15 @@ export const useProcessoStore = defineStore("processo", () => {
             return contextoCompleto.value;
         }
 
+        const carregamentoExistente = carregamentosEmAndamento.get(codProcesso);
+        if (carregamentoExistente) {
+            return carregamentoExistente;
+        }
+
         try {
-            const data = await serviceBuscarContextoCompleto(codProcesso);
+            const promessaCarregamento = serviceBuscarContextoCompleto(codProcesso);
+            carregamentosEmAndamento.set(codProcesso, promessaCarregamento);
+            const data = await promessaCarregamento;
             contextoCompleto.value = data;
             codProcessoCarregado.value = codProcesso;
             invalido.value = false;
@@ -47,6 +56,8 @@ export const useProcessoStore = defineStore("processo", () => {
         } catch (err) {
             logger.error(`Erro ao buscar contexto completo do processo ${codProcesso}:`, err);
             throw err; // relança para que a view possa exibir erro inline
+        } finally {
+            carregamentosEmAndamento.delete(codProcesso);
         }
     }
 

--- a/frontend/src/stores/subprocesso.ts
+++ b/frontend/src/stores/subprocesso.ts
@@ -21,6 +21,13 @@ export const useSubprocessoStore = defineStore("subprocesso", () => {
     const contextoEdicao = ref<ContextoEdicaoSubprocesso | null>(null);
     const codSubprocessoCarregado = ref<number | null>(null);
     const invalido = ref(true);
+    const carregamentosPorCodigo = new Map<number, Promise<ContextoEdicaoSubprocesso>>();
+    const carregamentosPorProcessoUnidade = new Map<string, Promise<{ codigo: number; contexto: ContextoEdicaoSubprocesso }>>();
+    const mapaProcessoUnidadeParaCodigo = new Map<string, number>();
+
+    function gerarChaveProcessoUnidade(codProcesso: number, siglaUnidade: string): string {
+        return `${codProcesso}:${siglaUnidade}`;
+    }
 
     /** Contexto ainda é válido para o subprocesso dado? */
     function dadosValidos(codSubprocesso: number): boolean {
@@ -30,6 +37,9 @@ export const useSubprocessoStore = defineStore("subprocesso", () => {
     /** Invalida o cache — deve ser chamado após qualquer ação de workflow. */
     function invalidar(): void {
         invalido.value = true;
+        carregamentosPorCodigo.clear();
+        carregamentosPorProcessoUnidade.clear();
+        mapaProcessoUnidadeParaCodigo.clear();
     }
 
     /**
@@ -41,8 +51,15 @@ export const useSubprocessoStore = defineStore("subprocesso", () => {
             return contextoEdicao.value;
         }
 
+        const carregamentoExistente = carregamentosPorCodigo.get(codSubprocesso);
+        if (carregamentoExistente) {
+            return carregamentoExistente;
+        }
+
         try {
-            const data = await serviceBuscarContextoEdicao(codSubprocesso);
+            const promessaCarregamento = serviceBuscarContextoEdicao(codSubprocesso);
+            carregamentosPorCodigo.set(codSubprocesso, promessaCarregamento);
+            const data = await promessaCarregamento;
             contextoEdicao.value = data;
             codSubprocessoCarregado.value = codSubprocesso;
             invalido.value = false;
@@ -50,6 +67,8 @@ export const useSubprocessoStore = defineStore("subprocesso", () => {
         } catch (err) {
             logger.error(`Erro ao buscar contexto de edição do subprocesso ${codSubprocesso}:`, err);
             return null;
+        } finally {
+            carregamentosPorCodigo.delete(codSubprocesso);
         }
     }
 
@@ -61,25 +80,52 @@ export const useSubprocessoStore = defineStore("subprocesso", () => {
         codProcesso: number,
         siglaUnidade: string
     ): Promise<{ codigo: number; contexto: ContextoEdicaoSubprocesso } | null> {
+        const chaveProcessoUnidade = gerarChaveProcessoUnidade(codProcesso, siglaUnidade);
+
         // Reutiliza cache se já temos contexto válido para a mesma unidade
         if (contextoEdicao.value && !invalido.value && codSubprocessoCarregado.value !== null) {
             const siglaCarregada = contextoEdicao.value.detalhes?.unidade?.sigla;
             if (siglaCarregada === siglaUnidade) {
+                mapaProcessoUnidadeParaCodigo.set(chaveProcessoUnidade, codSubprocessoCarregado.value);
                 return {codigo: codSubprocessoCarregado.value, contexto: contextoEdicao.value};
             }
         }
 
+        const codigoMapeado = mapaProcessoUnidadeParaCodigo.get(chaveProcessoUnidade);
+        if (typeof codigoMapeado === "number") {
+            const contexto = await garantirContextoEdicao(codigoMapeado);
+            if (contexto) {
+                return {codigo: codigoMapeado, contexto};
+            }
+        }
+
+        const carregamentoExistente = carregamentosPorProcessoUnidade.get(chaveProcessoUnidade);
+        if (carregamentoExistente) {
+            return carregamentoExistente;
+        }
+
         try {
-            const dto = await serviceBuscarSubprocessoPorProcessoEUnidade(codProcesso, siglaUnidade);
-            const codigo = dto.codigo;
-            const data = await serviceBuscarContextoEdicao(codigo);
-            contextoEdicao.value = data;
+            const promessaCarregamento = (async () => {
+                const dto = await serviceBuscarSubprocessoPorProcessoEUnidade(codProcesso, siglaUnidade);
+                const codigo = dto.codigo;
+                mapaProcessoUnidadeParaCodigo.set(chaveProcessoUnidade, codigo);
+                const data = await garantirContextoEdicao(codigo);
+                if (!data) {
+                    throw new Error(`Contexto de edição indisponível para subprocesso ${codigo}`);
+                }
+                return {codigo, contexto: data};
+            })();
+            carregamentosPorProcessoUnidade.set(chaveProcessoUnidade, promessaCarregamento);
+            const {codigo, contexto} = await promessaCarregamento;
+            contextoEdicao.value = contexto;
             codSubprocessoCarregado.value = codigo;
             invalido.value = false;
-            return {codigo, contexto: data};
+            return {codigo, contexto};
         } catch (err) {
             logger.error(`Erro ao buscar contexto de subprocesso para processo ${codProcesso} unidade ${siglaUnidade}:`, err);
             return null;
+        } finally {
+            carregamentosPorProcessoUnidade.delete(chaveProcessoUnidade);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Consolidar o backlog mantendo apenas as pendências reais para as próximas rodadas de execução e foco em reduzir round-trips de UI.
- Evitar chamadas simultâneas duplicadas que ocorriam nas telas de detalhe, reduzindo carga e latência percebida sem mudar contratos de API.

### Description
- Atualiza `backlog-racionalizacao.md` para deixar apenas os itens pendentes e prioridades de execução (consolidação de requests, revisão de sobreposição de payload e análise de workflows caros) em `backlog-racionalizacao.md`.
- Adiciona deduplicação de carregamentos em andamento no `useProcessoStore` (arquivo `frontend/src/stores/processo.ts`) usando um `Map` por `codProcesso` e limpando esse estado em `invalidar()`; a função principal afetada é `garantirContextoCompleto`.
- Adiciona deduplicação mais completa no `useSubprocessoStore` (arquivo `frontend/src/stores/subprocesso.ts`), com caches de promessa por código, por chave `processo:unidade`, mapeamento `processo+unidade -> codigo` e limpeza em `invalidar()`; as funções `garantirContextoEdicao` e `garantirContextoEdicaoPorProcessoEUnidade` foram adaptadas para reaproveitar promessas e mapeamentos.
- Amplia os testes unitários em `frontend/src/stores/__tests__/processo.spec.ts` e `frontend/src/stores/__tests__/subprocesso.spec.ts` para cobrir cenários de concorrência e garantir que requisições simultâneas reutilizem a mesma promessa.

### Testing
- Executados os testes unitários com `npm run test:unit -- src/stores/__tests__/processo.spec.ts src/stores/__tests__/subprocesso.spec.ts` e todas as specs passaram (`2 files, 22 tests passed`).
- Executado o typecheck com `npm run typecheck` e o checador TypeScript (`vue-tsc`) completou sem erros.
- Os testes unitários e o typecheck foram executados localmente e concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab0ec079c832b9a3fa373ec6d0d59)