### PR TITLE
Optimize sigla lookups and consolidate subprocesso context requests (cache + API changes)

### DIFF
--- a/backend/src/main/java/sgc/comum/config/CacheConfig.java
+++ b/backend/src/main/java/sgc/comum/config/CacheConfig.java
@@ -15,6 +15,8 @@ public class CacheConfig {
     public static final String CACHE_MAPA_HIERARQUIA_UNIDADES = "mapaHierarquiaUnidades";
     public static final String CACHE_UNIDADES_COM_MAPA = "unidadesComMapa";
     public static final String CACHE_UNIDADE_ADMIN = "unidadeAdmin";
+    public static final String CACHE_UNIDADE_POR_SIGLA = "unidadePorSigla";
+    public static final String CACHE_UNIDADE_CODIGO_POR_SIGLA = "unidadeCodigoPorSigla";
     public static final String CACHE_MAPA_FILHO_PAI = "mapaFilhoPai";
     public static final String CACHE_USUARIO_PERFIS = "usuarioPerfis";
     public static final String CACHE_USUARIO_AUTORIZACOES = "usuarioAutorizacoes";
@@ -27,6 +29,8 @@ public class CacheConfig {
                 CACHE_MAPA_HIERARQUIA_UNIDADES,
                 CACHE_UNIDADES_COM_MAPA,
                 CACHE_UNIDADE_ADMIN,
+                CACHE_UNIDADE_POR_SIGLA,
+                CACHE_UNIDADE_CODIGO_POR_SIGLA,
                 CACHE_USUARIO_PERFIS,
                 CACHE_USUARIO_AUTORIZACOES
         );
@@ -37,6 +41,16 @@ public class CacheConfig {
         cacheManager.registerCustomCache(CACHE_UNIDADE_ADMIN, Caffeine.newBuilder()
                 .recordStats()
                 .maximumSize(1)
+                .expireAfterWrite(java.time.Duration.ofHours(12))
+                .build());
+        cacheManager.registerCustomCache(CACHE_UNIDADE_POR_SIGLA, Caffeine.newBuilder()
+                .recordStats()
+                .maximumSize(300)
+                .expireAfterWrite(java.time.Duration.ofHours(12))
+                .build());
+        cacheManager.registerCustomCache(CACHE_UNIDADE_CODIGO_POR_SIGLA, Caffeine.newBuilder()
+                .recordStats()
+                .maximumSize(500)
                 .expireAfterWrite(java.time.Duration.ofHours(12))
                 .build());
         cacheManager.registerCustomCache(CACHE_MAPA_FILHO_PAI, Caffeine.newBuilder()

--- a/backend/src/main/java/sgc/e2e/E2eController.java
+++ b/backend/src/main/java/sgc/e2e/E2eController.java
@@ -267,8 +267,7 @@ public class E2eController {
         Processo processo = executeAsAdmin(() -> criarProcessoFixture(request, TipoProcesso.MAPEAMENTO));
         Long codProcesso = processo.getCodigo();
         
-        Unidade unidade = unidadeService.buscarPorSigla(request.unidadeSigla());
-        Long codUnidade = unidade.getCodigo();
+        Long codUnidade = unidadeService.buscarCodigoPorSigla(request.unidadeSigla());
 
         Long codSubprocesso = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcesso, codUnidade)
                 .map(Subprocesso::getCodigo)
@@ -327,9 +326,9 @@ public class E2eController {
     @JsonView(ProcessoViews.Publica.class)
     public Processo criarProcessoMapeamentoComMapaComSugestoes(@RequestBody ProcessoFixtureRequest request) {
         Processo processo = criarProcessoMapeamentoComMapaNaSituacao(request, "MAPEAMENTO_MAPA_COM_SUGESTOES");
-        Unidade unidade = unidadeService.buscarPorSigla(request.unidadeSigla());
+        Long codUnidade = unidadeService.buscarCodigoPorSigla(request.unidadeSigla());
         Long codSubprocesso = subprocessoRepo
-                .findByProcessoCodigoAndUnidadeCodigo(processo.getCodigo(), unidade.getCodigo())
+                .findByProcessoCodigoAndUnidadeCodigo(processo.getCodigo(), codUnidade)
                 .map(Subprocesso::getCodigo)
                 .orElseThrow();
         Mapa mapa = mapaRepo.buscarPorSubprocesso(codSubprocesso).orElseThrow();
@@ -509,8 +508,9 @@ public class E2eController {
 
         Long codProcesso = processo.getCodigo();
         Unidade unidade = unidadeService.buscarPorSigla(request.unidadeSigla());
+        Long codUnidade = unidade.getCodigo();
         Unidade admin = unidadeService.buscarAdmin();
-        Long codSubprocesso = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcesso, unidade.getCodigo())
+        Long codSubprocesso = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcesso, codUnidade)
                 .map(Subprocesso::getCodigo)
                 .orElseThrow();
         Long codMapa = mapaRepo.buscarPorSubprocesso(codSubprocesso)
@@ -581,12 +581,13 @@ public class E2eController {
 
         int diasLimite = request.diasLimite() != null ? request.diasLimite() : 30;
         Unidade unidade = unidadeService.buscarPorSigla(request.unidadeSigla());
+        Long codUnidade = unidade.getCodigo();
         Unidade admin = unidadeService.buscarAdmin();
 
         ProcessoFixtureRequest requestMapeamento = ProcessoFixtureRequest.mapaBase(request.unidadeSigla(), diasLimite);
         Processo processoMapeamento = criarProcessoFixture(requestMapeamento, TipoProcesso.MAPEAMENTO);
         Long codProcessoMapeamento = processoMapeamento.getCodigo();
-        Long codSubprocessoMapeamento = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcessoMapeamento, unidade.getCodigo())
+        Long codSubprocessoMapeamento = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcessoMapeamento, codUnidade)
                 .map(Subprocesso::getCodigo)
                 .orElseThrow();
         Long codMapaVigente = mapaRepo.buscarPorSubprocesso(codSubprocessoMapeamento)
@@ -603,9 +604,9 @@ public class E2eController {
 
         setSituacaoSubprocesso(codSubprocessoMapeamento, SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO);
         setSituacaoProcesso(codProcessoMapeamento);
-        jdbcTemplate.update("DELETE FROM sgc.unidade_mapa WHERE unidade_codigo = ?", unidade.getCodigo());
+        jdbcTemplate.update("DELETE FROM sgc.unidade_mapa WHERE unidade_codigo = ?", codUnidade);
         jdbcTemplate.update("INSERT INTO sgc.unidade_mapa (unidade_codigo, mapa_vigente_codigo) VALUES (?, ?)",
-                unidade.getCodigo(), codMapaVigente);
+                codUnidade, codMapaVigente);
         limparCaches();
 
         ProcessoFixtureRequest requestRevisao = ProcessoFixtureRequest.iniciado(
@@ -615,7 +616,7 @@ public class E2eController {
         );
         Processo processoRevisao = criarProcessoFixture(requestRevisao, TipoProcesso.REVISAO);
         Long codProcessoRevisao = processoRevisao.getCodigo();
-        Long codSubprocessoRevisao = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcessoRevisao, unidade.getCodigo())
+        Long codSubprocessoRevisao = subprocessoRepo.findByProcessoCodigoAndUnidadeCodigo(codProcessoRevisao, codUnidade)
                 .map(Subprocesso::getCodigo)
                 .orElseThrow();
         Long codMapaRevisao = mapaRepo.buscarPorSubprocesso(codSubprocessoRevisao)
@@ -712,7 +713,7 @@ public class E2eController {
             throw new ErroValidacao("Unidade é obrigatória");
         }
 
-        Unidade unidade = unidadeService.buscarPorSigla(request.unidadeSigla());
+        Long codUnidade = unidadeService.buscarCodigoPorSigla(request.unidadeSigla());
 
         int diasLimite = request.diasLimite() != null ? request.diasLimite() : 30;
         LocalDateTime dataLimite = LocalDate.now().plusDays(diasLimite).atStartOfDay();
@@ -729,13 +730,13 @@ public class E2eController {
                 .descricao(descricao)
                 .tipo(tipo)
                 .dataLimiteEtapa1(dataLimite)
-                .unidades(List.of(unidade.getCodigo()))
+                .unidades(List.of(codUnidade))
                 .build();
 
         Processo processo = processoService.criar(criarReq);
 
         if (Boolean.TRUE.equals(request.iniciar())) {
-            List<Long> unidades = List.of(unidade.getCodigo());
+            List<Long> unidades = List.of(codUnidade);
             Long processoCodigo = processo.getCodigo();
             processoService.iniciar(processoCodigo, unidades);
 

--- a/backend/src/main/java/sgc/organizacao/UnidadeController.java
+++ b/backend/src/main/java/sgc/organizacao/UnidadeController.java
@@ -97,7 +97,7 @@ public class UnidadeController {
     @GetMapping("/sigla/{siglaUnidade}")
     public ResponseEntity<UnidadeDto> buscarUnidadePorSigla(
             @PathVariable @Pattern(regexp = "^[a-zA-Z0-9_.-]+$") String siglaUnidade) {
-        Unidade unidade = unidadeService.buscarPorSigla(siglaUnidade);
+        Unidade unidade = unidadeService.buscarPorSiglaComResponsavel(siglaUnidade);
         return ResponseEntity.ok(UnidadeDto.fromEntityObrigatoria(unidade));
     }
 

--- a/backend/src/main/java/sgc/organizacao/model/UnidadeRepo.java
+++ b/backend/src/main/java/sgc/organizacao/model/UnidadeRepo.java
@@ -94,6 +94,14 @@ public interface UnidadeRepo extends JpaRepository<Unidade, Long> {
             """)
     Optional<Unidade> buscarPorSiglaComResponsavel(@Param("sigla") String sigla);
 
+    @Query("""
+            SELECT u FROM Unidade u
+            LEFT JOIN FETCH u.unidadeSuperior
+            WHERE UPPER(u.sigla) = UPPER(:sigla)
+            AND u.situacao = SituacaoUnidade.ATIVA
+            """)
+    Optional<Unidade> buscarPorSiglaComSuperior(@Param("sigla") String sigla);
+
     List<Unidade> findByUnidadeSuperiorCodigoAndSituacao(Long unidadeSuperiorCodigo, SituacaoUnidade situacao);
 
     default List<Unidade> findByUnidadeSuperiorCodigo(Long unidadeSuperiorCodigo) {

--- a/backend/src/main/java/sgc/organizacao/service/UnidadeService.java
+++ b/backend/src/main/java/sgc/organizacao/service/UnidadeService.java
@@ -40,8 +40,15 @@ public class UnidadeService {
                 .orElseThrow(() -> new ErroEntidadeNaoEncontrada(Unidade.class.getSimpleName(), codigo));
     }
 
+    @Cacheable(cacheNames = CacheConfig.CACHE_UNIDADE_POR_SIGLA, key = "#sigla.toUpperCase()", sync = true)
     public Unidade buscarPorSigla(String sigla) {
         return unidadeRepo.buscarPorSiglaComResponsavel(sigla)
+                .orElseThrow(() -> new ErroEntidadeNaoEncontrada(Unidade.class.getSimpleName(), sigla));
+    }
+
+    @Cacheable(cacheNames = CacheConfig.CACHE_UNIDADE_CODIGO_POR_SIGLA, key = "#sigla.toUpperCase()", sync = true)
+    public Long buscarCodigoPorSigla(String sigla) {
+        return unidadeRepo.buscarCodigoAtivoPorSigla(sigla)
                 .orElseThrow(() -> new ErroEntidadeNaoEncontrada(Unidade.class.getSimpleName(), sigla));
     }
 

--- a/backend/src/main/java/sgc/organizacao/service/UnidadeService.java
+++ b/backend/src/main/java/sgc/organizacao/service/UnidadeService.java
@@ -42,6 +42,11 @@ public class UnidadeService {
 
     @Cacheable(cacheNames = CacheConfig.CACHE_UNIDADE_POR_SIGLA, key = "#sigla.toUpperCase()", sync = true)
     public Unidade buscarPorSigla(String sigla) {
+        return unidadeRepo.buscarPorSiglaComSuperior(sigla)
+                .orElseThrow(() -> new ErroEntidadeNaoEncontrada(Unidade.class.getSimpleName(), sigla));
+    }
+
+    public Unidade buscarPorSiglaComResponsavel(String sigla) {
         return unidadeRepo.buscarPorSiglaComResponsavel(sigla)
                 .orElseThrow(() -> new ErroEntidadeNaoEncontrada(Unidade.class.getSimpleName(), sigla));
     }

--- a/backend/src/main/java/sgc/subprocesso/SubprocessoController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoController.java
@@ -61,8 +61,8 @@ public class SubprocessoController {
     @PostAuthorize("hasPermission(returnObject.body.codigo, 'Subprocesso', 'VISUALIZAR_SUBPROCESSO')")
     public ResponseEntity<SubprocessoCodigoDto> buscarPorProcessoEUnidade(
             @RequestParam Long codProcesso, @RequestParam String siglaUnidade) {
-        Unidade unidade = unidadeService.buscarPorSigla(siglaUnidade);
-        Subprocesso sp = consultaService.obterEntidadePorProcessoEUnidade(codProcesso, unidade.getCodigo());
+        Long codUnidade = unidadeService.buscarCodigoPorSigla(siglaUnidade);
+        Subprocesso sp = consultaService.obterEntidadePorProcessoEUnidade(codProcesso, codUnidade);
         return ResponseEntity.ok(new SubprocessoCodigoDto(sp.getCodigo()));
     }
 
@@ -145,8 +145,8 @@ public class SubprocessoController {
             @RequestParam Long codProcesso,
             @RequestParam String siglaUnidade
     ) {
-        Unidade unidade = unidadeService.buscarPorSigla(siglaUnidade);
-        Subprocesso subprocesso = consultaService.obterEntidadePorProcessoEUnidade(codProcesso, unidade.getCodigo());
+        Long codUnidade = unidadeService.buscarCodigoPorSigla(siglaUnidade);
+        Subprocesso subprocesso = consultaService.obterEntidadePorProcessoEUnidade(codProcesso, codUnidade);
         return ResponseEntity.ok(consultaService.obterContextoEdicao(subprocesso.getCodigo()));
     }
 
@@ -156,8 +156,8 @@ public class SubprocessoController {
             @RequestParam Long codProcesso,
             @RequestParam String siglaUnidade
     ) {
-        Unidade unidade = unidadeService.buscarPorSigla(siglaUnidade);
-        Subprocesso subprocesso = consultaService.obterEntidadePorProcessoEUnidade(codProcesso, unidade.getCodigo());
+        Long codUnidade = unidadeService.buscarCodigoPorSigla(siglaUnidade);
+        Subprocesso subprocesso = consultaService.obterEntidadePorProcessoEUnidade(codProcesso, codUnidade);
         return ResponseEntity.ok(consultaService.obterContextoCadastroAtividades(subprocesso.getCodigo()));
     }
 

--- a/backend/src/test/java/sgc/e2e/E2eControllerTest.java
+++ b/backend/src/test/java/sgc/e2e/E2eControllerTest.java
@@ -246,9 +246,7 @@ class E2eControllerTest {
         E2eController.ProcessoFixtureRequest req = new E2eController.ProcessoFixtureRequest(
                 null, "SIGLA", false, null);
 
-        Unidade un = new Unidade();
-        un.setCodigo(1L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(1L);
 
         Processo proc = new Processo();
         proc.setCodigo(100L);
@@ -267,9 +265,7 @@ class E2eControllerTest {
         E2eController.ProcessoFixtureRequest req = new E2eController.ProcessoFixtureRequest(
                 "Desc", "SIGLA", true, 10);
 
-        Unidade un = new Unidade();
-        un.setCodigo(1L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(1L);
 
         Processo proc = new Processo();
         proc.setCodigo(100L);
@@ -289,9 +285,7 @@ class E2eControllerTest {
         E2eController.ProcessoFixtureRequest req = new E2eController.ProcessoFixtureRequest(
                 "Desc", "SIGLA", true, 10);
 
-        Unidade un = new Unidade();
-        un.setCodigo(1L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(1L);
 
         Processo proc = new Processo();
         proc.setCodigo(100L);
@@ -370,9 +364,7 @@ class E2eControllerTest {
         E2eController.ProcessoFixtureRequest req = new E2eController.ProcessoFixtureRequest(
                 "Desc", "SIGLA", true, 10);
 
-        Unidade un = new Unidade();
-        un.setCodigo(1L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(1L);
 
         Processo proc = new Processo();
         proc.setCodigo(100L);
@@ -396,9 +388,7 @@ class E2eControllerTest {
         E2eController.ProcessoFixtureRequest req = new E2eController.ProcessoFixtureRequest(
                 "   ", "SIGLA", true, 10); // Blank description
 
-        Unidade un = new Unidade();
-        un.setCodigo(1L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(1L);
 
         Processo proc = new Processo();
         proc.setCodigo(100L);
@@ -474,7 +464,7 @@ class E2eControllerTest {
         @DisplayName("criarProcessoFixture: Unidade não encontrada")
         void criarProcessoFixture_UnidadeNaoEncontrada() {
             var req = new E2eController.ProcessoFixtureRequest("Desc", "SIGLA", false, 30);
-            when(unidadeServiceMock.buscarPorSigla("SIGLA")).thenThrow(new ErroEntidadeNaoEncontrada("Unidade", "SIGLA"));
+            when(unidadeServiceMock.buscarCodigoPorSigla("SIGLA")).thenThrow(new ErroEntidadeNaoEncontrada("Unidade", "SIGLA"));
 
             assertThatThrownBy(() -> controllerIsolado.criarProcessoMapeamento(req))
                     .isInstanceOf(ErroEntidadeNaoEncontrada.class);
@@ -485,9 +475,7 @@ class E2eControllerTest {
         void criarProcessoFixture_FalhaIniciar() {
             var req = new E2eController.ProcessoFixtureRequest("Desc", "SIGLA", true, 30);
 
-            Unidade unidade = new Unidade();
-            unidade.setCodigo(10L);
-            when(unidadeServiceMock.buscarPorSigla("SIGLA")).thenReturn(unidade);
+            when(unidadeServiceMock.buscarCodigoPorSigla("SIGLA")).thenReturn(10L);
 
             Processo dto = Processo.builder().codigo(100L).build();
             when(processoServiceMock.criar(any())).thenReturn(dto);
@@ -506,9 +494,7 @@ class E2eControllerTest {
         void criarProcessoFixture_FalhaRecarregar() {
             var req = new E2eController.ProcessoFixtureRequest("Desc", "SIGLA", true, 30);
 
-            Unidade unidade = new Unidade();
-            unidade.setCodigo(10L);
-            when(unidadeServiceMock.buscarPorSigla("SIGLA")).thenReturn(unidade);
+            when(unidadeServiceMock.buscarCodigoPorSigla("SIGLA")).thenReturn(10L);
 
             Processo dto = Processo.builder().codigo(100L).build();
             when(processoServiceMock.criar(any())).thenReturn(dto);

--- a/backend/src/test/java/sgc/organizacao/UnidadeControllerTest.java
+++ b/backend/src/test/java/sgc/organizacao/UnidadeControllerTest.java
@@ -202,7 +202,7 @@ class UnidadeControllerTest {
         u.setNome("Unidade SIGLA");
         u.setSigla("SIGLA");
         u.setTipo(TipoUnidade.OPERACIONAL);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(u);
+        when(unidadeService.buscarPorSiglaComResponsavel("SIGLA")).thenReturn(u);
 
         mockMvc.perform(get("/api/unidades/sigla/SIGLA")).andExpect(status().isOk());
     }

--- a/backend/src/test/java/sgc/organizacao/service/UnidadeServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/UnidadeServiceTest.java
@@ -48,9 +48,20 @@ class UnidadeServiceTest {
     @DisplayName("buscarPorSigla - Sucesso")
     void buscarPorSigla() {
         Unidade u = new Unidade();
-        when(unidadeRepo.buscarPorSiglaComResponsavel("U1")).thenReturn(Optional.of(u));
+        when(unidadeRepo.buscarPorSiglaComSuperior("U1")).thenReturn(Optional.of(u));
 
         Unidade result = service.buscarPorSigla("U1");
+
+        assertThat(result).isSameAs(u);
+    }
+
+    @Test
+    @DisplayName("buscarPorSiglaComResponsavel - Sucesso")
+    void buscarPorSiglaComResponsavel() {
+        Unidade u = new Unidade();
+        when(unidadeRepo.buscarPorSiglaComResponsavel("U1")).thenReturn(Optional.of(u));
+
+        Unidade result = service.buscarPorSiglaComResponsavel("U1");
 
         assertThat(result).isSameAs(u);
     }

--- a/backend/src/test/java/sgc/organizacao/service/UnidadeServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/UnidadeServiceTest.java
@@ -56,6 +56,16 @@ class UnidadeServiceTest {
     }
 
     @Test
+    @DisplayName("buscarCodigoPorSigla - Sucesso")
+    void buscarCodigoPorSigla() {
+        when(unidadeRepo.buscarCodigoAtivoPorSigla("U1")).thenReturn(Optional.of(10L));
+
+        Long result = service.buscarCodigoPorSigla("U1");
+
+        assertThat(result).isEqualTo(10L);
+    }
+
+    @Test
     @DisplayName("buscarEntidadesPorIds - Sucesso")
     void buscarPorCodigos() {
         List<Unidade> lista = List.of(new Unidade());

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageTest.java
@@ -94,8 +94,7 @@ class SubprocessoControllerCoverageTest {
     @DisplayName("buscarPorProcessoEUnidade - deve retornar subprocesso")
     @WithMockUser
     void buscarPorProcessoEUnidade() throws Exception {
-        Unidade un = new Unidade(); un.setCodigo(2L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(2L);
         Subprocesso sp = new Subprocesso();
         sp.setCodigo(1L);
         when(consultaService.obterEntidadePorProcessoEUnidade(1L, 2L)).thenReturn(sp);
@@ -107,7 +106,7 @@ class SubprocessoControllerCoverageTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.codigo").value(1L));
 
-        verify(unidadeService).buscarPorSigla("SIGLA");
+        verify(unidadeService).buscarCodigoPorSigla("SIGLA");
         verify(consultaService).obterEntidadePorProcessoEUnidade(1L, 2L);
         verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
@@ -888,8 +887,7 @@ class SubprocessoControllerCoverageTest {
     @DisplayName("obterContextoEdicaoPorProcessoEUnidade - deve retornar contexto e 200")
     @WithMockUser
     void obterContextoEdicaoPorProcessoEUnidade() throws Exception {
-        Unidade un = new Unidade(); un.setCodigo(2L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(2L);
         Subprocesso sp = new Subprocesso();
         sp.setCodigo(1L);
         when(consultaService.obterEntidadePorProcessoEUnidade(1L, 2L)).thenReturn(sp);
@@ -905,8 +903,7 @@ class SubprocessoControllerCoverageTest {
     @DisplayName("obterContextoCadastroAtividadesPorProcessoEUnidade - deve retornar contexto e 200")
     @WithMockUser
     void obterContextoCadastroAtividadesPorProcessoEUnidade() throws Exception {
-        Unidade un = new Unidade(); un.setCodigo(2L);
-        when(unidadeService.buscarPorSigla("SIGLA")).thenReturn(un);
+        when(unidadeService.buscarCodigoPorSigla("SIGLA")).thenReturn(2L);
         Subprocesso sp = new Subprocesso();
         sp.setCodigo(1L);
         when(consultaService.obterEntidadePorProcessoEUnidade(1L, 2L)).thenReturn(sp);

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
@@ -56,8 +56,7 @@ class SubprocessoControllerTest {
         @DisplayName("deve buscar por processo e unidade")
         @WithMockUser
         void buscarPorProcessoEUnidade() throws Exception {
-            Unidade unidade = new Unidade(); unidade.setCodigo(10L);
-            when(unidadeService.buscarPorSigla("U1")).thenReturn(unidade);
+            when(unidadeService.buscarCodigoPorSigla("U1")).thenReturn(10L);
             when(consultaService.obterEntidadePorProcessoEUnidade(1L, 10L)).thenReturn(Subprocesso.builder().codigo(100L).build());
 
             mockMvc.perform(get("/api/subprocessos/buscar")
@@ -66,7 +65,7 @@ class SubprocessoControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.codigo").value(100));
 
-            verify(unidadeService).buscarPorSigla("U1");
+            verify(unidadeService).buscarCodigoPorSigla("U1");
             verify(consultaService).obterEntidadePorProcessoEUnidade(1L, 10L);
         }
 
@@ -74,14 +73,14 @@ class SubprocessoControllerTest {
         @DisplayName("deve retornar 500 quando sigla da unidade for inválida")
         @WithMockUser
         void buscarPorProcessoEUnidadeErro() throws Exception {
-            when(unidadeService.buscarPorSigla("U1")).thenThrow(new RuntimeException("erro ao buscar unidade"));
+            when(unidadeService.buscarCodigoPorSigla("U1")).thenThrow(new RuntimeException("erro ao buscar unidade"));
 
             mockMvc.perform(get("/api/subprocessos/buscar")
                             .param("codProcesso", "1")
                             .param("siglaUnidade", "U1"))
                     .andExpect(status().isInternalServerError());
 
-            verify(unidadeService).buscarPorSigla("U1");
+            verify(unidadeService).buscarCodigoPorSigla("U1");
             verify(consultaService, never()).obterEntidadePorProcessoEUnidade(anyLong(), anyLong());
         }
     }
@@ -357,9 +356,7 @@ class SubprocessoControllerTest {
         @DisplayName("deve obter contexto de cadastro de atividades buscando processo e unidade")
         @WithMockUser
         void deveObterContextoCadastroAtividadesBusca() throws Exception {
-            Unidade unidade = new Unidade();
-            unidade.setCodigo(10L);
-            when(unidadeService.buscarPorSigla("U10")).thenReturn(unidade);
+            when(unidadeService.buscarCodigoPorSigla("U10")).thenReturn(10L);
 
             Subprocesso sp = new Subprocesso();
             sp.setCodigo(1L);

--- a/backlog-racionalizacao.md
+++ b/backlog-racionalizacao.md
@@ -1,94 +1,119 @@
-# Backlog de racionalização (pendências)
+# Backlog de racionalização (somente pendências atuais)
 
 ## Contexto
 
-Este backlog mantém **apenas** o que ainda falta executar a partir do plano de racionalização.
+Este backlog mantém **apenas o que ainda falta executar** após as rodadas 3, 4 e 5 já iniciadas.
 
-## Estado atual resumido
+## O que foi concluído nesta atualização
 
-- Painel (`/painel/processos` e `/painel/alertas`): frente estabilizada.
-- Contexto de processo e subprocesso: cache de sessão e invalidação explícita já implantados nas telas principais.
-- Diagnóstico organizacional e elegibilidade: frente estabilizada.
+- **Rodada 3 (A.1)**
+  - Refatorado o fluxo `processo + unidade -> contexto de edição` para **1 chamada** quando não há cache local:
+    - antes: `GET /api/subprocessos/buscar` + `GET /api/subprocessos/{codigo}/contexto-edicao`
+    - agora: `GET /api/subprocessos/contexto-edicao/buscar`
+  - Mantido cache por `codSubprocesso` e por chave `processo:unidade`, com invalidação explícita nas ações de workflow.
+
+- **Novos achados de monitoramento (e2e/monitoramento-e2e.txt)**
+  - Persistia alta recorrência de `GET /api/subprocessos/buscar` (70 chamadas no recorte), indicando custo de composição em cadeia.
+  - `GET /api/subprocessos/{codigo}/contexto-edicao` aparece em rajadas por mesma jornada (ex.: código 400 com 33 chamadas).
+  - `POST /api/subprocessos/{codigo}/cadastro/disponibilizar` segue como outlier pontual (amostra com pico ~152ms).
+  - `POST /api/processos/{codigo}/acao-em-bloco` já aparece abaixo do outlier principal no recorte analisado.
+- **Novo recorte da rodada (SGC_MONITORAMENTO=on + E2E cdu-24)**
+  - Com `npx playwright install --only-shell` + `npx playwright install-deps`, a suíte `cdu-24` passou completa com monitoramento ligado.
+  - Principais picos HTTP no recorte:
+    - `POST /api/processos/{codigo}/acao-em-bloco` (~321ms),
+    - `POST /api/usuarios/login` (pico ~188ms),
+    - `GET /api/painel/bootstrap` (pico ~166ms),
+    - `GET /api/subprocessos/{codigo}/contexto-edicao` (pico ~144ms).
+  - Principais picos TRACE no recorte:
+    - `EmailService.enviarEmailHtml` (~333ms),
+    - `ProcessoService.executarAcaoEmBloco` (~296ms),
+    - `SubprocessoTransicaoService.disponibilizarMapaEmBloco` (~284ms),
+    - `SubprocessoNotificacaoService.notificarTransicao` (~259ms).
+- **Nova coleta (rodada longa 2 — SGC_MONITORAMENTO=on + E2E cdu-24)**
+  - Suíte executada novamente após otimizações de lookup por sigla.
+  - Picos HTTP observados:
+    - `POST /api/processos/{codigo}/acao-em-bloco` (~426ms),
+    - `GET /api/subprocessos/{codigo}/contexto-edicao` (pico ~211ms),
+    - `POST /api/usuarios/login` (pico ~176ms).
+  - Picos TRACE observados:
+    - `ProcessoService.executarAcaoEmBloco` (~389ms),
+    - `SubprocessoTransicaoService.disponibilizarMapaEmBloco` (~372ms),
+    - `SubprocessoNotificacaoService.notificarTransicao` (~339ms),
+    - `EmailService.enviarEmailHtml` (~252ms).
+- **Otimização aplicada após o recorte**
+  - `UnidadeService.buscarCodigoPorSigla` foi introduzido para lookup enxuto (`codigo` somente), usando `UnidadeRepo.buscarCodigoAtivoPorSigla`.
+  - Fluxos de alta frequência (controllers de subprocesso e fixtures E2E) deixaram de resolver `Unidade` completa quando só o código é necessário.
+  - `UnidadeService.buscarCodigoPorSigla` passou a usar cache dedicado (`unidadeCodigoPorSigla`) com chave normalizada em maiúsculas para reduzir reconsulta por sigla.
+  - `UnidadeService.buscarPorSigla` segue com cache dedicado (`unidadePorSigla`) para reduzir repetição de leitura completa quando necessária.
 
 ## Pendências prioritárias
 
 ## Bloco A — fluxo de leitura e composição de tela
 
-### Item A.1 — consolidar sequência de abertura de processo/subprocesso
-
-**Objetivo**
-
-Reduzir round-trips na abertura de tela quando ainda há composição por múltiplas chamadas em cadeia.
-
-**Escopo pendente**
-
-- mapear sequência canônica de requests em produção para:
-  - `GET /api/processos/{codigo}/contexto-completo`
-  - `GET /api/subprocessos/buscar`
-  - `GET /api/subprocessos/{codigo}/contexto-edicao`
-- confirmar pontos em que a UI depende de dados que já existem no payload anterior.
-
-**Saída esperada**
-
-- grafo final por tela (detalhe de processo, detalhe de subprocesso, visualização de cadastro);
-- proposta concreta de contrato consolidado (bootstrap por caso de uso) **ou** justificativa para manter endpoints separados.
-
-### Item A.2 — revisar sobreposição entre `contexto-completo` e `detalhes`
+### Item A.2 — reduzir sobreposição entre `contexto-completo` e `detalhes` (processo)
 
 **Objetivo**
 
 Eliminar sobreposição funcional e payload redundante no domínio de processo.
 
-**Escopo pendente**
+**Pendências restantes**
 
-- inventariar campos realmente consumidos por cada tela;
-- separar o que é necessário na primeira renderização do que pode ser carregado sob demanda.
+- fechar inventário de campos realmente consumidos por tela no fluxo de processo;
+- separar payload de primeira renderização vs. carga sob demanda;
+- propor contrato final:
+  - manter dois endpoints com responsabilidades distintas **ou**
+  - consolidar com DTO enxuto e campos opcionais por caso de uso.
 
 **Saída esperada**
 
-- tabela de consumo por tela;
-- recomendação de enxugamento de DTO/endpoint.
+- tabela final de consumo por tela;
+- recomendação de enxugamento de DTO/endpoint com impacto estimado.
 
 ## Bloco B — workflow com custo elevado
 
-### Item B.1 — abrir cadeia interna de `cadastro/disponibilizar`
+### Item B.1 — aprofundar tracing em `cadastro/disponibilizar`
 
 **Objetivo**
 
-Entender o outlier de latência e identificar simplificações de regra/persistência.
+Isolar com precisão o custo relativo de validações, persistência e notificações no fluxo de disponibilização.
 
-**Escopo pendente**
+**Pendências restantes**
 
-- rastrear validações, atualizações, notificações e recomputações;
-- medir tempo relativo por etapa com tracing interno.
+- detalhar quebra de tempo por etapa interna em ambiente de homologação;
+- identificar 2-3 simplificações de baixa complexidade para remover custo evitável (foco atual: notificação/e-mail no caminho crítico de `acao-em-bloco`);
+- validar impacto após ajuste com novo recorte monitorado.
 
 **Saída esperada**
 
 - top 3 gargalos com evidência;
-- lista de simplificações implementáveis em baixa complexidade.
+- lista de simplificações de implementação imediata.
 
-### Item B.2 — medir ações de workflow correlatas
+### Item B.2 — matriz comparativa de ações de workflow
 
 **Objetivo**
 
 Comparar custo de `iniciar`, `acao-em-bloco`, `finalizar` e ações de subprocesso para priorização por impacto.
 
+**Pendências restantes**
+
+- consolidar matriz p50/p95/pico por ação com mesma janela de execução;
+- publicar ordem de ataque da próxima rodada baseada em custo x frequência.
+
 **Saída esperada**
 
 - matriz de latência por ação;
-- ordem de ataque para próxima rodada.
+- priorização objetiva da rodada seguinte.
 
-## Próximas rodadas (execução)
+## Próximas rodadas (remanescente)
 
-### Rodada 3 (em andamento)
+### Rodada 6
 
-- concluir mapeamento de composição de requests por tela (Bloco A.1);
-- fechar inventário de sobreposição entre `contexto-completo` e `detalhes` (Bloco A.2).
+- fechar A.2 (inventário de consumo + proposta de contrato para processo).
 
-### Rodada 4
+### Rodada 7
 
-- atacar outlier `cadastro/disponibilizar` com tracing e simplificações iniciais (Bloco B.1).
+- executar B.1 com tracing interno por etapa e aplicar simplificações iniciais.
 
-### Rodada 5
+### Rodada 8
 
-- consolidar medições comparativas das ações de workflow e priorizar nova leva de refatorações (Bloco B.2).
+- consolidar B.2 com matriz comparativa final e plano de ataque por impacto.

--- a/backlog-racionalizacao.md
+++ b/backlog-racionalizacao.md
@@ -44,7 +44,9 @@ Este backlog mantém **apenas o que ainda falta executar** após as rodadas 3, 4
   - `UnidadeService.buscarCodigoPorSigla` foi introduzido para lookup enxuto (`codigo` somente), usando `UnidadeRepo.buscarCodigoAtivoPorSigla`.
   - Fluxos de alta frequência (controllers de subprocesso e fixtures E2E) deixaram de resolver `Unidade` completa quando só o código é necessário.
   - `UnidadeService.buscarCodigoPorSigla` passou a usar cache dedicado (`unidadeCodigoPorSigla`) com chave normalizada em maiúsculas para reduzir reconsulta por sigla.
-  - `UnidadeService.buscarPorSigla` segue com cache dedicado (`unidadePorSigla`) para reduzir repetição de leitura completa quando necessária.
+  - Estratégia de volatilidade aplicada:
+    - `buscarPorSigla` cacheia leitura estrutural (unidade + superior, sem responsabilidade), adequada para dados que mudam em ciclos longos;
+    - `buscarPorSiglaComResponsavel` permanece sem cache dedicado para manter responsividade a substituições/afastamentos de chefia.
 
 ## Pendências prioritárias
 

--- a/frontend/src/stores/__tests__/subprocesso.spec.ts
+++ b/frontend/src/stores/__tests__/subprocesso.spec.ts
@@ -113,21 +113,18 @@ describe("subprocesso store", () => {
 
             const result = await context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
 
-            expect(subprocessoService.buscarSubprocessoPorProcessoEUnidade).not.toHaveBeenCalled();
+            expect(subprocessoService.buscarContextoEdicaoPorProcessoEUnidade).not.toHaveBeenCalled();
             expect(result).toEqual({codigo: 10, contexto: mockContexto});
         });
 
         it("deve buscar do service se não houver cache para a unidade", async () => {
-            const mockSubprocesso = {codigo: 20};
-            const mockContexto = {detalhes: {unidade: {sigla: "TEST"}}} as any;
+            const mockContexto = {detalhes: {codigo: 20, unidade: {sigla: "TEST"}}} as any;
 
-            vi.mocked(subprocessoService.buscarSubprocessoPorProcessoEUnidade).mockResolvedValue(mockSubprocesso as any);
-            vi.mocked(subprocessoService.buscarContextoEdicao).mockResolvedValue(mockContexto);
+            vi.mocked(subprocessoService.buscarContextoEdicaoPorProcessoEUnidade).mockResolvedValue(mockContexto);
 
             const result = await context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
 
-            expect(subprocessoService.buscarSubprocessoPorProcessoEUnidade).toHaveBeenCalledWith(1, "TEST");
-            expect(subprocessoService.buscarContextoEdicao).toHaveBeenCalledWith(20);
+            expect(subprocessoService.buscarContextoEdicaoPorProcessoEUnidade).toHaveBeenCalledWith(1, "TEST");
             expect(result).toEqual({codigo: 20, contexto: mockContexto});
             expect(context.store.contextoEdicao).toEqual(mockContexto);
             expect(context.store.codSubprocessoCarregado).toBe(20);
@@ -135,37 +132,30 @@ describe("subprocesso store", () => {
         });
 
         it("deve reutilizar carregamento em andamento por processo+unidade", async () => {
-            let resolverSubprocesso!: (valor: any) => void;
-            let resolverContexto!: (valor: any) => void;
-            const promessaSubprocesso = new Promise<any>((resolve) => {
-                resolverSubprocesso = resolve;
+            let resolverContextoPorUnidade!: (valor: any) => void;
+            const promessaContextoPorUnidade = new Promise<any>((resolve) => {
+                resolverContextoPorUnidade = resolve;
             });
-            const promessaContexto = new Promise<any>((resolve) => {
-                resolverContexto = resolve;
-            });
-            vi.mocked(subprocessoService.buscarSubprocessoPorProcessoEUnidade).mockReturnValue(promessaSubprocesso);
-            vi.mocked(subprocessoService.buscarContextoEdicao).mockReturnValue(promessaContexto);
+            vi.mocked(subprocessoService.buscarContextoEdicaoPorProcessoEUnidade).mockReturnValue(promessaContextoPorUnidade);
 
             const requisicaoA = context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
             const requisicaoB = context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
 
-            expect(subprocessoService.buscarSubprocessoPorProcessoEUnidade).toHaveBeenCalledTimes(1);
-            resolverSubprocesso({codigo: 20});
-            resolverContexto({detalhes: {unidade: {sigla: "TEST"}}});
+            expect(subprocessoService.buscarContextoEdicaoPorProcessoEUnidade).toHaveBeenCalledTimes(1);
+            resolverContextoPorUnidade({detalhes: {codigo: 20, unidade: {sigla: "TEST"}}});
 
             await expect(requisicaoA).resolves.toEqual({
                 codigo: 20,
-                contexto: {detalhes: {unidade: {sigla: "TEST"}}}
+                contexto: {detalhes: {codigo: 20, unidade: {sigla: "TEST"}}}
             });
             await expect(requisicaoB).resolves.toEqual({
                 codigo: 20,
-                contexto: {detalhes: {unidade: {sigla: "TEST"}}}
+                contexto: {detalhes: {codigo: 20, unidade: {sigla: "TEST"}}}
             });
-            expect(subprocessoService.buscarContextoEdicao).toHaveBeenCalledTimes(1);
         });
 
         it("deve retornar null e logar erro se a busca falhar", async () => {
-            vi.mocked(subprocessoService.buscarSubprocessoPorProcessoEUnidade).mockRejectedValue(new Error("Erro API"));
+            vi.mocked(subprocessoService.buscarContextoEdicaoPorProcessoEUnidade).mockRejectedValue(new Error("Erro API"));
 
             const result = await context.store.garantirContextoEdicaoPorProcessoEUnidade(1, "TEST");
 

--- a/frontend/src/stores/subprocesso.ts
+++ b/frontend/src/stores/subprocesso.ts
@@ -3,7 +3,7 @@ import {ref} from "vue";
 import type {ContextoEdicaoSubprocesso} from "@/types/tipos";
 import {
     buscarContextoEdicao as serviceBuscarContextoEdicao,
-    buscarSubprocessoPorProcessoEUnidade as serviceBuscarSubprocessoPorProcessoEUnidade,
+    buscarContextoEdicaoPorProcessoEUnidade as serviceBuscarContextoEdicaoPorProcessoEUnidade,
 } from "@/services/subprocessoService";
 import {logger} from "@/utils";
 
@@ -106,13 +106,12 @@ export const useSubprocessoStore = defineStore("subprocesso", () => {
 
         try {
             const promessaCarregamento = (async () => {
-                const dto = await serviceBuscarSubprocessoPorProcessoEUnidade(codProcesso, siglaUnidade);
-                const codigo = dto.codigo;
+                const data = await serviceBuscarContextoEdicaoPorProcessoEUnidade(codProcesso, siglaUnidade);
+                const codigo = data.detalhes.codigo;
                 mapaProcessoUnidadeParaCodigo.set(chaveProcessoUnidade, codigo);
-                const data = await garantirContextoEdicao(codigo);
-                if (!data) {
-                    throw new Error(`Contexto de edição indisponível para subprocesso ${codigo}`);
-                }
+                contextoEdicao.value = data;
+                codSubprocessoCarregado.value = codigo;
+                invalido.value = false;
                 return {codigo, contexto: data};
             })();
             carregamentosPorProcessoUnidade.set(chaveProcessoUnidade, promessaCarregamento);


### PR DESCRIPTION
### Motivation

- Reduce high-frequency overhead caused by repeated lookups by unit sigla and chained requests when opening subprocesso contexts by introducing a lightweight lookup for `codigo` and consolidating context fetching into one call.
- Add dedicated caches for sigla-based lookups to lower DB pressure and improve E2E/monitoring hotspots observed in traces and load captures.

### Description

- Added two new cache constants and custom caches in `CacheConfig`: `CACHE_UNIDADE_POR_SIGLA` and `CACHE_UNIDADE_CODIGO_POR_SIGLA`, and registered them with appropriate sizes/TTLs.
- Introduced `UnidadeService.buscarCodigoPorSigla(String)` with `@Cacheable` (key normalized to uppercase) that returns only the unit code, and added caching to `buscarPorSigla(String)`.  Updated usages to prefer the lightweight code lookup where only the `codigo` is needed.
- Updated controllers and fixtures to use `buscarCodigoPorSigla` (e.g. `E2eController`, `SubprocessoController`) and refactored logic to operate on `Long codUnidade` instead of loading full `Unidade` entities when unnecessary.
- Frontend `subprocesso` store refactored to call a single consolidated endpoint `buscarContextoEdicaoPorProcessoEUnidade` (via `serviceBuscarContextoEdicaoPorProcessoEUnidade`) instead of two separate calls, reusing in-flight requests and simplifying session cache state.
- Updated tests and coverage: backend tests updated/more precise mocks to use `buscarCodigoPorSigla`, added `buscarCodigoPorSigla` unit test in `UnidadeServiceTest`, and adapted E2E and Subprocesso controller tests; frontend unit tests adjusted to new service call shape; backlog doc updated to describe the rationale and results.

### Testing

- Ran backend unit tests including `UnidadeServiceTest`, `E2eControllerTest`, `SubprocessoControllerTest` and coverage tests with mocks updated to use `buscarCodigoPorSigla`, and all tests passed.
- Ran frontend unit tests including `frontend/src/stores/__tests__/subprocesso.spec.ts` adjusted for the consolidated service call, and they passed.
- Verified new `buscarCodigoPorSigla` unit test (`buscarCodigoPorSigla - Sucesso`) executes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab3aef7d0832bbabb75535d74a7c3)