### PR TITLE
test(backend): remove lenient mocks in UnidadeHierarquiaService tests

### DIFF
--- a/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceCoverageTest.java
@@ -33,11 +33,6 @@ class UnidadeHierarquiaServiceCoverageTest {
     @InjectMocks
     private UnidadeHierarquiaService target;
 
-    @BeforeEach
-    void configurarSelfProvider() {
-        lenient().when(selfProvider.getObject()).thenReturn(target);
-    }
-
     @Test
     @DisplayName("Deve cobrir método buscarArvoreComElegibilidade")
     void deveCobrirBuscarArvoreComElegibilidade() {
@@ -74,6 +69,7 @@ class UnidadeHierarquiaServiceCoverageTest {
     @Test
     @DisplayName("Deve cobrir método buscarNaHierarquiaPorSigla")
     void deveCobrirBuscarNaHierarquiaPorSigla() {
+        when(selfProvider.getObject()).thenReturn(target);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(List.of(
                 new UnidadeHierarquiaLeitura(1L, "RAIZ", "RAIZ", null, RAIZ, SituacaoUnidade.ATIVA, null),
                 new UnidadeHierarquiaLeitura(2L, "SUB", "SUB", null, OPERACIONAL, SituacaoUnidade.ATIVA, 1L)

--- a/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceTest.java
+++ b/backend/src/test/java/sgc/organizacao/service/UnidadeHierarquiaServiceTest.java
@@ -44,7 +44,6 @@ class UnidadeHierarquiaServiceTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(selfProvider.getObject()).thenReturn(service);
         unidadeRaiz = UnidadeTestBuilder.raiz().build();
         unidadeRaiz.setCodigo(1L);
         unidadeRaiz.setResponsabilidade(criarResponsabilidade(1L));
@@ -96,6 +95,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("Deve buscar IDs descendentes")
     void deveBuscarIdsDescendentes() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(hierarquiaBasica());
 
         List<Long> descendentes = service.buscarIdsDescendentes(1L);
@@ -106,6 +106,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("Deve buscar árvore por código (nível profundo)")
     void deveBuscarArvorePorCodigo() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(hierarquiaBasica());
 
         UnidadeDto resultado = service.buscarArvore(3L);
@@ -116,6 +117,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("Deve buscar siglas subordinadas (a partir da raiz)")
     void deveBuscarSiglasSubordinadas() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(hierarquiaBasica());
 
         List<String> siglas = service.buscarSiglasSubordinadas(unidadeRaiz.getSigla());
@@ -130,6 +132,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("buscarArvore deve buscar no repo se não encontrar na hierarquia")
     void buscarArvore_DeveBuscarNoRepoSeNaoEncontrarNaHierarquia() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(List.of(toLeitura(unidadeRaiz)));
         Unidade extra = Unidade.builder()
                 .codigo(99L)
@@ -147,6 +150,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("buscarSiglasSubordinadas deve retornar vazio se não encontrar sigla")
     void buscarSiglasSubordinadas_DeveRetornarVazioSeNaoEncontrar() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(List.of(toLeitura(unidadeRaiz)));
         Unidade extra = Unidade.builder()
                 .codigo(999L)
@@ -164,6 +168,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("Deve buscar sigla superior")
     void deveBuscarSiglaSuperior() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeService.buscarPorSigla(unidadeIntermediaria.getSigla())).thenReturn(unidadeIntermediaria);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(hierarquiaBasica());
         when(unidadeRepo.buscarSiglaPorCodigo(unidadeRaiz.getCodigo()))
@@ -188,6 +193,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("buscarCodigosSuperiores deve usar apenas o mapa filho pai")
     void buscarCodigosSuperiores_DeveUsarApenasMapaFilhoPai() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(hierarquiaBasica());
 
         List<Long> resultado = service.buscarCodigosSuperiores(3L);
@@ -199,6 +205,7 @@ class UnidadeHierarquiaServiceTest {
     @Test
     @DisplayName("buscarCodigoPai deve retornar vazio quando relacao nao existe no mapa")
     void buscarCodigoPai_DeveRetornarNullQuandoRelacaoNaoExisteNoMapa() {
+        when(selfProvider.getObject()).thenReturn(service);
         when(unidadeRepo.listarEstruturasAtivas()).thenReturn(List.of(toLeitura(unidadeRaiz)));
 
         Long resultado = service.buscarCodigoPai(99L);

--- a/etc/scripts/codigo/smells-auditar.js
+++ b/etc/scripts/codigo/smells-auditar.js
@@ -93,7 +93,7 @@ const PADROES = [
 function ehArquivoTesteOuStory(caminhoRelativo) {
     return caminhoRelativo.includes("/__tests__/")
         || caminhoRelativo.endsWith(".spec.ts")
-        || caminhoRelativo.endsWith(".stories.ts");
+        || caminhoRelativo.endsWith(".stories.ts") || caminhoRelativo.includes("/test-utils/");
 }
 
 function criarEstruturaContagens() {


### PR DESCRIPTION
- Removidos stubs \`lenient()\` em `UnidadeHierarquiaServiceTest` e `UnidadeHierarquiaServiceCoverageTest`.
- Ajustada a injeção estrita de dependências via `when()` nos testes de cada método conforme a política do projeto.
- Corrigida falha no script de classificação `smells-auditar.js`.

---
*PR created automatically by Jules for task [18295330189241873707](https://jules.google.com/task/18295330189241873707) started by @lgalvao*