### PR TITLE
Frontend Quality Check and Relatorios Unit Tests

### DIFF
--- a/frontend/src/services/__tests__/relatoriosService.spec.ts
+++ b/frontend/src/services/__tests__/relatoriosService.spec.ts
@@ -1,0 +1,94 @@
+import {describe, expect, it, vi, beforeEach} from "vitest";
+import apiClient from "@/axios-setup";
+import {relatoriosService} from "@/services/relatoriosService";
+
+vi.mock("@/axios-setup", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+describe("relatoriosService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    global.URL.createObjectURL = vi.fn(() => "mock-url");
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it("deve chamar obterRelatorioAndamento com o código do processo correto", async () => {
+    const mockData = [{siglaUnidade: "UNIT1", nomeUnidade: "Unit 1", situacaoAtual: "OK"}];
+    vi.mocked(apiClient.get).mockResolvedValueOnce({data: mockData});
+
+    const result = await relatoriosService.obterRelatorioAndamento(123);
+
+    expect(apiClient.get).toHaveBeenCalledWith("/relatorios/andamento/123");
+    expect(result).toEqual(mockData);
+  });
+
+  it("deve chamar downloadRelatorioAndamentoPdf e disparar o download", async () => {
+    const mockBlob = new Blob(["pdf content"], {type: "application/pdf"});
+    vi.mocked(apiClient.get).mockResolvedValueOnce({data: mockBlob});
+
+    // Mock document methods
+    const mockLink = {
+      href: "",
+      setAttribute: vi.fn(),
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+    vi.spyOn(document, "createElement").mockReturnValue(mockLink as any);
+    vi.spyOn(document.body, "appendChild").mockImplementation(() => mockLink as any);
+
+    await relatoriosService.downloadRelatorioAndamentoPdf(123);
+
+    expect(apiClient.get).toHaveBeenCalledWith("/relatorios/andamento/123/exportar", {
+      responseType: "blob",
+    });
+    expect(document.createElement).toHaveBeenCalledWith("a");
+    expect(mockLink.setAttribute).toHaveBeenCalledWith("download", "relatorio-andamento-123.pdf");
+    expect(mockLink.click).toHaveBeenCalled();
+    expect(mockLink.remove).toHaveBeenCalled();
+  });
+
+  it("deve chamar downloadRelatorioMapasPdf e disparar o download", async () => {
+    const mockBlob = new Blob(["pdf content"], {type: "application/pdf"});
+    vi.mocked(apiClient.get).mockResolvedValueOnce({data: mockBlob});
+
+    const mockLink = {
+      href: "",
+      setAttribute: vi.fn(),
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+    vi.spyOn(document, "createElement").mockReturnValue(mockLink as any);
+    vi.spyOn(document.body, "appendChild").mockImplementation(() => mockLink as any);
+
+    await relatoriosService.downloadRelatorioMapasPdf(123);
+
+    expect(apiClient.get).toHaveBeenCalledWith("/relatorios/mapas/123/exportar", {
+      responseType: "blob",
+    });
+    expect(mockLink.setAttribute).toHaveBeenCalledWith("download", "relatorio-mapas-vigentes-123.pdf");
+  });
+
+  it("deve chamar downloadRelatorioMapasPdf com unidadeId quando fornecido", async () => {
+    const mockBlob = new Blob(["pdf content"], {type: "application/pdf"});
+    vi.mocked(apiClient.get).mockResolvedValueOnce({data: mockBlob});
+
+    const mockLink = {
+      href: "",
+      setAttribute: vi.fn(),
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+    vi.spyOn(document, "createElement").mockReturnValue(mockLink as any);
+    vi.spyOn(document.body, "appendChild").mockImplementation(() => mockLink as any);
+
+    await relatoriosService.downloadRelatorioMapasPdf(123, 456);
+
+    expect(apiClient.get).toHaveBeenCalledWith("/relatorios/mapas/123/exportar?unidadeId=456", {
+      responseType: "blob",
+    });
+  });
+});

--- a/frontend/src/stores/__tests__/relatorios.spec.ts
+++ b/frontend/src/stores/__tests__/relatorios.spec.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it, vi, beforeEach} from "vitest";
+import {setActivePinia, createPinia} from "pinia";
+import {useRelatoriosStore} from "@/stores/relatorios";
+import {relatoriosService} from "@/services/relatoriosService";
+
+vi.mock("@/services/relatoriosService", () => ({
+  relatoriosService: {
+    obterRelatorioAndamento: vi.fn(),
+    downloadRelatorioAndamentoPdf: vi.fn(),
+    downloadRelatorioMapasPdf: vi.fn(),
+  },
+}));
+
+describe("Relatorios Store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("deve buscar relatorio de andamento com sucesso", async () => {
+    const store = useRelatoriosStore();
+    const mockData = [{siglaUnidade: "UNIT1", nomeUnidade: "Unit 1", situacaoAtual: "OK"}];
+    vi.mocked(relatoriosService.obterRelatorioAndamento).mockResolvedValue(mockData as any);
+
+    await store.buscarRelatorioAndamento(123);
+
+    expect(relatoriosService.obterRelatorioAndamento).toHaveBeenCalledWith(123);
+    expect(store.relatorioAndamento).toEqual(mockData);
+    expect(store.lastError).toBeNull();
+  });
+
+  it("deve tratar erro ao buscar relatorio de andamento", async () => {
+    const store = useRelatoriosStore();
+    vi.mocked(relatoriosService.obterRelatorioAndamento).mockRejectedValue(new Error("Erro API"));
+
+    await expect(store.buscarRelatorioAndamento(123)).rejects.toThrow("Erro API");
+
+    expect(store.relatorioAndamento).toEqual([]);
+    expect(store.lastError).not.toBeNull();
+  });
+
+  it("deve exportar andamento PDF com sucesso", async () => {
+    const store = useRelatoriosStore();
+    vi.mocked(relatoriosService.downloadRelatorioAndamentoPdf).mockResolvedValue(undefined);
+
+    await store.exportarAndamentoPdf(123);
+
+    expect(relatoriosService.downloadRelatorioAndamentoPdf).toHaveBeenCalledWith(123);
+    expect(store.lastError).toBeNull();
+  });
+
+  it("deve exportar mapas PDF com sucesso", async () => {
+    const store = useRelatoriosStore();
+    vi.mocked(relatoriosService.downloadRelatorioMapasPdf).mockResolvedValue(undefined);
+
+    await store.exportarMapasPdf(123, 456);
+
+    expect(relatoriosService.downloadRelatorioMapasPdf).toHaveBeenCalledWith(123, 456);
+    expect(store.lastError).toBeNull();
+  });
+
+  it("deve limpar relatorio", () => {
+    const store = useRelatoriosStore();
+    store.relatorioAndamento = [{siglaUnidade: "UNIT1"}] as any;
+
+    store.limparRelatorio();
+
+    expect(store.relatorioAndamento).toEqual([]);
+    expect(store.lastError).toBeNull();
+  });
+});

--- a/frontend/src/utils/__tests__/styleUtils.spec.ts
+++ b/frontend/src/utils/__tests__/styleUtils.spec.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it} from "vitest";
+import {badgeClass, iconeTipo} from "@/utils/styleUtils";
+
+describe("styleUtils", () => {
+  describe("badgeClass", () => {
+    it("deve retornar a classe correta para situações conhecidas", () => {
+      // Assumindo que EM_ELABORACAO existe em CLASSES_BADGE_SITUACAO
+      expect(badgeClass("EM_ELABORACAO")).toBeDefined();
+    });
+
+    it("deve retornar bg-secondary para situações desconhecidas", () => {
+      expect(badgeClass("SITUACAO_INEXISTENTE")).toBe("bg-secondary");
+    });
+  });
+
+  describe("iconeTipo", () => {
+    it("deve retornar o ícone correto para success", () => {
+      expect(iconeTipo("success")).toContain("bi-check-circle-fill");
+    });
+
+    it("deve retornar o ícone correto para error", () => {
+      expect(iconeTipo("error")).toContain("bi-exclamation-triangle-fill");
+    });
+
+    it("deve retornar o ícone correto para warning", () => {
+      expect(iconeTipo("warning")).toContain("bi-exclamation-triangle-fill");
+    });
+
+    it("deve retornar o ícone correto para info", () => {
+      expect(iconeTipo("info")).toContain("bi-info-circle-fill");
+    });
+
+    it("deve retornar ícone default para tipos desconhecidos", () => {
+      // @ts-expect-error - testando fallback para valor inválido
+      expect(iconeTipo("desconhecido")).toBe("bi bi-bell-fill");
+    });
+  });
+});

--- a/frontend/src/views/RelatorioMapasView.vue
+++ b/frontend/src/views/RelatorioMapasView.vue
@@ -34,8 +34,8 @@
           <BButton
             :disabled="!processoIdSelecionado || carregando"
             variant="success"
-            @click="exportarPdf"
             data-testid="btn-gerar-mapas"
+            @click="exportarPdf"
           >
             <BSpinner v-if="carregando" small class="me-1" />
             <i v-else class="bi bi-file-earmark-pdf me-1" />

--- a/frontend/src/views/__tests__/RelatorioMapasView.spec.ts
+++ b/frontend/src/views/__tests__/RelatorioMapasView.spec.ts
@@ -1,0 +1,97 @@
+import {describe, expect, it, vi, beforeEach} from "vitest";
+import {mount} from "@vue/test-utils";
+import RelatorioMapasView from "@/views/RelatorioMapasView.vue";
+import {getCommonMountOptions, setupComponentTest} from "@/test-utils/componentTestHelpers";
+import * as painelService from "@/services/painelService";
+import {useRelatoriosStore} from "@/stores/relatorios";
+import {usePerfilStore} from "@/stores/perfil";
+
+vi.mock("@/services/painelService", () => ({
+  listarProcessos: vi.fn(),
+}));
+
+describe("RelatorioMapasView.vue", () => {
+  const ctx = setupComponentTest();
+
+  const stubs = {
+    LayoutPadrao: { template: "<div><slot /></div>" },
+    PageHeader: { template: "<div><slot name='actions' /></div>" },
+    BCard: { template: "<div><slot /></div>" },
+    BRow: { template: "<div><slot /></div>" },
+    BCol: { template: "<div><slot /></div>" },
+    BFormGroup: { template: "<div><label><slot /></label></div>" },
+    BFormSelect: {
+      props: ["modelValue", "options"],
+      template: "<select :value='modelValue' @change='$emit(\"update:modelValue\", Number($event.target.value) || null)'><option v-for='o in options' :key='o.value' :value='o.value'>{{o.text}}</option></select>"
+    },
+    BButton: {
+        props: ["disabled"],
+        template: "<button :disabled='disabled' @click='$emit(\"click\")'><slot /></button>"
+    },
+    BSpinner: { template: "<span>loading...</span>" },
+    EmptyState: { template: "<div>Empty State</div>" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(painelService.listarProcessos).mockResolvedValue({
+      content: [{ codigo: 1, descricao: "Processo 1" }],
+      totalElements: 1,
+    } as any);
+  });
+
+  it("deve carregar processos ao montar", async () => {
+    ctx.wrapper = mount(RelatorioMapasView, getCommonMountOptions({}, stubs));
+    await ctx.wrapper.vm.$nextTick();
+
+    expect(painelService.listarProcessos).toHaveBeenCalled();
+  });
+
+  it("deve mostrar empty state quando nenhum processo está selecionado", async () => {
+    ctx.wrapper = mount(RelatorioMapasView, getCommonMountOptions({}, stubs));
+
+    expect(ctx.wrapper.text()).toContain("Empty State");
+  });
+
+  it("deve chamar exportarMapasPdf ao clicar no botão gerar", async () => {
+    ctx.wrapper = mount(RelatorioMapasView, getCommonMountOptions({}, stubs));
+    await ctx.wrapper.vm.$nextTick();
+
+    const relatoriosStore = useRelatoriosStore();
+    const exportarSpy = vi.spyOn(relatoriosStore, "exportarMapasPdf").mockResolvedValue(undefined as any);
+
+    const btn = ctx.wrapper.find("[data-testid='btn-gerar-mapas']");
+    expect((btn.element as HTMLButtonElement).disabled).toBe(true);
+
+    const vm = ctx.wrapper.vm as any;
+    vm.processoIdSelecionado = 1;
+    await ctx.wrapper.vm.$nextTick();
+
+    expect((btn.element as HTMLButtonElement).disabled).toBe(false);
+
+    await btn.trigger("click");
+
+    expect(exportarSpy).toHaveBeenCalledWith(1, undefined);
+  });
+
+  it("deve incluir unidadeId na exportação se selecionada", async () => {
+    const perfilStore = usePerfilStore();
+    perfilStore.unidadeSelecionada = 99;
+    perfilStore.unidadeSelecionadaSigla = "SIGLA";
+
+    ctx.wrapper = mount(RelatorioMapasView, getCommonMountOptions({}, stubs));
+    await ctx.wrapper.vm.$nextTick();
+
+    const relatoriosStore = useRelatoriosStore();
+    const exportarSpy = vi.spyOn(relatoriosStore, "exportarMapasPdf").mockResolvedValue(undefined as any);
+
+    const vm = ctx.wrapper.vm as any;
+    vm.processoIdSelecionado = 1;
+    vm.unidadeIdSelecionada = 99;
+    await ctx.wrapper.vm.$nextTick();
+
+    await ctx.wrapper.find("[data-testid='btn-gerar-mapas']").trigger("click");
+
+    expect(exportarSpy).toHaveBeenCalledWith(1, 99);
+  });
+});

--- a/frontend/src/views/__tests__/RelatoriosView.spec.ts
+++ b/frontend/src/views/__tests__/RelatoriosView.spec.ts
@@ -46,4 +46,15 @@ describe('RelatoriosView.vue', () => {
         await ctx.wrapper.find('[data-testid="card-relatorio-mapas"]').trigger('click');
         expect(mockPush).toHaveBeenCalledWith('/relatorios/mapas-vigentes');
     });
+
+    it('deve navegar usando teclado', async () => {
+        const mountOptions = getCommonMountOptions({}, stubs);
+        ctx.wrapper = mount(RelatoriosView, mountOptions);
+
+        await ctx.wrapper.find('[data-testid="card-relatorio-andamento"]').trigger('keydown.enter');
+        expect(mockPush).toHaveBeenCalledWith('/relatorios/andamento');
+
+        await ctx.wrapper.find('[data-testid="card-relatorio-andamento"]').trigger('keydown.space');
+        expect(mockPush).toHaveBeenCalledWith('/relatorios/andamento');
+    });
 });


### PR DESCRIPTION
This PR addresses the quality check request for the frontend. 
It fixes linting warnings, ensures all typechecks pass, and significantly improves unit test coverage for the 'relatorios' module, which was previously untested.

Key changes:
- Reordered attributes in `RelatorioMapasView.vue` to satisfy `vue/attributes-order`.
- Implemented comprehensive unit tests for:
    - `relatoriosService.ts` (API calls and download logic)
    - `relatorios` store (Pinia actions and error handling)
    - `RelatorioMapasView.vue` (component rendering and user interactions)
- Added/Improved tests for `styleUtils.ts` and `RelatoriosView.vue` to meet coverage thresholds.
- Verified all root and frontend type-checking and linting.

---
*PR created automatically by Jules for task [14825087391163292450](https://jules.google.com/task/14825087391163292450) started by @lgalvao*