### PR TITLE
Correção feita para solucionar o erro presente na seguinte issue #1539

### DIFF
--- a/backend/src/main/java/sgc/organizacao/UsuarioFacade.java
+++ b/backend/src/main/java/sgc/organizacao/UsuarioFacade.java
@@ -85,12 +85,12 @@ public class UsuarioFacade {
     }
 
     @Transactional(readOnly = true)
-    public ResponsavelDto buscarResponsabilidadeDetalhadaAtual(String sigla) {
+    public @Nullable ResponsavelDto buscarResponsabilidadeDetalhadaAtual(String sigla) {
         return responsavelUnidadeService.buscarResponsabilidadeDetalhadaAtual(sigla);
     }
 
     @Transactional(readOnly = true)
-    public ResponsavelDto buscarResponsabilidadeDetalhadaAtual(Long codigoUnidade) {
+    public @Nullable ResponsavelDto buscarResponsabilidadeDetalhadaAtual(Long codigoUnidade) {
         return responsavelUnidadeService.buscarResponsabilidadeDetalhadaAtual(codigoUnidade);
     }
 

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoNotificacaoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoNotificacaoService.java
@@ -1,6 +1,7 @@
 package sgc.subprocesso.service;
 
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.*;
 import org.springframework.stereotype.*;
 import org.thymeleaf.context.*;
@@ -19,6 +20,7 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SubprocessoNotificacaoService {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
@@ -72,7 +74,14 @@ public class SubprocessoNotificacaoService {
     }
 
     private void notificarResponsavelPessoal(Unidade unidade, String assunto, String corpo) {
-        UnidadeResponsavelDto responsavel = responsavelService.buscarResponsavelUnidade(unidade.getCodigo());
+        UnidadeResponsavelDto responsavel;
+        try {
+            responsavel = responsavelService.buscarResponsavelUnidade(unidade.getCodigo());
+        } catch (sgc.comum.erros.ErroEntidadeNaoEncontrada ex) {
+            log.warn("Responsavel nao encontrado para unidade {}; email pessoal nao enviado.", unidade.getCodigo());
+            return;
+        }
+
         if (responsavel.substitutoTitulo() != null) {
             usuarioService.buscarOpt(responsavel.substitutoTitulo()).ifPresent(u -> {
                 if (!u.getEmail().isBlank()) emailService.enviarEmailHtml(u.getEmail(), assunto, corpo);

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java
@@ -570,8 +570,11 @@ public class SubprocessoTransicaoService {
         Unidade unidadeAnalise = localizacaoSubprocessoService.obterLocalizacaoAtual(sp);
         Unidade unidadeDevolucao = obterUnidadeDevolucao(sp, unidadeAnalise);
 
-        SituacaoSubprocesso novaSituacao = obterSituacaoObrigatoria(SITUACAO_MAPA_DISPONIBILIZADO, sp, "devolução de validação");
-        sp.setDataFimEtapa2(null);
+        SituacaoSubprocesso novaSituacao = sp.getSituacao();
+        if (Objects.equals(unidadeDevolucao.getCodigo(), sp.getUnidade().getCodigo())) {
+            novaSituacao = obterSituacaoObrigatoria(SITUACAO_MAPA_DISPONIBILIZADO, sp, "devolução de validação");
+            sp.setDataFimEtapa2(null);
+        }
 
         registrarWorkflowComDestino(RegistrarWorkflowInternoCommand.devolucaoValidacao(
                 sp,


### PR DESCRIPTION

1. SubprocessoTransicaoService
   Foi feito ajuste em devolverValidacao para só mudar a situação para “Mapa disponibilizado” e limpar dataFimEtapa2 quando a
   devolução volta para a própria unidade do subprocesso. Se a devolução vai para unidade superior/intermediária, a
   situação permanece a atual.
2. SubprocessoConsultaService
   Foi feito ajuste no cálculo de permissões do mapa para considerar localização atual: mesmo com situação “Mapa
   disponibilizado”, quando a unidade ativa é a local de tramitação e não é a unidade do subprocesso, os botões de
   gestão (devolver/aceitar/homologar) passam a aparecer no vis-mapa.
3. SubprocessoNotificacaoService
   No envio de e‑mail pessoal do responsável, agora tratamos a ausência de responsabilidade: se não existir registro na
   vw_responsabilidade, o método registra WARN e não interrompe o fluxo.

Causas dos erros

- Botões sumindo no vis-mapa: após a devolução de validação para unidade superior, a situação continuava “Mapa
  disponibilizado” e as permissões eram calculadas só pela situação, sem considerar a localização atual. Resultado: o
  frontend recebia permissões falsas e escondia os botões.
- Responsabilidade não encontrada: o fluxo de aceite/disponibilização chama a notificação. Essa notificação buscava
  o responsável da unidade e lançava erro quando não havia registro de responsabilidade. Isso gerava os logs de
  ErroEntidadeNaoEncontrada.