### PR TITLE
Reforça testes de reabertura para alertas na cadeia hierárquica (CDU-32/33)

### DIFF
--- a/backend/src/test/java/sgc/integracao/CDU32IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU32IntegrationTest.java
@@ -129,6 +129,14 @@ class CDU32IntegrationTest extends BaseIntegrationTest {
                         Objects.equals(a.getUnidadeDestino().getCodigo(), codigoUnidadeSuperior) &&
                         a.getDescricao().contains("Cadastro da unidade %s reaberto".formatted(reaberto.getUnidade().getSigla())));
         assertThat(alertaSuperiorExiste).isTrue();
+
+        List<Long> codigosEsperadosSuperiores = coletarCodigosSuperiores(reaberto.getUnidade());
+        long quantidadeAlertasSuperiores = alerts.stream()
+                .filter(a -> a.getUnidadeDestino() != null)
+                .filter(a -> codigosEsperadosSuperiores.contains(a.getUnidadeDestino().getCodigo()))
+                .filter(a -> a.getDescricao().contains("Cadastro da unidade %s reaberto".formatted(reaberto.getUnidade().getSigla())))
+                .count();
+        assertThat(quantidadeAlertasSuperiores).isEqualTo(codigosEsperadosSuperiores.size());
     }
 
     @Test
@@ -174,5 +182,15 @@ class CDU32IntegrationTest extends BaseIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isUnprocessableContent());
+    }
+
+    private List<Long> coletarCodigosSuperiores(Unidade unidade) {
+        List<Long> codigos = new ArrayList<>();
+        Unidade superiorAtual = unidade.getUnidadeSuperior();
+        while (superiorAtual != null) {
+            codigos.add(superiorAtual.getCodigo());
+            superiorAtual = superiorAtual.getUnidadeSuperior();
+        }
+        return codigos;
     }
 }

--- a/backend/src/test/java/sgc/integracao/CDU32IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU32IntegrationTest.java
@@ -51,15 +51,7 @@ class CDU32IntegrationTest extends BaseIntegrationTest {
             unidadeRepo.save(admin);
         }
 
-        // Obter unidade com cadeia hierárquica conhecida
-        Unidade unidade = unidadeRepo.findBySigla("SEDESENV").orElseGet(() -> {
-            Unidade u = new Unidade();
-            u.setSigla("TESTE");
-            u.setNome("Unidade teste");
-            u.setSituacao(SituacaoUnidade.ATIVA);
-            u.setTipo(TipoUnidade.OPERACIONAL);
-            return unidadeRepo.save(u);
-        });
+        Unidade unidade = buscarOuCriarUnidadeComDoisSuperiores("CDU32");
 
         // Criar processo
         Processo processo = ProcessoFixture.processoPadrao();
@@ -131,6 +123,9 @@ class CDU32IntegrationTest extends BaseIntegrationTest {
         assertThat(alertaSuperiorExiste).isTrue();
 
         List<Long> codigosEsperadosSuperiores = coletarCodigosSuperiores(reaberto.getUnidade());
+        assertThat(codigosEsperadosSuperiores)
+                .as("CDU-32 deve propagar alerta para toda a cadeia hierárquica superior")
+                .hasSizeGreaterThanOrEqualTo(2);
         long quantidadeAlertasSuperiores = alerts.stream()
                 .filter(a -> a.getUnidadeDestino() != null)
                 .filter(a -> codigosEsperadosSuperiores.contains(a.getUnidadeDestino().getCodigo()))
@@ -192,5 +187,36 @@ class CDU32IntegrationTest extends BaseIntegrationTest {
             superiorAtual = superiorAtual.getUnidadeSuperior();
         }
         return codigos;
+    }
+
+    private Unidade buscarOuCriarUnidadeComDoisSuperiores(String sufixo) {
+        String siglaSecao = "SEC_T_%s".formatted(sufixo);
+        Optional<Unidade> secaoExistente = unidadeRepo.findBySigla(siglaSecao);
+        if (secaoExistente.isPresent()) {
+            return secaoExistente.get();
+        }
+
+        Unidade secretaria = new Unidade();
+        secretaria.setSigla("SECRET_T_%s".formatted(sufixo));
+        secretaria.setNome("Secretaria teste %s".formatted(sufixo));
+        secretaria.setSituacao(SituacaoUnidade.ATIVA);
+        secretaria.setTipo(TipoUnidade.INTEROPERACIONAL);
+        secretaria = unidadeRepo.save(secretaria);
+
+        Unidade coordenadoria = new Unidade();
+        coordenadoria.setSigla("COORD_T_%s".formatted(sufixo));
+        coordenadoria.setNome("Coordenadoria teste %s".formatted(sufixo));
+        coordenadoria.setSituacao(SituacaoUnidade.ATIVA);
+        coordenadoria.setTipo(TipoUnidade.INTERMEDIARIA);
+        coordenadoria.setUnidadeSuperior(secretaria);
+        coordenadoria = unidadeRepo.save(coordenadoria);
+
+        Unidade secao = new Unidade();
+        secao.setSigla(siglaSecao);
+        secao.setNome("Seção teste %s".formatted(sufixo));
+        secao.setSituacao(SituacaoUnidade.ATIVA);
+        secao.setTipo(TipoUnidade.OPERACIONAL);
+        secao.setUnidadeSuperior(coordenadoria);
+        return unidadeRepo.save(secao);
     }
 }

--- a/backend/src/test/java/sgc/integracao/CDU33IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU33IntegrationTest.java
@@ -55,15 +55,7 @@ class CDU33IntegrationTest extends BaseIntegrationTest {
             unidadeRepo.save(admin);
         }
 
-        // Obter unidade com cadeia hierárquica conhecida
-        Unidade unidade = unidadeRepo.findBySigla("SEDESENV").orElseGet(() -> {
-            Unidade u = new Unidade();
-            u.setSigla("TESTE");
-            u.setNome("Unidade teste");
-            u.setSituacao(ATIVA);
-            u.setTipo(OPERACIONAL);
-            return unidadeRepo.save(u);
-        });
+        Unidade unidade = buscarOuCriarUnidadeComDoisSuperiores("CDU33");
 
         // Criar processo de REVISAO
         Processo processo = ProcessoFixture.processoPadrao();
@@ -138,6 +130,9 @@ class CDU33IntegrationTest extends BaseIntegrationTest {
         assertThat(alertaSuperiorExiste).isTrue();
 
         List<Long> codigosEsperadosSuperiores = coletarCodigosSuperiores(spReaberto.getUnidade());
+        assertThat(codigosEsperadosSuperiores)
+                .as("CDU-33 deve propagar alerta para toda a cadeia hierárquica superior")
+                .hasSizeGreaterThanOrEqualTo(2);
         long quantidadeAlertasSuperiores = alerts.stream()
                 .filter(a -> a.getUnidadeDestino() != null)
                 .filter(a -> codigosEsperadosSuperiores.contains(a.getUnidadeDestino().getCodigo()))
@@ -200,5 +195,36 @@ class CDU33IntegrationTest extends BaseIntegrationTest {
             superiorAtual = superiorAtual.getUnidadeSuperior();
         }
         return codigos;
+    }
+
+    private Unidade buscarOuCriarUnidadeComDoisSuperiores(String sufixo) {
+        String siglaSecao = "SEC_T_%s".formatted(sufixo);
+        Optional<Unidade> secaoExistente = unidadeRepo.findBySigla(siglaSecao);
+        if (secaoExistente.isPresent()) {
+            return secaoExistente.get();
+        }
+
+        Unidade secretaria = new Unidade();
+        secretaria.setSigla("SECRET_T_%s".formatted(sufixo));
+        secretaria.setNome("Secretaria teste %s".formatted(sufixo));
+        secretaria.setSituacao(ATIVA);
+        secretaria.setTipo(INTEROPERACIONAL);
+        secretaria = unidadeRepo.save(secretaria);
+
+        Unidade coordenadoria = new Unidade();
+        coordenadoria.setSigla("COORD_T_%s".formatted(sufixo));
+        coordenadoria.setNome("Coordenadoria teste %s".formatted(sufixo));
+        coordenadoria.setSituacao(ATIVA);
+        coordenadoria.setTipo(INTERMEDIARIA);
+        coordenadoria.setUnidadeSuperior(secretaria);
+        coordenadoria = unidadeRepo.save(coordenadoria);
+
+        Unidade secao = new Unidade();
+        secao.setSigla(siglaSecao);
+        secao.setNome("Seção teste %s".formatted(sufixo));
+        secao.setSituacao(ATIVA);
+        secao.setTipo(OPERACIONAL);
+        secao.setUnidadeSuperior(coordenadoria);
+        return unidadeRepo.save(secao);
     }
 }

--- a/backend/src/test/java/sgc/integracao/CDU33IntegrationTest.java
+++ b/backend/src/test/java/sgc/integracao/CDU33IntegrationTest.java
@@ -136,6 +136,15 @@ class CDU33IntegrationTest extends BaseIntegrationTest {
                     a.getDescricao().contains("Revisão de cadastro da unidade %s reaberta pela ADMIN".formatted(spReaberto.getUnidade().getSigla()));
         });
         assertThat(alertaSuperiorExiste).isTrue();
+
+        List<Long> codigosEsperadosSuperiores = coletarCodigosSuperiores(spReaberto.getUnidade());
+        long quantidadeAlertasSuperiores = alerts.stream()
+                .filter(a -> a.getUnidadeDestino() != null)
+                .filter(a -> codigosEsperadosSuperiores.contains(a.getUnidadeDestino().getCodigo()))
+                .filter(a -> a.getDescricao().contains(
+                        "Revisão de cadastro da unidade %s reaberta pela ADMIN".formatted(spReaberto.getUnidade().getSigla())))
+                .count();
+        assertThat(quantidadeAlertasSuperiores).isEqualTo(codigosEsperadosSuperiores.size());
     }
 
     @Test
@@ -181,5 +190,15 @@ class CDU33IntegrationTest extends BaseIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isUnprocessableContent());
+    }
+
+    private List<Long> coletarCodigosSuperiores(Unidade unidade) {
+        List<Long> codigos = new ArrayList<>();
+        Unidade superiorAtual = unidade.getUnidadeSuperior();
+        while (superiorAtual != null) {
+            codigos.add(superiorAtual.getCodigo());
+            superiorAtual = superiorAtual.getUnidadeSuperior();
+        }
+        return codigos;
     }
 }

--- a/e2e/cdu-32.spec.ts
+++ b/e2e/cdu-32.spec.ts
@@ -84,6 +84,20 @@ test.describe.serial('CDU-32 - Reabrir cadastro', () => {
         await expect(tabelaAlertas).toBeVisible();
         await expect(tabelaAlertas).toContainText(descProcesso);
         await expect(tabelaAlertas).toContainText(/Cadastro da unidade SECAO_221 reaberto/i);
+        await expect(tabelaAlertas).toContainText(/ADMIN/i);
+        await expect(tabelaAlertas).toContainText(/\d{2}\/\d{2}\/\d{4}/);
+    });
+
+    test('Cenário complementar: nível acima da unidade superior também visualiza alerta de reabertura', async ({
+                                                                                                                     _resetAutomatico,
+                                                                                                                     page,
+                                                                                                                     _autenticadoComoGestorSecretaria2
+    }) => {
+        const tabelaAlertas = page.getByTestId('tbl-alertas');
+        await expect(tabelaAlertas).toBeVisible();
+        await expect(tabelaAlertas).toContainText(descProcesso);
+        await expect(tabelaAlertas).toContainText(/Cadastro da unidade SECAO_221 reaberto/i);
+        await expect(tabelaAlertas).toContainText(/ADMIN/i);
         await expect(tabelaAlertas).toContainText(/\d{2}\/\d{2}\/\d{4}/);
     });
 });

--- a/e2e/cdu-33.spec.ts
+++ b/e2e/cdu-33.spec.ts
@@ -115,6 +115,20 @@ test.describe.serial('CDU-33 - Reabrir revisão de cadastro', () => {
         await expect(tabelaAlertas).toBeVisible();
         await expect(tabelaAlertas).toContainText(descRevisao);
         await expect(tabelaAlertas).toContainText(/Revisão de cadastro da unidade SECAO_212 reaberta/i);
+        await expect(tabelaAlertas).toContainText(/ADMIN/i);
+        await expect(tabelaAlertas).toContainText(/\d{2}\/\d{2}\/\d{4}/);
+    });
+
+    test('Cenário complementar: nível acima da unidade superior visualiza alerta de reabertura de revisão', async ({
+                                                                                                                          _resetAutomatico,
+                                                                                                                          page,
+                                                                                                                          _autenticadoComoGestorSecretaria2
+    }) => {
+        const tabelaAlertas = page.getByTestId('tbl-alertas');
+        await expect(tabelaAlertas).toBeVisible();
+        await expect(tabelaAlertas).toContainText(descRevisao);
+        await expect(tabelaAlertas).toContainText(/Revisão de cadastro da unidade SECAO_212 reaberta/i);
+        await expect(tabelaAlertas).toContainText(/ADMIN/i);
         await expect(tabelaAlertas).toContainText(/\d{2}\/\d{2}\/\d{4}/);
     });
 });


### PR DESCRIPTION
### Motivation
- Garantir que o fluxo de reabertura (CDU-32 e CDU-33) notifique corretamente toda a cadeia de unidades superiores e evitar regressões que só verificavam o superior imediato. 
- A UI de alertas não expõe todas as informações internas (p.ex. sigla do destino), então os E2E precisam validar os campos visíveis e semânticos ao usuário.

### Description
- Ampliei os testes de integração `CDU32IntegrationTest` e `CDU33IntegrationTest` para coletar a cadeia completa de superiores via `coletarCodigosSuperiores` e validar que há um alerta por cada nível superior esperado, comparando por descrição do alerta. 
- Adicionei a função auxiliar `coletarCodigosSuperiores(Unidade)` em ambos os testes de integração e asserções que contam os alertas gerados para todos os superiores. 
- Reforcei os specs E2E `e2e/cdu-32.spec.ts` e `e2e/cdu-33.spec.ts` adicionando cenários que validam que: o superior imediato e o nível acima também visualizam o alerta; e que a tabela de alertas exibe campos visíveis e relevantes (`ADMIN` como origem e data/hora). 
- Ajustei os asserts E2E para não dependerem de informações não-renderizadas na UI (removi verificações de sigla de unidade quando não disponível e foquei em `descrição`, `origem` e `data/hora`).

### Testing
- Executei os testes de integração com `./gradlew :backend:test --tests 'sgc.integracao.CDU32IntegrationTest' --tests 'sgc.integracao.CDU33IntegrationTest'`, resultado: `8 tests run, 8 passed`.
- Executei os E2E relevantes com `npx playwright test e2e/cdu-32.spec.ts e2e/cdu-33.spec.ts --workers=1`, resultado: todos os cenários dos dois specs passaram (10 passed).
- Todas as alterações foram validadas localmente e os novos asserts passaram sem flakiness no ambiente de execução usado para esta correção.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2ece1b5c4832b9bd0dc961277d304)