### PR TITLE
Extract context loader and mapa actions to composables, update views and tests

### DIFF
--- a/frontend/src/composables/__tests__/useContextoSubprocesso.spec.ts
+++ b/frontend/src/composables/__tests__/useContextoSubprocesso.spec.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it, vi} from 'vitest';
+import {carregarContextoSubprocessoInicial} from '@/composables/useContextoSubprocesso';
+
+function criarStoreMock() {
+  return {
+    garantirContextoEdicao: vi.fn(),
+    garantirContextoEdicaoPorProcessoEUnidade: vi.fn(),
+  };
+}
+
+describe('carregarContextoSubprocessoInicial', () => {
+  it('deve priorizar codSubprocesso da query quando válido', async () => {
+    const contexto = {detalhes: {codigo: 10}} as any;
+    const store = criarStoreMock();
+    store.garantirContextoEdicao.mockResolvedValue(contexto);
+
+    const resultado = await carregarContextoSubprocessoInicial({
+      codProcesso: 77,
+      siglaUnidade: 'SUGEP',
+      codSubprocessoQuery: '10',
+      store,
+    });
+
+    expect(store.garantirContextoEdicao).toHaveBeenCalledWith(10);
+    expect(store.garantirContextoEdicaoPorProcessoEUnidade).not.toHaveBeenCalled();
+    expect(resultado).toEqual({codigo: 10, contexto});
+  });
+
+  it('deve usar processo+unidade quando query for inválida', async () => {
+    const contexto = {detalhes: {codigo: 25}} as any;
+    const store = criarStoreMock();
+    store.garantirContextoEdicaoPorProcessoEUnidade.mockResolvedValue({codigo: 25, contexto});
+
+    const resultado = await carregarContextoSubprocessoInicial({
+      codProcesso: 88,
+      siglaUnidade: 'SEPLAN',
+      codSubprocessoQuery: 'invalido',
+      store,
+    });
+
+    expect(store.garantirContextoEdicao).not.toHaveBeenCalled();
+    expect(store.garantirContextoEdicaoPorProcessoEUnidade).toHaveBeenCalledWith(88, 'SEPLAN');
+    expect(resultado).toEqual({codigo: 25, contexto});
+  });
+
+  it('deve cair para processo+unidade quando query válida não encontrar contexto', async () => {
+    const store = criarStoreMock();
+    store.garantirContextoEdicao.mockResolvedValue(null);
+    store.garantirContextoEdicaoPorProcessoEUnidade.mockResolvedValue({
+      codigo: 99,
+      contexto: {detalhes: {codigo: 99}},
+    });
+
+    const resultado = await carregarContextoSubprocessoInicial({
+      codProcesso: 1,
+      siglaUnidade: 'GAB',
+      codSubprocessoQuery: '15',
+      store,
+    });
+
+    expect(store.garantirContextoEdicao).toHaveBeenCalledWith(15);
+    expect(store.garantirContextoEdicaoPorProcessoEUnidade).toHaveBeenCalledWith(1, 'GAB');
+    expect(resultado).toEqual({
+      codigo: 99,
+      contexto: {detalhes: {codigo: 99}},
+    });
+  });
+
+  it('deve retornar null quando query e fallback não encontrarem contexto', async () => {
+    const store = criarStoreMock();
+    store.garantirContextoEdicao.mockResolvedValue(null);
+    store.garantirContextoEdicaoPorProcessoEUnidade.mockResolvedValue(null);
+
+    const resultado = await carregarContextoSubprocessoInicial({
+      codProcesso: 1,
+      siglaUnidade: 'GAB',
+      codSubprocessoQuery: '15',
+      store,
+    });
+
+    expect(resultado).toBeNull();
+  });
+});

--- a/frontend/src/composables/useContextoSubprocesso.ts
+++ b/frontend/src/composables/useContextoSubprocesso.ts
@@ -1,0 +1,50 @@
+import type {ContextoEdicaoSubprocesso} from '@/types/tipos';
+
+interface DependenciasContextoSubprocesso {
+  garantirContextoEdicao: (codigoSubprocesso: number) => Promise<ContextoEdicaoSubprocesso | null>;
+  garantirContextoEdicaoPorProcessoEUnidade: (
+    codigoProcesso: number,
+    siglaUnidade: string,
+  ) => Promise<{codigo: number; contexto: ContextoEdicaoSubprocesso} | null>;
+}
+
+interface ParametrosCarregarContextoSubprocesso {
+  codProcesso: number;
+  siglaUnidade: string;
+  codSubprocessoQuery: unknown;
+  store: DependenciasContextoSubprocesso;
+}
+
+export interface ResultadoContextoSubprocesso {
+  codigo: number;
+  contexto: ContextoEdicaoSubprocesso;
+}
+
+function extrairCodigoSubprocesso(codSubprocessoQuery: unknown): number | null {
+  const codigoSubprocesso = Number(codSubprocessoQuery);
+  if (!Number.isFinite(codigoSubprocesso) || codigoSubprocesso <= 0) {
+    return null;
+  }
+  return codigoSubprocesso;
+}
+
+export async function carregarContextoSubprocessoInicial({
+  codProcesso,
+  siglaUnidade,
+  codSubprocessoQuery,
+  store,
+}: ParametrosCarregarContextoSubprocesso): Promise<ResultadoContextoSubprocesso | null> {
+  const codigoSubprocessoQuery = extrairCodigoSubprocesso(codSubprocessoQuery);
+
+  if (codigoSubprocessoQuery) {
+    const contexto = await store.garantirContextoEdicao(codigoSubprocessoQuery);
+    if (contexto) {
+      return {
+        codigo: codigoSubprocessoQuery,
+        contexto,
+      };
+    }
+  }
+
+  return store.garantirContextoEdicaoPorProcessoEUnidade(codProcesso, siglaUnidade);
+}

--- a/frontend/src/composables/useMapaAcoesAnalise.ts
+++ b/frontend/src/composables/useMapaAcoesAnalise.ts
@@ -1,0 +1,135 @@
+import {ref, type Ref} from 'vue';
+import logger from '@/utils/logger';
+import {TEXTOS} from '@/constants/textos';
+import {
+  aceitarValidacao as aceitarValidacaoService,
+  devolverValidacao as devolverValidacaoService,
+  homologarValidacao as homologarValidacaoService,
+  validarMapa as validarMapaService,
+} from '@/services/processoService';
+
+type NotificacaoMapa = (mensagem: string, variante: 'success' | 'danger' | 'warning' | 'info') => void;
+
+interface AcaoPrincipalMapa {
+  codigo: 'ACEITAR' | 'HOMOLOGAR';
+  mensagemSucesso: string;
+}
+
+interface ParametrosUseMapaAcoesAnalise {
+  codSubprocesso: Ref<number | null>;
+  acaoPrincipalMapa: Ref<AcaoPrincipalMapa | null | undefined>;
+  concluirAcaoPainel: (mensagem: string, fecharModal: () => void) => Promise<void>;
+  notify: NotificacaoMapa;
+}
+
+export function useMapaAcoesAnalise({
+  codSubprocesso,
+  acaoPrincipalMapa,
+  concluirAcaoPainel,
+  notify,
+}: ParametrosUseMapaAcoesAnalise) {
+  const mostrarModalAceitar = ref(false);
+  const mostrarModalValidar = ref(false);
+  const mostrarModalDevolucao = ref(false);
+  const observacaoDevolucao = ref('');
+  const isLoading = ref(false);
+
+  async function executarComLoading(acao: () => Promise<void>) {
+    isLoading.value = true;
+    try {
+      await acao();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  async function confirmarValidacao() {
+    if (!codSubprocesso.value) return;
+    try {
+      await executarComLoading(async () => {
+        await validarMapaService(codSubprocesso.value!);
+        await concluirAcaoPainel(TEXTOS.sucesso.MAPA_VALIDADO_SUBMETIDO, fecharModalValidar);
+      });
+    } catch {
+      notify(TEXTOS.mapa.ERRO_VALIDAR, 'danger');
+    }
+  }
+
+  async function confirmarAceitacao(observacao = '') {
+    if (!codSubprocesso.value) return;
+
+    const acao = acaoPrincipalMapa.value;
+    if (!acao) return;
+
+    try {
+      await executarComLoading(async () => {
+        if (acao.codigo === 'HOMOLOGAR') {
+          await homologarValidacaoService(codSubprocesso.value!, {texto: observacao});
+        } else {
+          await aceitarValidacaoService(codSubprocesso.value!, {texto: observacao});
+        }
+        await concluirAcaoPainel(acao.mensagemSucesso, fecharModalAceitar);
+      });
+    } catch (error) {
+      logger.error(error);
+      notify(TEXTOS.comum.ERRO_OPERACAO, 'danger');
+    }
+  }
+
+  async function confirmarDevolucao() {
+    if (!codSubprocesso.value) return;
+    try {
+      await executarComLoading(async () => {
+        await devolverValidacaoService(codSubprocesso.value!, {
+          justificativa: observacaoDevolucao.value,
+        });
+        await concluirAcaoPainel(TEXTOS.sucesso.DEVOLUCAO_REALIZADA, fecharModalDevolucao);
+      });
+    } catch (error) {
+      logger.error(error);
+      notify(TEXTOS.mapa.ERRO_DEVOLVER, 'danger');
+    }
+  }
+
+  function abrirModalAceitar() {
+    mostrarModalAceitar.value = true;
+  }
+
+  function fecharModalAceitar() {
+    mostrarModalAceitar.value = false;
+  }
+
+  function abrirModalValidar() {
+    mostrarModalValidar.value = true;
+  }
+
+  function fecharModalValidar() {
+    mostrarModalValidar.value = false;
+  }
+
+  function abrirModalDevolucao() {
+    mostrarModalDevolucao.value = true;
+  }
+
+  function fecharModalDevolucao() {
+    mostrarModalDevolucao.value = false;
+    observacaoDevolucao.value = '';
+  }
+
+  return {
+    mostrarModalAceitar,
+    mostrarModalValidar,
+    mostrarModalDevolucao,
+    observacaoDevolucao,
+    isLoading,
+    confirmarValidacao,
+    confirmarAceitacao,
+    confirmarDevolucao,
+    abrirModalAceitar,
+    fecharModalAceitar,
+    abrirModalValidar,
+    fecharModalValidar,
+    abrirModalDevolucao,
+    fecharModalDevolucao,
+  };
+}

--- a/frontend/src/views/CadastroVisualizacaoView.vue
+++ b/frontend/src/views/CadastroVisualizacaoView.vue
@@ -171,6 +171,7 @@ import {useSubprocessos} from "@/composables/useSubprocessos";
 import {useToastStore} from "@/stores/toast";
 import {useSubprocessoStore} from "@/stores/subprocesso";
 import {useInvalidacaoNavegacao} from "@/composables/useInvalidacaoNavegacao";
+import {carregarContextoSubprocessoInicial} from "@/composables/useContextoSubprocesso";
 import type {
   AceitarCadastroRequest,
   Analise,
@@ -367,14 +368,12 @@ async function confirmarDevolucao() {
 onMounted(async () => {
   try {
     limparEstadoSubprocessoAtual();
-    const codigoQuery = Number(route.query.codSubprocesso);
-    const resultado = Number.isFinite(codigoQuery) && codigoQuery > 0
-        ? await subprocessoStoreCache.garantirContextoEdicao(codigoQuery)
-            .then((contexto) => contexto ? {codigo: codigoQuery, contexto} : null)
-        : await subprocessoStoreCache.garantirContextoEdicaoPorProcessoEUnidade(
-            codProcesso.value,
-            unidadeId.value,
-        );
+    const resultado = await carregarContextoSubprocessoInicial({
+      codProcesso: codProcesso.value,
+      siglaUnidade: unidadeId.value,
+      codSubprocessoQuery: route.query.codSubprocesso,
+      store: subprocessoStoreCache,
+    });
 
     if (resultado) {
       codSubprocesso.value = resultado.codigo;

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -140,6 +140,7 @@ import {useSubprocessos} from "@/composables/useSubprocessos";
 import {useToastStore} from "@/stores/toast";
 import {useSubprocessoStore} from "@/stores/subprocesso";
 import {useInvalidacaoNavegacao} from "@/composables/useInvalidacaoNavegacao";
+import {carregarContextoSubprocessoInicial} from "@/composables/useContextoSubprocesso";
 import type {Atividade, Competencia, MapaCompleto, SalvarCompetenciaRequest, Unidade} from "@/types/tipos";
 import type {NormalizedError} from "@/utils/apiError";
 import ModalConfirmacao from "@/components/comum/ModalConfirmacao.vue";
@@ -198,14 +199,12 @@ async function carregarContextoEdicao(codigo: number) {
 }
 
 async function carregarContextoInicial() {
-  const codigoQuery = Number(route.query.codSubprocesso);
-  const resultado = Number.isFinite(codigoQuery) && codigoQuery > 0
-      ? await subprocessoStoreCache.garantirContextoEdicao(codigoQuery)
-          .then((contexto) => contexto ? {codigo: codigoQuery, contexto} : null)
-      : await subprocessoStoreCache.garantirContextoEdicaoPorProcessoEUnidade(
-          codProcesso.value,
-          siglaUnidade.value,
-      );
+  const resultado = await carregarContextoSubprocessoInicial({
+    codProcesso: codProcesso.value,
+    siglaUnidade: siglaUnidade.value,
+    codSubprocessoQuery: route.query.codSubprocesso,
+    store: subprocessoStoreCache,
+  });
 
   if (!resultado) {
     return null;

--- a/frontend/src/views/MapaVisualizacaoView.vue
+++ b/frontend/src/views/MapaVisualizacaoView.vue
@@ -253,15 +253,13 @@ import {useToastStore} from "@/stores/toast";
 import {useSubprocessoStore} from "@/stores/subprocesso";
 import {useInvalidacaoNavegacao} from "@/composables/useInvalidacaoNavegacao";
 import {useAcesso} from "@/composables/useAcesso";
+import {useMapaAcoesAnalise} from "@/composables/useMapaAcoesAnalise";
+import {carregarContextoSubprocessoInicial} from "@/composables/useContextoSubprocesso";
 import logger from "@/utils/logger";
 import {listarAnalisesCadastro} from "@/services/analiseService";
 import {obterMapaVisualizacao, obterSugestoesMapa} from "@/services/subprocessoService";
 import {
-  aceitarValidacao as aceitarValidacaoService,
   apresentarSugestoes as apresentarSugestoesService,
-  devolverValidacao as devolverValidacaoService,
-  homologarValidacao as homologarValidacaoService,
-  validarMapa as validarMapaService,
 } from "@/services/processoService";
 import type {Analise, MapaVisualizacao, Unidade} from "@/types/tipos";
 import {TEXTOS} from "@/constants/textos";
@@ -308,17 +306,30 @@ const historicoAnalise = computed(() => {
 
 const temHistoricoAnalise = computed(() => historicoAnalise.value.length > 0);
 
-const mostrarModalAceitar = ref(false);
 const mostrarModalSugestoes = ref(false);
 const mostrarModalVerSugestoes = ref(false);
-const mostrarModalValidar = ref(false);
-const mostrarModalDevolucao = ref(false);
 const mostrarModalHistorico = ref(false);
 const sugestoes = ref("");
 const sugestoesVisualizacao = ref("");
-const observacaoDevolucao = ref("");
-
-const isLoading = ref(false);
+const {
+  mostrarModalAceitar,
+  mostrarModalValidar,
+  mostrarModalDevolucao,
+  observacaoDevolucao,
+  isLoading,
+  confirmarValidacao,
+  confirmarAceitacao,
+  confirmarDevolucao,
+  abrirModalAceitar,
+  fecharModalAceitar,
+  abrirModalValidar,
+  abrirModalDevolucao,
+} = useMapaAcoesAnalise({
+  codSubprocesso,
+  acaoPrincipalMapa,
+  concluirAcaoPainel,
+  notify,
+});
 
 // Refs para foco
 const sugestoesTextareaRef = ref<InstanceType<typeof BFormTextarea> | null>(null);
@@ -334,14 +345,12 @@ async function executarComLoading(acao: () => Promise<void>) {
 }
 
 async function carregarContextoInicial() {
-  const codigoQuery = Number(route.query.codSubprocesso);
-  const resultado = Number.isFinite(codigoQuery) && codigoQuery > 0
-      ? await subprocessoStoreCache.garantirContextoEdicao(codigoQuery)
-          .then((contexto) => contexto ? {codigo: codigoQuery, contexto} : null)
-      : await subprocessoStoreCache.garantirContextoEdicaoPorProcessoEUnidade(
-          codProcesso.value,
-          sigla.value,
-      );
+  const resultado = await carregarContextoSubprocessoInicial({
+    codProcesso: codProcesso.value,
+    siglaUnidade: sigla.value,
+    codSubprocessoQuery: route.query.codSubprocesso,
+    store: subprocessoStoreCache,
+  });
 
   if (!resultado) {
     codSubprocesso.value = null;
@@ -397,65 +406,6 @@ async function confirmarSugestoes() {
   }
 }
 
-async function confirmarValidacao() {
-  if (!codSubprocesso.value) return;
-  try {
-    await executarComLoading(async () => {
-      await validarMapaService(codSubprocesso.value!);
-      await concluirAcaoPainel(TEXTOS.sucesso.MAPA_VALIDADO_SUBMETIDO, fecharModalValidar);
-    });
-  } catch {
-    notify(TEXTOS.mapa.ERRO_VALIDAR, 'danger');
-  }
-}
-
-async function confirmarAceitacao(observacao = "") {
-  if (!codSubprocesso.value) return;
-
-  const acao = acaoPrincipalMapa.value;
-  if (!acao) return;
-
-  try {
-    await executarComLoading(async () => {
-      if (acao.codigo === "HOMOLOGAR") {
-        await homologarValidacaoService(codSubprocesso.value!, {texto: observacao});
-      } else {
-        await aceitarValidacaoService(codSubprocesso.value!, {texto: observacao});
-      }
-      await concluirAcaoPainel(
-          acao.mensagemSucesso,
-          fecharModalAceitar,
-      );
-    });
-  } catch (error) {
-    logger.error(error);
-    notify(TEXTOS.comum.ERRO_OPERACAO, 'danger');
-  }
-}
-
-async function confirmarDevolucao() {
-  if (!codSubprocesso.value) return;
-  try {
-    await executarComLoading(async () => {
-      await devolverValidacaoService(codSubprocesso.value!, {
-        justificativa: observacaoDevolucao.value,
-      });
-      await concluirAcaoPainel(TEXTOS.sucesso.DEVOLUCAO_REALIZADA, fecharModalDevolucao);
-    });
-  } catch (error) {
-    logger.error(error);
-    notify(TEXTOS.mapa.ERRO_DEVOLVER, 'danger');
-  }
-}
-
-function abrirModalAceitar() {
-  mostrarModalAceitar.value = true;
-}
-
-function fecharModalAceitar() {
-  mostrarModalAceitar.value = false;
-}
-
 async function carregarSugestoesParaEdicao() {
   try {
     sugestoes.value = await sincronizarSugestoesMapa();
@@ -493,23 +443,6 @@ function verSugestoes() {
 function fecharModalVerSugestoes() {
   mostrarModalVerSugestoes.value = false;
   sugestoesVisualizacao.value = "";
-}
-
-function abrirModalValidar() {
-  mostrarModalValidar.value = true;
-}
-
-function fecharModalValidar() {
-  mostrarModalValidar.value = false;
-}
-
-function abrirModalDevolucao() {
-  mostrarModalDevolucao.value = true;
-}
-
-function fecharModalDevolucao() {
-  mostrarModalDevolucao.value = false;
-  observacaoDevolucao.value = "";
 }
 
 async function abrirModalHistorico() {

--- a/frontend/src/views/SubprocessoView.vue
+++ b/frontend/src/views/SubprocessoView.vue
@@ -245,6 +245,7 @@ import {TEXTOS} from "@/constants/textos";
 import {useToastStore} from "@/stores/toast";
 import {useSubprocessoStore} from "@/stores/subprocesso";
 import {useInvalidacaoNavegacao} from "@/composables/useInvalidacaoNavegacao";
+import {carregarContextoSubprocessoInicial} from "@/composables/useContextoSubprocesso";
 
 const props = defineProps<{ codProcesso: number; siglaUnidade: string }>();
 
@@ -350,14 +351,12 @@ function exibirToastPendente() {
 async function carregarSubprocesso() {
   subprocessosStore.subprocessoDetalhe = null;
 
-  const codigoQuery = Number(route.query.codSubprocesso);
-  const resultado = Number.isFinite(codigoQuery) && codigoQuery > 0
-      ? await subprocessoStoreCache.garantirContextoEdicao(codigoQuery)
-          .then((contexto) => contexto ? {codigo: codigoQuery, contexto} : null)
-      : await subprocessoStoreCache.garantirContextoEdicaoPorProcessoEUnidade(
-          props.codProcesso,
-          props.siglaUnidade,
-      );
+  const resultado = await carregarContextoSubprocessoInicial({
+    codProcesso: props.codProcesso,
+    siglaUnidade: props.siglaUnidade,
+    codSubprocessoQuery: route.query.codSubprocesso,
+    store: subprocessoStoreCache,
+  });
 
   if (resultado) {
     erroNaoEncontrado.value = false;

--- a/planos/backlog-racionalizacao.md
+++ b/planos/backlog-racionalizacao.md
@@ -180,7 +180,30 @@ Enxugar o fluxo de sugestões/histórico e reduzir caminhos duplicados no `<scri
   - remoção do alias de histórico e retorno para função explícita.
 - Resultado imediato: menos ramificação incidental, sem prender abertura de modal ao carregamento de sugestões e sem mascarar falhas de leitura.
 
+**Extensão aplicada (rodada 12)**
+
+- Extração do bloco de ações de análise (`validar`, `devolver`, `aceitar/homologar`) para composable dedicado (`useMapaAcoesAnalise`);
+- `MapaVisualizacaoView` passou a manter no arquivo principal apenas coordenação da tela, enquanto regras de loading, execução de ação e fechamento de modal ficaram encapsuladas por intenção;
+- Fluxo de sugestões/histórico permanece desacoplado e agora convive com o novo bloco sem reintroduzir duplicação de tratamento.
+
 **Pendências restantes**
 
-- avaliar extração pontual do bloco de ações de análise (aceitar/homologar/devolver/validar) para reduzir o tamanho do arquivo;
 - verificar se mais decisões de permissão podem vir prontas no backend para simplificar renderização condicional da tela.
+
+### Rodada 12 (executada)
+
+- extração do bloco de ações de análise de `MapaVisualizacaoView` para `useMapaAcoesAnalise`;
+- redução adicional de responsabilidades no `<script setup>` da tela de visualização de mapa;
+- backlog atualizado com novo baseline da Onda 2 para continuidade da simplificação.
+
+### Rodada 13 (executada)
+
+- extração da estratégia de carregamento inicial de contexto de subprocesso para helper compartilhado (`carregarContextoSubprocessoInicial`);
+- remoção de duplicação do fallback por query/processo+unidade em quatro telas (`SubprocessoView`, `CadastroVisualizacaoView`, `MapaView`, `MapaVisualizacaoView`);
+- baseline de testes ampliado com suíte dedicada ao novo helper para preservar o contrato de resolução de contexto.
+
+### Rodada 14 (executada)
+
+- ajuste de semântica no helper de contexto: quando `codSubprocesso` vindo da query não resolve contexto, o fluxo agora recua explicitamente para busca por `processo+unidade` em vez de retornar nulo imediato;
+- suíte unitária do helper expandida para cobrir fallback após falha da query e cenário de ausência total de contexto;
+- validação E2E completa executada em `--workers=1` após o ajuste para confirmar que a correção não introduziu regressão funcional.


### PR DESCRIPTION
### Motivation

- Reduce duplicated logic for resolving the initial subprocess editing context across multiple views and encapsulate mapa analysis actions to simplify and shrink `<script setup>` blocks. 
- Make the query-based subprocess selection semantics explicit so a valid `codSubprocesso` in the query falls back to `processo+unidade` when the query id does not resolve a context. 

### Description

- Added `frontend/src/composables/useContextoSubprocesso.ts` implementing `carregarContextoSubprocessoInicial` and `extrairCodigoSubprocesso` to centralize query/processo+unidade resolution. 
- Added unit tests `frontend/src/composables/__tests__/useContextoSubprocesso.spec.ts` to cover query-priority, invalid query fallback, query-then-fallback, and total-miss scenarios. 
- Added `frontend/src/composables/useMapaAcoesAnalise.ts` to encapsulate mapa analysis actions (`validar`, `aceitar`/`homologar`, `devolver`) and their loading/error handling and modal state. 
- Updated views `CadastroVisualizacaoView.vue`, `MapaView.vue`, `MapaVisualizacaoView.vue`, and `SubprocessoView.vue` to use the new `carregarContextoSubprocessoInicial` helper and to adopt `useMapaAcoesAnalise` in `MapaVisualizacaoView.vue`, removing duplicated code. 
- Updated `planos/backlog-racionalizacao.md` to document the refactor rounds and rationale. 

### Testing

- Ran the new unit test suite for the context loader with `vitest` and the `useContextoSubprocesso` spec succeeded. 
- Ran project unit tests (including the changed views) and they passed in the CI run. 
- Executed the E2E validation with `--workers=1` after the semantic fallback change and the run completed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36581ec14832bb57cb96b0cf5e37b)