### PR TITLE
Frontend quality check and lint fixes

### DIFF
--- a/frontend/src/views/__tests__/CadProcessoUncovered.spec.ts
+++ b/frontend/src/views/__tests__/CadProcessoUncovered.spec.ts
@@ -5,7 +5,6 @@ import {createTestingPinia} from "@pinia/testing";
 import * as processoService from "@/services/processoService";
 import {useUnidadeStore} from "@/stores/unidade";
 import {useProcessoForm} from "@/composables/useProcessoForm";
-import {useNotification} from "@/composables/useNotification";
 import {ref} from "vue";
 import {logger} from "@/utils";
 import {TEXTOS} from "@/constants/textos";

--- a/frontend/src/views/__tests__/PainelView.spec.ts
+++ b/frontend/src/views/__tests__/PainelView.spec.ts
@@ -193,7 +193,6 @@ describe('PainelView', () => {
     const wrapper = mount(PainelView, options);
     await flushPromises();
     
-    const pinia = options.global.plugins[1] as any;
     const painelStore = (wrapper.vm as any).painelStore;
     
     painelStore.processos = [

--- a/frontend/src/views/__tests__/RelatorioAndamentoView.spec.ts
+++ b/frontend/src/views/__tests__/RelatorioAndamentoView.spec.ts
@@ -100,7 +100,7 @@ describe('RelatorioAndamentoView', () => {
 
     it('cobre falha em carregarProcessos', async () => {
         vi.mocked(painelService.listarProcessos).mockRejectedValue(new Error("Erro simulado"));
-        const wrapper = mount(RelatorioAndamentoView, { global: { stubs } });
+        mount(RelatorioAndamentoView, { global: { stubs } });
         await flushPromises();
         expect(notify).toHaveBeenCalledWith("Erro ao carregar processos", "danger");
     });


### PR DESCRIPTION
Performed a quality check on the frontend, including typechecking (root and frontend), linting, and unit tests. Fixed linting warnings in frontend test files regarding unused variables and imports. Verified that all checks now pass with zero errors and warnings.

---
*PR created automatically by Jules for task [8566355572640047519](https://jules.google.com/task/8566355572640047519) started by @lgalvao*