### PR TITLE
Corrige tela inicial crua e ajusta testes de disponibilização de cadastro

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>SGC</title>
+    <style>
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+    </style>
 </head>
 <body>
 <h1 class="visually-hidden">SGC</h1>

--- a/frontend/src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts
+++ b/frontend/src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts
@@ -47,17 +47,16 @@ describe('ConfirmacaoDisponibilizacaoModal.vue', () => {
         expect(wrapper.text()).toContain('Confirma a disponibilização do cadastro?')
     })
 
-    it('emite evento "confirmar" com observação ao clicar no botão confirmar', async () => {
+    it('emite evento "confirmar" ao clicar no botão confirmar', async () => {
         const wrapper = mount(ConfirmacaoDisponibilizacaoModal, {
             props: defaultProps,
             global: globalOptions
         })
 
-        await wrapper.find('[data-testid="inp-disponibilizar-cadastro-obs"]').setValue("Observação teste")
         const confirmBtn = wrapper.find('[data-testid="btn-confirmar-disponibilizacao"]')
         await confirmBtn.trigger('click')
 
-        expect(wrapper.emitted('confirmar')).toEqual([["Observação teste"]])
+        expect(wrapper.emitted('confirmar')).toHaveLength(1)
     })
 
     it('emite evento "fechar" ao clicar em cancelar', async () => {

--- a/frontend/src/composables/useFluxoSubprocesso.ts
+++ b/frontend/src/composables/useFluxoSubprocesso.ts
@@ -21,7 +21,6 @@ import {useSubprocessos} from "@/composables/useSubprocessos";
 import type {
     AceitarCadastroRequest,
     DevolverCadastroRequest,
-    DisponibilizarCadastroRequest,
     HomologarCadastroRequest,
 } from "@/types/tipos";
 

--- a/frontend/src/views/NotificacoesAdminView.vue
+++ b/frontend/src/views/NotificacoesAdminView.vue
@@ -54,51 +54,51 @@
             responsive
             small
         >
-          <template #cell(unidadeSigla)="{ item }">
-            <UnidadeLink :item="item"/>
+          <template #cell(unidadeSigla)="{ item: linha }">
+            <UnidadeLink :item="linha"/>
           </template>
 
-          <template #cell(processoDescricao)="{ item }">
-            <span :data-testid="`notificacao-processo-${item.unidadeSigla}`">
-              {{ item.processoDescricao }}
+          <template #cell(processoDescricao)="{ item: linha }">
+            <span :data-testid="`notificacao-processo-${linha.unidadeSigla}`">
+              {{ linha.processoDescricao }}
             </span>
           </template>
 
-          <template #cell(statusGeral)="{ item }">
-            <BBadge :data-testid="`notificacao-status-${item.unidadeSigla}`" :variant="statusVariant(item.statusGeral)">
-              {{ statusLabel(item.statusGeral) }}
+          <template #cell(statusGeral)="{ item: linha }">
+            <BBadge :data-testid="`notificacao-status-${linha.unidadeSigla}`" :variant="statusVariant(linha.statusGeral)">
+              {{ statusLabel(linha.statusGeral) }}
             </BBadge>
-            <div v-if="item.maiorTentativas > 0" class="text-muted small mt-1">
-              {{ item.maiorTentativas }} tentativa(s)
+            <div v-if="linha.maiorTentativas > 0" class="text-muted small mt-1">
+              {{ linha.maiorTentativas }} tentativa(s)
             </div>
           </template>
 
-          <template #cell(ultimoErro)="{ item }">
+          <template #cell(ultimoErro)="{ item: linha }">
             <span
-                v-if="item.ultimoErro"
-                :data-testid="`notificacao-erro-${item.unidadeSigla}`"
-                :title="item.ultimoErro"
+                v-if="linha.ultimoErro"
+                :data-testid="`notificacao-erro-${linha.unidadeSigla}`"
+                :title="linha.ultimoErro"
                 class="text-muted text-truncate d-inline-block erro-notificacao"
             >
-              {{ item.ultimoErro }}
+              {{ linha.ultimoErro }}
             </span>
-            <span v-else :data-testid="`notificacao-erro-${item.unidadeSigla}`">-</span>
+            <span v-else :data-testid="`notificacao-erro-${linha.unidadeSigla}`">-</span>
           </template>
 
-          <template #cell(proximaTentativaEm)="{ item }">
-            <span :data-testid="`notificacao-proxima-tentativa-${item.unidadeSigla}`">
-              {{ formatarDataOuHifen(item.proximaTentativaEm) }}
+          <template #cell(proximaTentativaEm)="{ item: linha }">
+            <span :data-testid="`notificacao-proxima-tentativa-${linha.unidadeSigla}`">
+              {{ formatarDataOuHifen(linha.proximaTentativaEm) }}
             </span>
           </template>
 
-          <template #cell(acoes)="{ item }">
+          <template #cell(acoes)="{ item: linha }">
             <div class="text-end">
               <BButton
-                  v-if="item.podeReenviar"
-                  :data-testid="`btn-notificacoes-reenviar-${item.unidadeSigla}`"
+                  v-if="linha.podeReenviar"
+                  :data-testid="`btn-notificacoes-reenviar-${linha.unidadeSigla}`"
                   size="sm"
                   variant="outline-dark"
-                  @click="confirmarReenvio(item)"
+                  @click="confirmarReenvio(linha)"
               >
                 <i aria-hidden="true" class="bi bi-send"></i>
                 {{ TEXTOS.administracao.NOTIFICACOES_REENVIAR }}
@@ -127,25 +127,25 @@
             responsive
             small
         >
-          <template #cell(unidadeSigla)="{ item }">
-            <UnidadeLink :item="item"/>
+          <template #cell(unidadeSigla)="{ item: linha }">
+            <UnidadeLink :item="linha"/>
           </template>
 
-          <template #cell(processoDescricao)="{ item }">
-            <span :data-testid="`notificacao-processo-${item.unidadeSigla}`">
-              {{ item.processoDescricao }}
+          <template #cell(processoDescricao)="{ item: linha }">
+            <span :data-testid="`notificacao-processo-${linha.unidadeSigla}`">
+              {{ linha.processoDescricao }}
             </span>
           </template>
 
-          <template #cell(statusGeral)="{ item }">
-            <BBadge :data-testid="`notificacao-status-${item.unidadeSigla}`" :variant="statusVariant(item.statusGeral)">
-              {{ statusLabel(item.statusGeral) }}
+          <template #cell(statusGeral)="{ item: linha }">
+            <BBadge :data-testid="`notificacao-status-${linha.unidadeSigla}`" :variant="statusVariant(linha.statusGeral)">
+              {{ statusLabel(linha.statusGeral) }}
             </BBadge>
           </template>
 
-          <template #cell(dataHoraEnvio)="{ item }">
-            <span :data-testid="`notificacao-conclusao-${item.unidadeSigla}`">
-              {{ formatarDataOuHifen(item.ultimaNotificacaoEm) }}
+          <template #cell(dataHoraEnvio)="{ item: linha }">
+            <span :data-testid="`notificacao-conclusao-${linha.unidadeSigla}`">
+              {{ formatarDataOuHifen(linha.ultimaNotificacaoEm) }}
             </span>
           </template>
         </BTable>


### PR DESCRIPTION
### Motivation
- Evitar que o título "SGC" apareça sem estilo durante o pré-carregamento da aplicação e remover expectativas de campo obsoleto "Observações" nos testes de disponibilização de cadastro.
- Eliminar warnings de lint relacionados a import não usado e sombra de variável em templates para manter o frontend limpo e com qualidade.

### Description
- Adiciona CSS inline de `visually-hidden` em `frontend/index.html` para manter o `<h1>SGC</h1>` acessível e oculto visualmente antes do carregamento do CSS da app. (arquivo: `frontend/index.html`)
- Atualiza `ConfirmacaoDisponibilizacaoModal.spec.ts` para não tentar preencher o campo inexistente de observações e validar apenas a emissão do evento `confirmar`. (arquivo: `frontend/src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts`)
- Remove o import não utilizado `DisponibilizarCadastroRequest` em `useFluxoSubprocesso.ts` para eliminar aviso de lint. (arquivo: `frontend/src/composables/useFluxoSubprocesso.ts`)
- Renomeia variáveis de slot de `item` para `linha` em `NotificacoesAdminView.vue` e ajusta usos correspondentes para eliminar warnings de `vue/no-template-shadow`. (arquivo: `frontend/src/views/NotificacoesAdminView.vue`)

### Testing
- Executado `npm run test:unit -- src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts` e o teste passou. (status: passou)
- Executado `npm run test:unit -- src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts src/composables/__tests__/useFluxoSubprocesso.spec.ts` e ambas as suites focadas passaram. (status: passou)
- Executado `npm run typecheck` e não foram reportados erros de tipagem. (status: passou)
- Executado `npm run lint` e não foram reportados warnings/erros após as correções. (status: passou)
- Observação: a suíte completa `npm run test:unit` é numerosa e não foi concluída integralmente neste ambiente; os testes diretamente afetados pelas mudanças foram validados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2e48628c832b9e6c69d732793f79)