### PR TITLE
Support optional `observacoes` on disponibilizar cadastro/revisao (frontend + backend)

### DIFF
--- a/backend/src/main/java/sgc/subprocesso/SubprocessoController.java
+++ b/backend/src/main/java/sgc/subprocesso/SubprocessoController.java
@@ -191,8 +191,14 @@ public class SubprocessoController {
     @PostMapping("/{codSubprocesso}/cadastro/disponibilizar")
     @PreAuthorize("hasPermission(#codSubprocesso, 'Subprocesso', 'DISPONIBILIZAR_CADASTRO')")
     @Operation(summary = "Disponibiliza o cadastro de atividades para análise")
-    public ResponseEntity<MensagemResponse> disponibilizarCadastro(@PathVariable Long codSubprocesso) {
-        transicaoService.disponibilizarCadastro(codSubprocesso);
+    public ResponseEntity<MensagemResponse> disponibilizarCadastro(
+            @PathVariable Long codSubprocesso,
+            @RequestBody(required = false) DisponibilizarCadastroRequest request) {
+        String observacoes = Optional.ofNullable(request)
+                .map(DisponibilizarCadastroRequest::observacoes)
+                .map(UtilSanitizacao::sanitizar)
+                .orElse(null);
+        transicaoService.disponibilizarCadastro(codSubprocesso, observacoes);
         return ResponseEntity.ok(new MensagemResponse("Cadastro de atividades disponibilizado"));
     }
 
@@ -215,8 +221,14 @@ public class SubprocessoController {
     @PostMapping("/{codSubprocesso}/disponibilizar-revisao")
     @PreAuthorize("hasPermission(#codSubprocesso, 'Subprocesso', 'DISPONIBILIZAR_REVISAO_CADASTRO')")
     @Operation(summary = "Disponibiliza a revisão do cadastro de atividades para análise")
-    public ResponseEntity<MensagemResponse> disponibilizarRevisao(@PathVariable Long codSubprocesso) {
-        transicaoService.disponibilizarRevisao(codSubprocesso);
+    public ResponseEntity<MensagemResponse> disponibilizarRevisao(
+            @PathVariable Long codSubprocesso,
+            @RequestBody(required = false) DisponibilizarCadastroRequest request) {
+        String observacoes = Optional.ofNullable(request)
+                .map(DisponibilizarCadastroRequest::observacoes)
+                .map(UtilSanitizacao::sanitizar)
+                .orElse(null);
+        transicaoService.disponibilizarRevisao(codSubprocesso, observacoes);
 
         return ResponseEntity.ok(new MensagemResponse("Revisão do cadastro disponibilizada"));
     }

--- a/backend/src/main/java/sgc/subprocesso/dto/DisponibilizarCadastroRequest.java
+++ b/backend/src/main/java/sgc/subprocesso/dto/DisponibilizarCadastroRequest.java
@@ -1,0 +1,6 @@
+package sgc.subprocesso.dto;
+
+public record DisponibilizarCadastroRequest(
+        String observacoes
+) {
+}

--- a/backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java
+++ b/backend/src/main/java/sgc/subprocesso/service/SubprocessoTransicaoService.java
@@ -324,11 +324,16 @@ public class SubprocessoTransicaoService {
 
     @Transactional
     public void disponibilizarCadastro(Long codSubprocesso) {
+        disponibilizarCadastro(codSubprocesso, null);
+    }
+
+    @Transactional
+    public void disponibilizarCadastro(Long codSubprocesso, @Nullable String observacoes) {
         log.info("Disponibilizando cadastro do subprocesso {}", codSubprocesso);
         Subprocesso sp = consultaService.buscarSubprocesso(codSubprocesso);
         validacaoService.validarSituacaoPermitida(sp, MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
         Usuario usuario = usuarioFacade.usuarioAutenticado();
-        disponibilizar(sp, MAPEAMENTO_CADASTRO_DISPONIBILIZADO, TipoTransicao.CADASTRO_DISPONIBILIZADO, usuario);
+        disponibilizar(sp, MAPEAMENTO_CADASTRO_DISPONIBILIZADO, TipoTransicao.CADASTRO_DISPONIBILIZADO, usuario, observacoes);
     }
 
     public void iniciarRevisaoCadastro(Long codSubprocesso) {
@@ -352,20 +357,24 @@ public class SubprocessoTransicaoService {
     }
 
     public void disponibilizarRevisao(Long codSubprocesso) {
+        disponibilizarRevisao(codSubprocesso, null);
+    }
+
+    public void disponibilizarRevisao(Long codSubprocesso, @Nullable String observacoes) {
         log.info("Disponibilizando revisão do subprocesso {}", codSubprocesso);
         Subprocesso sp = consultaService.buscarSubprocesso(codSubprocesso);
         validacaoService.validarSituacaoPermitida(sp, REVISAO_CADASTRO_EM_ANDAMENTO);
         Usuario usuario = usuarioFacade.usuarioAutenticado();
-        disponibilizar(sp, REVISAO_CADASTRO_DISPONIBILIZADA, TipoTransicao.REVISAO_CADASTRO_DISPONIBILIZADA, usuario);
+        disponibilizar(sp, REVISAO_CADASTRO_DISPONIBILIZADA, TipoTransicao.REVISAO_CADASTRO_DISPONIBILIZADA, usuario, observacoes);
     }
 
     private void disponibilizar(Subprocesso sp, SituacaoSubprocesso novaSituacao,
-                                TipoTransicao transicao, Usuario usuario) {
+                                TipoTransicao transicao, Usuario usuario, @Nullable String observacoes) {
         validacaoService.validarRequisitosNegocioParaDisponibilizacao(sp);
 
         sp.setSituacao(novaSituacao);
         sp.setDataFimEtapa1(LocalDateTime.now());
-        registrarTransicaoParaSuperiorDaUnidade(sp, transicao, usuario, null);
+        registrarTransicaoParaSuperiorDaUnidade(sp, transicao, usuario, normalizarTexto(observacoes));
     }
 
     @Transactional

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerCoverageExtraTest.java
@@ -57,14 +57,14 @@ class SubprocessoControllerCoverageExtraTest {
     @WithMockUser
     void disponibilizarCadastroErro() throws Exception {
         doThrow(new ErroValidacao("Existem atividades sem conhecimentos associados."))
-                .when(transicaoService).disponibilizarCadastro(1L);
+                .when(transicaoService).disponibilizarCadastro(1L, null);
         when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("DISPONIBILIZAR_CADASTRO"))).thenReturn(true);
 
         mockMvc.perform(post("/api/subprocessos/1/cadastro/disponibilizar").with(csrf()))
                 .andExpect(status().isUnprocessableContent())
                 .andExpect(jsonPath("$.message").value("Existem atividades sem conhecimentos associados."));
 
-        verify(transicaoService).disponibilizarCadastro(1L);
+        verify(transicaoService).disponibilizarCadastro(1L, null);
         verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 
@@ -73,14 +73,14 @@ class SubprocessoControllerCoverageExtraTest {
     @WithMockUser
     void disponibilizarRevisaoErro() throws Exception {
         doThrow(new ErroValidacao("Existem atividades sem conhecimentos associados."))
-                .when(transicaoService).disponibilizarRevisao(1L);
+                .when(transicaoService).disponibilizarRevisao(1L, null);
         when(permissionEvaluator.hasPermission(any(), eq(1L), eq("Subprocesso"), eq("DISPONIBILIZAR_REVISAO_CADASTRO"))).thenReturn(true);
 
         mockMvc.perform(post("/api/subprocessos/1/disponibilizar-revisao").with(csrf()))
                 .andExpect(status().isUnprocessableContent())
                 .andExpect(jsonPath("$.message").value("Existem atividades sem conhecimentos associados."));
 
-        verify(transicaoService).disponibilizarRevisao(1L);
+        verify(transicaoService).disponibilizarRevisao(1L, null);
         verifyNoMoreInteractions(subprocessoService, transicaoService, unidadeService);
     }
 

--- a/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
+++ b/backend/src/test/java/sgc/subprocesso/SubprocessoControllerTest.java
@@ -235,7 +235,7 @@ class SubprocessoControllerTest {
         @DisplayName("deve disponibilizar cadastro")
         @WithMockUser(roles = "CHEFE")
         void deveDisponibilizarCadastro() throws Exception {
-            TextoOpcionalRequest request = new TextoOpcionalRequest("Observacao");
+            DisponibilizarCadastroRequest request = new DisponibilizarCadastroRequest("Observacao");
             mockMvc.perform(post("/api/subprocessos/1/cadastro/disponibilizar")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
@@ -243,7 +243,7 @@ class SubprocessoControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.mensagem").value("Cadastro de atividades disponibilizado"));
 
-            verify(transicaoService).disponibilizarCadastro(1L);
+            verify(transicaoService).disponibilizarCadastro(1L, "Observacao");
         }
 
         @Test
@@ -251,8 +251,8 @@ class SubprocessoControllerTest {
         @WithMockUser(roles = "CHEFE")
         void deveDisponibilizarCadastroComErroValidacao() throws Exception {
             doThrow(new ErroValidacao("Cadastro incompleto."))
-                    .when(transicaoService).disponibilizarCadastro(1L);
-            TextoOpcionalRequest request = new TextoOpcionalRequest("Observacao");
+                    .when(transicaoService).disponibilizarCadastro(1L, "Observacao");
+            DisponibilizarCadastroRequest request = new DisponibilizarCadastroRequest("Observacao");
 
             mockMvc.perform(post("/api/subprocessos/1/cadastro/disponibilizar")
                             .with(csrf())
@@ -261,7 +261,7 @@ class SubprocessoControllerTest {
                     .andExpect(status().isUnprocessableContent())
                     .andExpect(jsonPath("$.message").value("Cadastro incompleto."));
 
-            verify(transicaoService).disponibilizarCadastro(1L);
+            verify(transicaoService).disponibilizarCadastro(1L, "Observacao");
         }
 
         @Test
@@ -329,7 +329,7 @@ class SubprocessoControllerTest {
         @DisplayName("deve disponibilizar revisão de cadastro")
         @WithMockUser(roles = "CHEFE")
         void deveDisponibilizarRevisaoCadastro() throws Exception {
-            TextoOpcionalRequest request = new TextoOpcionalRequest("Observacao");
+            DisponibilizarCadastroRequest request = new DisponibilizarCadastroRequest("Observacao");
             mockMvc.perform(post("/api/subprocessos/1/disponibilizar-revisao")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
@@ -337,7 +337,7 @@ class SubprocessoControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.mensagem").value("Revisão do cadastro disponibilizada"));
 
-            verify(transicaoService).disponibilizarRevisao(1L);
+            verify(transicaoService).disponibilizarRevisao(1L, "Observacao");
         }
 
         @Test

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoTransicaoServiceExtraCoverageTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoTransicaoServiceExtraCoverageTest.java
@@ -86,7 +86,15 @@ class SubprocessoTransicaoServiceExtraCoverageTest {
         when(unidadeHierarquiaService.buscarCodigoPai(1L)).thenReturn(99L);
         when(unidadeService.buscarPorCodigo(99L)).thenReturn(admin);
 
-        invokeMethod(service, "disponibilizar", sp, SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO, TipoTransicao.CADASTRO_DISPONIBILIZADO, new Usuario());
+        invokeMethod(
+                service,
+                "disponibilizar",
+                sp,
+                SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO,
+                TipoTransicao.CADASTRO_DISPONIBILIZADO,
+                new Usuario(),
+                null
+        );
 
         verify(movimentacaoRepo).save(argThat(mov -> Objects.equals(mov.getUnidadeDestino(), admin)));
     }

--- a/etc/docs/issue-1553-plano-correcao.md
+++ b/etc/docs/issue-1553-plano-correcao.md
@@ -1,0 +1,54 @@
+# Issue #1553 — Investigação e plano de correção
+
+## Resumo da investigação
+
+Durante a investigação, foi identificado que os fluxos de disponibilização de cadastro e disponibilização de revisão no frontend não transportam observações para a API.
+
+Evidências levantadas:
+
+- O tipo `DisponibilizarCadastroRequest` existe no frontend com campo `observacoes`, indicando intenção de contrato para esse dado.
+- As funções `disponibilizarCadastro` e `disponibilizarRevisaoCadastro` no service chamam `POST` sem payload.
+- Foram adicionados testes de caracterização para confirmar o comportamento atual (problema), validando que a chamada HTTP é feita apenas com a URL, sem corpo.
+
+## Escopo provável do defeito
+
+- Frontend (service/composable/view): falta de coleta e envio da observação de disponibilização.
+- Backend (controller/service): endpoint de disponibilização de cadastro/revisão atualmente sem `@RequestBody`, sugerindo que a observação ainda não está sendo recebida e persistida nesse fluxo.
+
+## Plano de correção
+
+1. **Definir contrato explícito de request**
+   - Padronizar request de disponibilização com `observacoes` (permitindo vazio).
+   - Alinhar controller e frontend para o mesmo contrato.
+
+2. **Ajustar backend para receber observações**
+   - Atualizar endpoints de disponibilização para receber DTO de request.
+   - Encaminhar observações para `SubprocessoTransicaoService` com normalização já existente.
+
+3. **Ajustar frontend para coletar e enviar observações**
+   - Incluir campo de observação no modal de confirmação de disponibilização.
+   - Encaminhar observações no fluxo de `CadastroView` → composable → service.
+
+4. **Expandir cobertura de testes**
+   - Atualizar testes de service (trocar caracterização do problema por comportamento esperado corrigido).
+   - Incluir testes de componente/view garantindo envio do payload e tratamento de campo vazio.
+   - Incluir testes de controller/service no backend para confirmar recebimento e persistência da observação.
+
+5. **Validação funcional**
+   - Testar manualmente fluxo de disponibilização em cadastro normal e revisão.
+   - Confirmar presença da observação no histórico/analise correspondente.
+
+## Execução do plano (status atual)
+
+- ✅ Contrato de request alinhado entre frontend e backend para `observacoes`.
+- ✅ Backend atualizado para aceitar `observacoes` nos endpoints de disponibilização de cadastro e revisão.
+- ✅ Frontend atualizado para coletar observações no modal e enviar no fluxo de confirmação.
+- ✅ Cobertura de testes expandida (services/composables/componentes/views no frontend + controller/service no backend).
+- ⏳ Validação funcional manual ponta a ponta pendente de homologação com ambiente integrado.
+
+## Riscos e mitigação
+
+- **Risco de quebra de compatibilidade** em chamadas existentes sem body.
+  - Mitigação: aceitar payload opcional no backend na fase de transição.
+- **Risco de divergência entre textos/labels de UI e comportamento**.
+  - Mitigação: validar cenários de UI com testes de componente e smoke test manual.

--- a/frontend/src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts
+++ b/frontend/src/components/__tests__/ConfirmacaoDisponibilizacaoModal.spec.ts
@@ -47,16 +47,18 @@ describe('ConfirmacaoDisponibilizacaoModal.vue', () => {
         expect(wrapper.text()).toContain('Confirma a disponibilização do cadastro?')
     })
 
-    it('emite evento "confirmar" ao clicar no botão confirmar', async () => {
+    it('emite evento "confirmar" ao clicar no botão confirmar com observações', async () => {
         const wrapper = mount(ConfirmacaoDisponibilizacaoModal, {
             props: defaultProps,
             global: globalOptions
         })
 
+        await wrapper.find('[data-testid="inp-disponibilizacao-observacoes"]').setValue('observação enviada')
         const confirmBtn = wrapper.find('[data-testid="btn-confirmar-disponibilizacao"]')
         await confirmBtn.trigger('click')
 
         expect(wrapper.emitted('confirmar')).toHaveLength(1)
+        expect(wrapper.emitted('confirmar')?.[0]).toEqual(['observação enviada'])
     })
 
     it('emite evento "fechar" ao clicar em cancelar', async () => {
@@ -78,5 +80,22 @@ describe('ConfirmacaoDisponibilizacaoModal.vue', () => {
         })
 
         expect(wrapper.find('[data-testid="btn-confirmar-disponibilizacao"]').attributes('disabled')).toBeDefined()
+    })
+
+    it('limpa observações ao reabrir o modal', async () => {
+        const wrapper = mount(ConfirmacaoDisponibilizacaoModal, {
+            props: defaultProps,
+            global: globalOptions
+        })
+
+        const input = wrapper.find('[data-testid="inp-disponibilizacao-observacoes"]')
+        await input.setValue('texto antigo')
+        expect((input.element as HTMLTextAreaElement).value).toBe('texto antigo')
+
+        await wrapper.setProps({mostrar: false})
+        await wrapper.setProps({mostrar: true})
+
+        const inputAtualizado = wrapper.find('[data-testid="inp-disponibilizacao-observacoes"]')
+        expect((inputAtualizado.element as HTMLTextAreaElement).value).toBe('')
     })
 })

--- a/frontend/src/components/mapa/ConfirmacaoDisponibilizacaoModal.vue
+++ b/frontend/src/components/mapa/ConfirmacaoDisponibilizacaoModal.vue
@@ -15,11 +15,24 @@
         isRevisao ? TEXTOS.atividades.MODAL_DISPONIBILIZAR_REVISAO_TEXTO : TEXTOS.atividades.MODAL_DISPONIBILIZAR_TEXTO
       }}
     </p>
+    <BFormGroup
+        class="mt-3"
+        label="Observações"
+        label-for="observacoesDisponibilizacao"
+    >
+      <BFormTextarea
+          id="observacoesDisponibilizacao"
+          v-model="observacoes"
+          data-testid="inp-disponibilizacao-observacoes"
+          rows="3"
+      />
+    </BFormGroup>
   </ModalConfirmacao>
 </template>
 
 <script lang="ts" setup>
-import {computed} from "vue";
+import {computed, ref, watch} from "vue";
+import {BFormGroup, BFormTextarea} from "bootstrap-vue-next";
 import ModalConfirmacao from "@/components/comum/ModalConfirmacao.vue";
 import {TEXTOS} from "@/constants/textos";
 
@@ -31,8 +44,9 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'fechar'): void;
-  (e: 'confirmar'): void;
+  (e: 'confirmar', observacoes: string): void;
 }>();
+const observacoes = ref("");
 
 const mostrarComputado = computed({
   get: () => props.mostrar,
@@ -41,7 +55,13 @@ const mostrarComputado = computed({
   }
 });
 
+watch(() => props.mostrar, (mostrar) => {
+  if (mostrar) {
+    observacoes.value = "";
+  }
+});
+
 function confirmar() {
-  emit('confirmar');
+  emit('confirmar', observacoes.value);
 }
 </script>

--- a/frontend/src/composables/__tests__/useFluxoSubprocesso.spec.ts
+++ b/frontend/src/composables/__tests__/useFluxoSubprocesso.spec.ts
@@ -48,15 +48,15 @@ describe("useFluxoSubprocesso", () => {
         expect(resultado).toEqual({valido: true});
     });
 
-    it("deve disponibilizar cadastro sem recarga implícita de processo", async () => {
+    it("deve disponibilizar cadastro com observações sem recarga implícita de processo", async () => {
         const {disponibilizarCadastro} = await import("../useFluxoSubprocesso").then((m) => m.useFluxoSubprocesso());
         const {disponibilizarCadastro: serviceDisponibilizarCadastro} = await import("@/services/cadastroService");
         (serviceDisponibilizarCadastro as any).mockResolvedValue(undefined);
 
-        const resultado = await disponibilizarCadastro(10);
+        const resultado = await disponibilizarCadastro(10, {observacoes: "Observação de disponibilização"});
 
         expect(resultado).toBe(true);
-        expect(serviceDisponibilizarCadastro).toHaveBeenCalledWith(10);
+        expect(serviceDisponibilizarCadastro).toHaveBeenCalledWith(10, {observacoes: "Observação de disponibilização"});
     });
 
     it("deve homologar cadastro e recarregar subprocesso", async () => {
@@ -99,8 +99,8 @@ describe("useFluxoSubprocesso", () => {
         const {disponibilizarRevisaoCadastro: service} = await import("@/services/cadastroService");
         (service as any).mockResolvedValue(undefined);
 
-        await disponibilizarRevisaoCadastro(10);
-        expect(service).toHaveBeenCalledWith(10);
+        await disponibilizarRevisaoCadastro(10, {observacoes: "Observação da revisão"});
+        expect(service).toHaveBeenCalledWith(10, {observacoes: "Observação da revisão"});
     });
 
     it("deve iniciar revisao sem limpar o detalhe atual durante a recarga", async () => {

--- a/frontend/src/composables/useFluxoSubprocesso.ts
+++ b/frontend/src/composables/useFluxoSubprocesso.ts
@@ -21,6 +21,7 @@ import {useSubprocessos} from "@/composables/useSubprocessos";
 import type {
     AceitarCadastroRequest,
     DevolverCadastroRequest,
+    DisponibilizarCadastroRequest,
     HomologarCadastroRequest,
 } from "@/types/tipos";
 
@@ -52,12 +53,12 @@ export function useFluxoSubprocesso() {
         return withErrorHandling(async () => serviceValidarCadastro(codigoSubprocesso));
     }
 
-    async function disponibilizarCadastro(codigoSubprocesso: number) {
-        return executarAcao(() => serviceDisponibilizarCadastro(codigoSubprocesso));
+    async function disponibilizarCadastro(codigoSubprocesso: number, req?: DisponibilizarCadastroRequest) {
+        return executarAcao(() => serviceDisponibilizarCadastro(codigoSubprocesso, req));
     }
 
-    async function disponibilizarRevisaoCadastro(codigoSubprocesso: number) {
-        return executarAcao(() => serviceDisponibilizarRevisaoCadastro(codigoSubprocesso));
+    async function disponibilizarRevisaoCadastro(codigoSubprocesso: number, req?: DisponibilizarCadastroRequest) {
+        return executarAcao(() => serviceDisponibilizarRevisaoCadastro(codigoSubprocesso, req));
     }
 
     async function iniciarRevisaoCadastro(codigoSubprocesso: number) {

--- a/frontend/src/services/__tests__/cadastroService.spec.ts
+++ b/frontend/src/services/__tests__/cadastroService.spec.ts
@@ -1,14 +1,15 @@
-import {describe} from "vitest";
+import {describe, expect, it} from "vitest";
 import {setupServiceTest, testErrorHandling, testPostEndpoint} from "@/test-utils/serviceTestHelpers";
 import * as cadastroService from "@/services/cadastroService";
 
 describe("cadastroService", () => {
-    setupServiceTest();
+    const {mockApi} = setupServiceTest();
 
     describe("disponibilizarCadastro", () => {
         testPostEndpoint(
             () => cadastroService.disponibilizarCadastro(1),
-            "/subprocessos/1/cadastro/disponibilizar"
+            "/subprocessos/1/cadastro/disponibilizar",
+            {observacoes: ""}
         );
         testErrorHandling(() => cadastroService.disponibilizarCadastro(1), 'post');
     });
@@ -16,9 +17,32 @@ describe("cadastroService", () => {
     describe("disponibilizarRevisaoCadastro", () => {
         testPostEndpoint(
             () => cadastroService.disponibilizarRevisaoCadastro(1),
-            "/subprocessos/1/disponibilizar-revisao"
+            "/subprocessos/1/disponibilizar-revisao",
+            {observacoes: ""}
         );
         testErrorHandling(() => cadastroService.disponibilizarRevisaoCadastro(1), 'post');
+    });
+
+    describe("issue #1553 - observações na disponibilização", () => {
+        it("deve enviar observações em disponibilizarCadastro", async () => {
+            mockApi.post.mockResolvedValue({data: {}});
+
+            await cadastroService.disponibilizarCadastro(1, {observacoes: "observação de teste"});
+
+            expect(mockApi.post).toHaveBeenCalledWith("/subprocessos/1/cadastro/disponibilizar", {
+                observacoes: "observação de teste"
+            });
+        });
+
+        it("deve enviar observações em disponibilizarRevisaoCadastro", async () => {
+            mockApi.post.mockResolvedValue({data: {}});
+
+            await cadastroService.disponibilizarRevisaoCadastro(1, {observacoes: "observação de revisão"});
+
+            expect(mockApi.post).toHaveBeenCalledWith("/subprocessos/1/disponibilizar-revisao", {
+                observacoes: "observação de revisão"
+            });
+        });
     });
 
     describe("devolverCadastro", () => {

--- a/frontend/src/services/cadastroService.ts
+++ b/frontend/src/services/cadastroService.ts
@@ -1,9 +1,13 @@
 import apiClient from "../axios-setup";
+import type {DisponibilizarCadastroRequest} from "@/types/tipos";
 
 export async function disponibilizarCadastro(
-    codSubprocesso: number
+    codSubprocesso: number,
+    dados?: DisponibilizarCadastroRequest
 ): Promise<void> {
-    await apiClient.post(`/subprocessos/${codSubprocesso}/cadastro/disponibilizar`);
+    await apiClient.post(`/subprocessos/${codSubprocesso}/cadastro/disponibilizar`, {
+        observacoes: dados?.observacoes ?? ""
+    });
 }
 
 export async function iniciarRevisaoCadastro(codSubprocesso: number): Promise<void> {
@@ -15,9 +19,12 @@ export async function cancelarInicioRevisaoCadastro(codSubprocesso: number): Pro
 }
 
 export async function disponibilizarRevisaoCadastro(
-    codSubprocesso: number
+    codSubprocesso: number,
+    dados?: DisponibilizarCadastroRequest
 ): Promise<void> {
-    await apiClient.post(`/subprocessos/${codSubprocesso}/disponibilizar-revisao`);
+    await apiClient.post(`/subprocessos/${codSubprocesso}/disponibilizar-revisao`, {
+        observacoes: dados?.observacoes ?? ""
+    });
 }
 
 export async function devolverCadastro(

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -653,16 +653,16 @@ async function disponibilizarCadastro() {
   }
 }
 
-async function confirmarDisponibilizacao() {
+async function confirmarDisponibilizacao(observacoes = "") {
   if (!codSubprocesso.value || loadingDisponibilizacao.value) return;
 
   let sucesso: boolean;
   loadingDisponibilizacao.value = true;
   try {
     if (isRevisao.value) {
-      sucesso = await fluxoSubprocesso.disponibilizarRevisaoCadastro(codSubprocesso.value);
+      sucesso = await fluxoSubprocesso.disponibilizarRevisaoCadastro(codSubprocesso.value, {observacoes});
     } else {
-      sucesso = await fluxoSubprocesso.disponibilizarCadastro(codSubprocesso.value);
+      sucesso = await fluxoSubprocesso.disponibilizarCadastro(codSubprocesso.value, {observacoes});
     }
   } finally {
     loadingDisponibilizacao.value = false;

--- a/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
+++ b/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
@@ -424,7 +424,7 @@ describe("CadastroView.vue", () => {
         modal.vm.$emit('confirmar');
         await flushPromises();
 
-        expect(fluxoSubprocesso.disponibilizarCadastro).toHaveBeenCalledWith(123);
+        expect(fluxoSubprocesso.disponibilizarCadastro).toHaveBeenCalledWith(123, {observacoes: ""});
         expect(pushMock).toHaveBeenCalledWith("/painel");
     });
 


### PR DESCRIPTION
### Motivation
- Enable sending an observation note when making disponibilização of cadastro or revisão so the note is persisted in the transition history and aligns frontend and backend contracts.
- Keep backward compatibility by accepting an optional request body so existing callers without a body still work.

### Description
- Add a new request DTO `DisponibilizarCadastroRequest` and update controller endpoints `POST /subprocessos/{codSubprocesso}/cadastro/disponibilizar` and `POST /subprocessos/{codSubprocesso}/disponibilizar-revisao` to accept an optional `@RequestBody` with `observacoes` and sanitize it before handing to the service. 
- Extend `SubprocessoTransicaoService` methods to accept an optional `observacoes` parameter and forward a normalized text to the existing `disponibilizar` flow so the observation is recorded with the transition. 
- Update frontend `ConfirmacaoDisponibilizacaoModal.vue` to collect observations in a textarea, clear it when reopened, and emit the observation on confirmation. 
- Update composable `useFluxoSubprocesso` and service `cadastroService` to include `observacoes` in calls to the backend, sending an empty string when none provided. 
- Adjust unit tests across backend and frontend to reflect the new optional payload and add tests that assert the `observacoes` field is sent and handled.
- Add documentation `etc/docs/issue-1553-plano-correcao.md` describing the investigation and correction plan.

### Testing
- Ran backend unit tests including `SubprocessoControllerTest`, `SubprocessoControllerCoverageExtraTest`, and `SubprocessoTransicaoServiceExtraCoverageTest`, which were updated to expect the optional `observacoes` parameter and all passed. 
- Ran frontend unit tests including `ConfirmacaoDisponibilizacaoModal.spec.ts`, `useFluxoSubprocesso.spec.ts`, `cadastroService.spec.ts`, and `AtividadesCadastroView.spec.ts`, validating emission, composable behavior, API payloads, and view integration, and all passed. 
- Added service-level tests that assert the POST payload contains `{observacoes: ""}` for empty calls and the provided text for populated calls, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5061f9a4832bbdc0566639f6a3e3)