### PR TITLE
Fix frontend unit tests and quality check

### DIFF
--- a/frontend/src/router/__tests__/index.spec.ts
+++ b/frontend/src/router/__tests__/index.spec.ts
@@ -30,6 +30,7 @@ describe("Router", () => {
 
     it("permite rota administrativa quando autenticado", async () => {
         perfilStore.usuarioCodigo = "123";
+        perfilStore.perfilSelecionado = Perfil.ADMIN;
         await router.push("/administracao/limpeza-processos");
         expect(router.currentRoute.value.path).toBe("/administracao/limpeza-processos");
     });

--- a/frontend/src/router/__tests__/main.routes.spec.ts
+++ b/frontend/src/router/__tests__/main.routes.spec.ts
@@ -12,7 +12,7 @@ vi.mock('@/views/ErroGeralView.vue', () => ({ default: { name: 'ErroGeralView' }
 describe("main.routes", () => {
     it("deve exportar um array de rotas", () => {
         expect(Array.isArray(mainRoutes)).toBe(true);
-        expect(mainRoutes).toHaveLength(11);
+        expect(mainRoutes).toHaveLength(12);
     });
 
     it("deve conter a rota RelatorioAndamento", async () => {

--- a/frontend/src/views/__tests__/UnidadesView.spec.ts
+++ b/frontend/src/views/__tests__/UnidadesView.spec.ts
@@ -3,6 +3,7 @@ import {flushPromises, mount} from "@vue/test-utils";
 import Unidades from "@/views/UnidadesView.vue";
 import * as unidadeService from "@/services/unidadeService";
 import {getCommonMountOptions, setupComponentTest} from "@/test-utils/componentTestHelpers";
+import {TEXTOS} from "@/constants/textos";
 
 const mockPush = vi.fn();
 
@@ -246,7 +247,7 @@ describe("Unidades.vue", () => {
     it("deve exibir mensagem quando não houver unidades", async () => {
         const wrapper = createWrapper({unidades: []});
         await flushPromises();
-        expect(wrapper.text()).toContain("Nenhuma unidade encontrada.");
+        expect(wrapper.text()).toContain(TEXTOS.unidades.EMPTY_TITLE);
         expect(wrapper.findComponent({name: 'TreeTable'}).exists()).toBe(false);
     });
 


### PR DESCRIPTION
Performed a comprehensive quality check on the frontend, including typechecking, linting, and unit tests. Fixed three unit test failures related to routing guards, route count, and text constants. All quality checks (typecheck, lint, and unit tests) are now passing.

---
*PR created automatically by Jules for task [14227887391461952659](https://jules.google.com/task/14227887391461952659) started by @lgalvao*