### PR TITLE
Fix frontend quality check errors (tests, lint)

### DIFF
--- a/frontend/src/components/comum/AppAlert.spec.ts
+++ b/frontend/src/components/comum/AppAlert.spec.ts
@@ -1,27 +1,31 @@
 import {describe, expect, it} from 'vitest';
-import {render} from '@testing-library/vue';
-import {run} from 'axe-core';
+import {mount} from '@vue/test-utils';
+import * as axeCore from 'axe-core';
 import AppAlert from './AppAlert.vue';
 
 describe('AppAlert A11y', () => {
   it('has no accessibility violations in default mode', async () => {
-    const { container } = render(AppAlert, {
+    const wrapper = mount(AppAlert, {
       props: { message: 'Hello world' },
+      attachTo: document.body,
     });
-    const results = await run(container);
-    expect(results).toHaveNoViolations();
+    const results = await axeCore.run(wrapper.element);
+    expect(results.violations).toEqual([]);
+    wrapper.unmount();
   });
 
   it('has no accessibility violations in detailed mode', async () => {
-    const { container } = render(AppAlert, {
+    const wrapper = mount(AppAlert, {
       props: {
         notification: {
           summary: 'Error',
           details: ['Detail 1', 'Detail 2']
         }
       },
+      attachTo: document.body,
     });
-    const results = await run(container);
-    expect(results).toHaveNoViolations();
+    const results = await axeCore.run(wrapper.element);
+    expect(results.violations).toEqual([]);
+    wrapper.unmount();
   });
 });

--- a/frontend/src/stores/__tests__/subprocessos.spec.ts
+++ b/frontend/src/stores/__tests__/subprocessos.spec.ts
@@ -56,7 +56,8 @@ const {mockApiClient} = vi.hoisted(() => ({
 
 vi.mock('@/axios-setup', () => ({
     default: mockApiClient,
-    apiClient: mockApiClient
+    apiClient: mockApiClient,
+    isErroCanceladoHttp: vi.fn(() => false)
 }));
 
 function criarPermissoes(parciais: Partial<PermissoesSubprocesso> = {}): PermissoesSubprocesso {

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -229,7 +229,6 @@ const {
   podeVisualizarImpacto,
   habilitarEditarCadastro,
   podeDisponibilizarCadastro,
-  habilitarDisponibilizarCadastro
 } = acesso;
 const isRevisao = computed(() => subprocesso.value?.tipoProcesso === TipoProcesso.REVISAO);
 

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -279,7 +279,6 @@ const {
   podeEditarMapa,
   podeDisponibilizarMapa,
   habilitarEditarMapa,
-  habilitarDisponibilizarMapa,
   podeAnalisarMapa,
   podeVerSugestoes: podeMostrarVerSugestoes,
   habilitarDevolverMapa,

--- a/frontend/src/views/SubprocessoView.vue
+++ b/frontend/src/views/SubprocessoView.vue
@@ -248,7 +248,7 @@ import {enviarLembrete as enviarLembreteService} from "@/services/processoServic
 
 import {useAcesso} from "@/composables/useAcesso";
 import {type Movimentacao, type ResponsavelDto, type SubprocessoDetalhe, TipoProcesso} from "@/types/tipos";
-import {formatDateTimeBR, logger, parseDate} from "@/utils";
+import {formatDateTimeBR, parseDate} from "@/utils";
 import {formatSituacaoSubprocesso} from "@/utils/formatters";
 import {TEXTOS} from "@/constants/textos";
 import {useToastStore} from "@/stores/toast";


### PR DESCRIPTION
This change addresses failures found during a quality check of the frontend.
- Fixed a unit test failure in `subprocessos.spec.ts` where `isErroCanceladoHttp` was missing from the `@/axios-setup` mock.
- Resolved `NotFoundError` and unhandled unmount warnings in `AppAlert.spec.ts` accessibility tests by using `@vue/test-utils` and attaching the component to the document body during the test.
- Cleared linting warnings for unused variables and imports in `CadastroView.vue`, `MapaView.vue`, and `SubprocessoView.vue`.
- Verified all fixes by running `npm run quality:all` in the frontend and `npm run typecheck`/`npm run lint` in the project root.

---
*PR created automatically by Jules for task [15345457780804288098](https://jules.google.com/task/15345457780804288098) started by @lgalvao*