### PR TITLE
test(backend): remover lenient e add testes para dto e services

### DIFF
--- a/backend/src/test/java/sgc/alerta/dto/NotificacaoDtoTest.java
+++ b/backend/src/test/java/sgc/alerta/dto/NotificacaoDtoTest.java
@@ -1,0 +1,48 @@
+package sgc.alerta.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import sgc.alerta.model.NotificacaoEmail;
+import sgc.alerta.model.SituacaoNotificacao;
+import sgc.alerta.model.TipoNotificacao;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NotificacaoDto - Cobertura de Testes")
+class NotificacaoDtoTest {
+
+    @Test
+    @DisplayName("fromEntity deve mapear todos os campos corretamente")
+    void fromEntity() {
+        LocalDateTime agora = LocalDateTime.now();
+        NotificacaoEmail email = new NotificacaoEmail();
+        email.setCodigo(1L);
+        email.setTipoNotificacao(TipoNotificacao.CADASTRO_DISPONIBILIZADO);
+        email.setUsuarioDestinoTitulo("123");
+        email.setDestinatario("teste@teste.com");
+        email.setAssunto("Assunto Teste");
+        email.setSituacao(SituacaoNotificacao.PENDENTE);
+        email.setTentativas(2);
+        email.setDataHoraCriacao(agora);
+        email.setDataHoraEnvio(agora.plusMinutes(10));
+        email.setProximaTentativaEm(agora.plusMinutes(20));
+        email.setUltimoErro("Erro X");
+
+        NotificacaoDto dto = NotificacaoDto.fromEntity(email, 100L);
+
+        assertThat(dto.codigo()).isEqualTo(1L);
+        assertThat(dto.subprocessoCodigo()).isEqualTo(100L);
+        assertThat(dto.tipoNotificacao()).isEqualTo(TipoNotificacao.CADASTRO_DISPONIBILIZADO);
+        assertThat(dto.usuarioDestinoTitulo()).isEqualTo("123");
+        assertThat(dto.destinatario()).isEqualTo("teste@teste.com");
+        assertThat(dto.assunto()).isEqualTo("Assunto Teste");
+        assertThat(dto.situacao()).isEqualTo(SituacaoNotificacao.PENDENTE);
+        assertThat(dto.tentativas()).isEqualTo(2);
+        assertThat(dto.dataHoraCriacao()).isEqualTo(agora);
+        assertThat(dto.dataHoraEnvio()).isEqualTo(agora.plusMinutes(10));
+        assertThat(dto.proximaTentativaEm()).isEqualTo(agora.plusMinutes(20));
+        assertThat(dto.ultimoErro()).isEqualTo("Erro X");
+    }
+}

--- a/backend/src/test/java/sgc/alerta/dto/NotificacaoSubprocessoResumoDtoTest.java
+++ b/backend/src/test/java/sgc/alerta/dto/NotificacaoSubprocessoResumoDtoTest.java
@@ -1,0 +1,72 @@
+package sgc.alerta.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import sgc.subprocesso.model.SituacaoSubprocesso;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("NotificacaoSubprocessoResumoDto - Cobertura de Testes")
+class NotificacaoSubprocessoResumoDtoTest {
+
+    private NotificacaoSubprocessoResumoQuery createQuery(
+            long total, long pendentes, long enviando, long falhasTemporarias, long falhasDefinitivas) {
+        return new NotificacaoSubprocessoResumoQuery(
+                1L, 2L, "Proc Teste", "U10", SituacaoSubprocesso.NAO_INICIADO,
+                total, pendentes, enviando, 0L, falhasTemporarias, falhasDefinitivas,
+                LocalDateTime.now(), LocalDateTime.now(), 0, "Erro"
+        );
+    }
+
+    @Test
+    @DisplayName("calcularStatus deve retornar FALHA_DEFINITIVA quando falhasDefinitivas > 0")
+    void deveRetornarFalhaDefinitiva() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 0, 0, 1);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.FALHA_DEFINITIVA);
+        assertThat(dto.podeReenviar()).isTrue();
+    }
+
+    @Test
+    @DisplayName("calcularStatus deve retornar FALHA_TEMPORARIA quando falhasTemporarias > 0")
+    void deveRetornarFalhaTemporaria() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 0, 1, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.FALHA_TEMPORARIA);
+        assertThat(dto.podeReenviar()).isFalse();
+    }
+
+    @Test
+    @DisplayName("calcularStatus deve retornar PENDENTE quando pendentes > 0")
+    void deveRetornarPendentePorPendentes() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 1, 0, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.PENDENTE);
+    }
+
+    @Test
+    @DisplayName("calcularStatus deve retornar PENDENTE quando enviando > 0")
+    void deveRetornarPendentePorEnviando() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 1, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.PENDENTE);
+    }
+
+    @Test
+    @DisplayName("calcularStatus deve retornar INCONSISTENTE quando total == 0")
+    void deveRetornarInconsistente() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(0, 0, 0, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.INCONSISTENTE);
+    }
+
+    @Test
+    @DisplayName("calcularStatus deve retornar OK nos demais casos")
+    void deveRetornarOk() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 0, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.OK);
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/dto/SugestoesDtoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/dto/SugestoesDtoTest.java
@@ -1,0 +1,31 @@
+package sgc.subprocesso.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("SugestoesDto - Cobertura de Testes")
+class SugestoesDtoTest {
+
+    @Test
+    @DisplayName("vazia deve retornar DTO com string vazia")
+    void vazia() {
+        SugestoesDto dto = SugestoesDto.vazia();
+        assertThat(dto.sugestoes()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("de deve retornar string recebida quando nao nula")
+    void de_NaoNula() {
+        SugestoesDto dto = SugestoesDto.de("Sugestao Teste");
+        assertThat(dto.sugestoes()).isEqualTo("Sugestao Teste");
+    }
+
+    @Test
+    @DisplayName("de deve retornar string vazia quando nula")
+    void de_Nula() {
+        SugestoesDto dto = SugestoesDto.de(null);
+        assertThat(dto.sugestoes()).isEmpty();
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoConsultaServiceCoverageTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoConsultaServiceCoverageTest.java
@@ -73,7 +73,7 @@ class SubprocessoConsultaServiceCoverageTest {
     }
 
     private void stubContextoAutenticado(Usuario usuario) {
-        lenient().when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado(
+        when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado(
                 usuario.getTituloEleitoral(),
                 usuario.getUnidadeAtivaCodigo(),
                 usuario.getPerfilAtivo()
@@ -82,7 +82,7 @@ class SubprocessoConsultaServiceCoverageTest {
         u.setCodigo(usuario.getUnidadeAtivaCodigo());
         u.setNome("Unidade Usuario");
         u.setSigla("UU");
-        lenient().when(unidadeService.buscarPorCodigoComSuperior(usuario.getUnidadeAtivaCodigo())).thenReturn(u);
+        when(unidadeService.buscarPorCodigoComSuperior(usuario.getUnidadeAtivaCodigo())).thenReturn(u);
     }
 
     @Test
@@ -240,7 +240,7 @@ class SubprocessoConsultaServiceCoverageTest {
         when(subprocessoRepo.buscarPorCodigoComMapa(100L)).thenReturn(Optional.of(subprocesso));
         when(mapaManutencaoService.mapaVigenteUnidade(10L)).thenReturn(Optional.of(mapaVigente));
         when(mapaManutencaoService.atividadesMapaCodigoComConhecimentos(400L)).thenReturn(List.of(atividadeVigente));
-        lenient().when(mapaManutencaoService.atividadesMapaCodigoComConhecimentos(300L)).thenReturn(List.of());
+        when(mapaManutencaoService.atividadesMapaCodigoComConhecimentos(300L)).thenReturn(List.of());
 
         Usuario usuario = Usuario.builder()
                 .tituloEleitoral("123456789012")
@@ -248,7 +248,7 @@ class SubprocessoConsultaServiceCoverageTest {
                 .perfilAtivo(Perfil.ADMIN)
                 .build();
         stubContextoAutenticado(usuario);
-        lenient().when(localizacaoSubprocessoService.obterLocalizacaoAtual(subprocesso)).thenReturn(unidade);
+        when(localizacaoSubprocessoService.obterLocalizacaoAtual(subprocesso)).thenReturn(unidade);
 
         ContextoCadastroAtividadesResponse res = target.obterContextoCadastroAtividades(100L);
 
@@ -272,8 +272,8 @@ class SubprocessoConsultaServiceCoverageTest {
 
         when(subprocessoRepo.buscarPorCodigoComMapa(1L)).thenReturn(Optional.of(sp));
         when(usuarioFacade.contextoAutenticado()).thenReturn(new ContextoUsuarioAutenticado("tit", 10L, Perfil.ADMIN));
-        lenient().when(localizacaoSubprocessoService.obterLocalizacaoAtual(any())).thenReturn(uni);
-        lenient().when(unidadeService.buscarPorCodigoComSuperior(anyLong())).thenReturn(uni);
+        when(localizacaoSubprocessoService.obterLocalizacaoAtual(any())).thenReturn(uni);
+        when(unidadeService.buscarPorCodigoComSuperior(anyLong())).thenReturn(uni);
 
         assertThatThrownBy(() -> target.obterContextoCadastroAtividades(1L))
                 .isInstanceOf(IllegalStateException.class)

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoContextoConsultaServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoContextoConsultaServiceTest.java
@@ -1,0 +1,141 @@
+package sgc.subprocesso.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.organizacao.ContextoUsuarioAutenticado;
+import sgc.organizacao.UsuarioFacade;
+import sgc.organizacao.model.Perfil;
+import sgc.organizacao.model.Unidade;
+import sgc.organizacao.service.HierarquiaService;
+import sgc.organizacao.service.UnidadeService;
+import sgc.processo.model.Processo;
+import sgc.processo.model.SituacaoProcesso;
+import sgc.subprocesso.model.Movimentacao;
+import sgc.subprocesso.model.Subprocesso;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SubprocessoContextoConsultaService - Cobertura de Testes")
+class SubprocessoContextoConsultaServiceTest {
+
+    @InjectMocks
+    private SubprocessoContextoConsultaService target;
+
+    @Mock
+    private UnidadeService unidadeService;
+
+    @Mock
+    private UsuarioFacade usuarioFacade;
+
+    @Mock
+    private HierarquiaService hierarquiaService;
+
+    @Mock
+    private LocalizacaoSubprocessoService localizacaoSubprocessoService;
+
+    @Test
+    @DisplayName("montar deve preencher contexto corretamente quando usuario for da mesma unidade alvo, nao finalizado e com mapa vigente")
+    void montar_UsuarioMesmaUnidadeNaoFinalizadoComMapa() {
+        Processo processo = new Processo();
+        processo.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
+
+        Unidade unidadeAlvo = new Unidade();
+        unidadeAlvo.setCodigo(10L);
+
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setProcesso(processo);
+        subprocesso.setUnidade(unidadeAlvo);
+
+        ContextoUsuarioAutenticado contextoUsuario = new ContextoUsuarioAutenticado("tit", 10L, Perfil.ADMIN);
+        when(usuarioFacade.contextoAutenticado()).thenReturn(contextoUsuario);
+
+        Unidade unidadeUsuario = new Unidade();
+        unidadeUsuario.setCodigo(10L);
+        when(unidadeService.buscarPorCodigoComSuperior(10L)).thenReturn(unidadeUsuario);
+        when(localizacaoSubprocessoService.obterLocalizacaoAtual(subprocesso)).thenReturn(unidadeAlvo);
+        when(unidadeService.temMapaVigente(10L)).thenReturn(true);
+
+        SubprocessoContextoConsultaService.ContextoConsultaBase result = target.montar(subprocesso, List.of());
+
+        assertThat(result.perfil()).isEqualTo(Perfil.ADMIN);
+        assertThat(result.localizacaoAtual()).isEqualTo(unidadeAlvo);
+        assertThat(result.processoFinalizado()).isFalse();
+        assertThat(result.mesmaUnidade()).isTrue();
+        assertThat(result.mesmaUnidadeAlvo()).isTrue();
+        assertThat(result.unidadeAlvoNaHierarquiaUsuario()).isTrue();
+        assertThat(result.temMapaVigente()).isTrue();
+    }
+
+    @Test
+    @DisplayName("montar deve usar unidade destino da ultima movimentacao como localizacao atual")
+    void montar_ComMovimentacao() {
+        Processo processo = new Processo();
+        processo.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
+
+        Unidade unidadeAlvo = new Unidade();
+        unidadeAlvo.setCodigo(10L);
+
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setProcesso(processo);
+        subprocesso.setUnidade(unidadeAlvo);
+
+        Unidade unidadeMovimentacao = new Unidade();
+        unidadeMovimentacao.setCodigo(20L);
+        Movimentacao mov = new Movimentacao();
+        mov.setUnidadeDestino(unidadeMovimentacao);
+
+        ContextoUsuarioAutenticado contextoUsuario = new ContextoUsuarioAutenticado("tit", 30L, Perfil.GESTOR);
+        when(usuarioFacade.contextoAutenticado()).thenReturn(contextoUsuario);
+
+        Unidade unidadeUsuario = new Unidade();
+        unidadeUsuario.setCodigo(30L);
+        when(unidadeService.buscarPorCodigoComSuperior(30L)).thenReturn(unidadeUsuario);
+        when(hierarquiaService.ehMesmaOuSubordinada(unidadeAlvo, unidadeUsuario)).thenReturn(false);
+        when(unidadeService.temMapaVigente(10L)).thenReturn(false);
+
+        SubprocessoContextoConsultaService.ContextoConsultaBase result = target.montar(subprocesso, List.of(mov));
+
+        assertThat(result.localizacaoAtual()).isEqualTo(unidadeMovimentacao);
+        assertThat(result.mesmaUnidade()).isFalse();
+        assertThat(result.mesmaUnidadeAlvo()).isFalse();
+        assertThat(result.unidadeAlvoNaHierarquiaUsuario()).isFalse();
+        assertThat(result.temMapaVigente()).isFalse();
+    }
+
+    @Test
+    @DisplayName("montar deve retornar campos ajustados quando processo estiver finalizado")
+    void montar_ProcessoFinalizado() {
+        Processo processo = new Processo();
+        processo.setSituacao(SituacaoProcesso.FINALIZADO);
+
+        Unidade unidadeAlvo = new Unidade();
+        unidadeAlvo.setCodigo(10L);
+
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setProcesso(processo);
+        subprocesso.setUnidade(unidadeAlvo);
+
+        ContextoUsuarioAutenticado contextoUsuario = new ContextoUsuarioAutenticado("tit", 10L, Perfil.ADMIN);
+        when(usuarioFacade.contextoAutenticado()).thenReturn(contextoUsuario);
+
+        Unidade unidadeUsuario = new Unidade();
+        unidadeUsuario.setCodigo(10L);
+        when(unidadeService.buscarPorCodigoComSuperior(10L)).thenReturn(unidadeUsuario);
+        when(localizacaoSubprocessoService.obterLocalizacaoAtual(subprocesso)).thenReturn(unidadeAlvo);
+
+        SubprocessoContextoConsultaService.ContextoConsultaBase result = target.montar(subprocesso, List.of());
+
+        assertThat(result.processoFinalizado()).isTrue();
+        assertThat(result.mesmaUnidade()).isFalse(); // !processoFinalizado && ... => falso
+        assertThat(result.temMapaVigente()).isFalse(); // !processoFinalizado && ... => falso
+    }
+}


### PR DESCRIPTION
O checkup de backend identificou que classes DTO (`NotificacaoDto`, `NotificacaoSubprocessoResumoDto`, `SugestoesDto`) e Service (`SubprocessoContextoConsultaService`) estavam sem testes dedicados. Testes criados.

Além disso, havia o uso desencorajado de stubs `lenient` com o Mockito (na classe `SubprocessoConsultaServiceCoverageTest`). Eles foram removidos e refeitos localmente com stubs restritos (`when`).

---
*PR created automatically by Jules for task [14733341650585430283](https://jules.google.com/task/14733341650585430283) started by @lgalvao*