### PR TITLE
Improve backend test coverage with strict mocking

### DIFF
--- a/backend/src/test/java/sgc/alerta/dto/NotificacaoDtoTest.java
+++ b/backend/src/test/java/sgc/alerta/dto/NotificacaoDtoTest.java
@@ -1,0 +1,50 @@
+package sgc.alerta.dto;
+
+import org.junit.jupiter.api.Test;
+import sgc.alerta.model.NotificacaoEmail;
+import sgc.alerta.model.SituacaoNotificacao;
+import sgc.alerta.model.TipoNotificacao;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificacaoDtoTest {
+
+    @Test
+    void shouldCreateNotificacaoDtoFromEntity() {
+        // Given
+        Long subprocessoCodigo = 123L;
+        LocalDateTime now = LocalDateTime.now();
+        NotificacaoEmail entity = NotificacaoEmail.builder()
+                .codigo(1L)
+                .tipoNotificacao(TipoNotificacao.MAPA_DISPONIBILIZADO)
+                .usuarioDestinoTitulo("123456789012")
+                .destinatario("test@example.com")
+                .assunto("Test Subject")
+                .situacao(SituacaoNotificacao.ENVIADO)
+                .tentativas(1)
+                .dataHoraCriacao(now.minusDays(1))
+                .dataHoraEnvio(now)
+                .proximaTentativaEm(null)
+                .ultimoErro(null)
+                .build();
+
+        // When
+        NotificacaoDto dto = NotificacaoDto.fromEntity(entity, subprocessoCodigo);
+
+        // Then
+        assertThat(dto.codigo()).isEqualTo(entity.getCodigo());
+        assertThat(dto.subprocessoCodigo()).isEqualTo(subprocessoCodigo);
+        assertThat(dto.tipoNotificacao()).isEqualTo(entity.getTipoNotificacao());
+        assertThat(dto.usuarioDestinoTitulo()).isEqualTo(entity.getUsuarioDestinoTitulo());
+        assertThat(dto.destinatario()).isEqualTo(entity.getDestinatario());
+        assertThat(dto.assunto()).isEqualTo(entity.getAssunto());
+        assertThat(dto.situacao()).isEqualTo(entity.getSituacao());
+        assertThat(dto.tentativas()).isEqualTo(entity.getTentativas());
+        assertThat(dto.dataHoraCriacao()).isEqualTo(entity.getDataHoraCriacao());
+        assertThat(dto.dataHoraEnvio()).isEqualTo(entity.getDataHoraEnvio());
+        assertThat(dto.proximaTentativaEm()).isNull();
+        assertThat(dto.ultimoErro()).isNull();
+    }
+}

--- a/backend/src/test/java/sgc/alerta/dto/NotificacaoSubprocessoResumoDtoTest.java
+++ b/backend/src/test/java/sgc/alerta/dto/NotificacaoSubprocessoResumoDtoTest.java
@@ -1,0 +1,95 @@
+package sgc.alerta.dto;
+
+import org.junit.jupiter.api.Test;
+import sgc.subprocesso.model.SituacaoSubprocesso;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificacaoSubprocessoResumoDtoTest {
+
+    @Test
+    void shouldCreateDtoWithFalhaDefinitiva() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 0, 0, 0, 1);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.FALHA_DEFINITIVA);
+        assertThat(dto.podeReenviar()).isTrue();
+    }
+
+    @Test
+    void shouldCreateDtoWithFalhaTemporaria() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 0, 0, 1, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.FALHA_TEMPORARIA);
+        assertThat(dto.podeReenviar()).isFalse();
+    }
+
+    @Test
+    void shouldCreateDtoWithPendenteFromPendentes() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 1, 0, 0, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.PENDENTE);
+        assertThat(dto.podeReenviar()).isFalse();
+    }
+
+    @Test
+    void shouldCreateDtoWithPendenteFromEnviando() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 1, 0, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.PENDENTE);
+        assertThat(dto.podeReenviar()).isFalse();
+    }
+
+    @Test
+    void shouldCreateDtoWithInconsistente() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(0, 0, 0, 0, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.INCONSISTENTE);
+        assertThat(dto.podeReenviar()).isFalse();
+    }
+
+    @Test
+    void shouldCreateDtoWithOk() {
+        NotificacaoSubprocessoResumoQuery query = createQuery(10, 0, 0, 10, 0, 0);
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+        assertThat(dto.statusGeral()).isEqualTo(SituacaoNotificacao.OK);
+        assertThat(dto.podeReenviar()).isFalse();
+    }
+
+    @Test
+    void shouldMapAllFields() {
+        LocalDateTime ultima = LocalDateTime.now().minusHours(1);
+        LocalDateTime proxima = LocalDateTime.now().plusHours(1);
+        NotificacaoSubprocessoResumoQuery query = new NotificacaoSubprocessoResumoQuery(
+                1L, 2L, "Processo", "SIGLA", SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO,
+                10, 1, 2, 3, 4, 0, ultima, proxima, 5, "Erro"
+        );
+        NotificacaoSubprocessoResumoDto dto = NotificacaoSubprocessoResumoDto.fromQuery(query);
+
+        assertThat(dto.subprocessoCodigo()).isEqualTo(1L);
+        assertThat(dto.processoCodigo()).isEqualTo(2L);
+        assertThat(dto.processoDescricao()).isEqualTo("Processo");
+        assertThat(dto.unidadeSigla()).isEqualTo("SIGLA");
+        assertThat(dto.situacaoSubprocesso()).isEqualTo(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+        assertThat(dto.totalNotificacoes()).isEqualTo(10);
+        assertThat(dto.pendentes()).isEqualTo(1);
+        assertThat(dto.enviando()).isEqualTo(2);
+        assertThat(dto.enviadas()).isEqualTo(3);
+        assertThat(dto.falhasTemporarias()).isEqualTo(4);
+        assertThat(dto.falhasDefinitivas()).isEqualTo(0);
+        assertThat(dto.ultimaNotificacaoEm()).isEqualTo(ultima);
+        assertThat(dto.proximaTentativaEm()).isEqualTo(proxima);
+        assertThat(dto.maiorTentativas()).isEqualTo(5);
+        assertThat(dto.ultimoErro()).isEqualTo("Erro");
+    }
+
+    private NotificacaoSubprocessoResumoQuery createQuery(
+            long total, long pendentes, long enviando, long enviadas, long falhasTemporarias, long falhasDefinitivas) {
+        return new NotificacaoSubprocessoResumoQuery(
+                1L, 1L, "Processo 1", "UN", SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO,
+                total, pendentes, enviando, enviadas, falhasTemporarias, falhasDefinitivas,
+                LocalDateTime.now(), LocalDateTime.now(), 0, null
+        );
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/dto/SugestoesDtoTest.java
+++ b/backend/src/test/java/sgc/subprocesso/dto/SugestoesDtoTest.java
@@ -1,0 +1,27 @@
+package sgc.subprocesso.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SugestoesDtoTest {
+
+    @Test
+    void shouldCreateVazia() {
+        SugestoesDto dto = SugestoesDto.vazia();
+        assertThat(dto.sugestoes()).isEmpty();
+    }
+
+    @Test
+    void shouldCreateDeWithText() {
+        String text = "Algumas sugestões";
+        SugestoesDto dto = SugestoesDto.de(text);
+        assertThat(dto.sugestoes()).isEqualTo(text);
+    }
+
+    @Test
+    void shouldCreateDeWithNull() {
+        SugestoesDto dto = SugestoesDto.de(null);
+        assertThat(dto.sugestoes()).isEmpty();
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoAcessoServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoAcessoServiceTest.java
@@ -1,0 +1,184 @@
+package sgc.subprocesso.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.mapa.service.ImpactoMapaService;
+import sgc.organizacao.model.Perfil;
+import sgc.organizacao.model.Unidade;
+import sgc.subprocesso.dto.PermissoesSubprocessoDto;
+import sgc.subprocesso.model.SituacaoSubprocesso;
+import sgc.subprocesso.model.Subprocesso;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubprocessoAcessoServiceTest {
+
+    @Mock
+    private ImpactoMapaService impactoMapaService;
+
+    @InjectMocks
+    private SubprocessoAcessoService acessoService;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void shouldResolverPermissoesForFinalizado() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.SERVIDOR, true, true, true, true);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.habilitarEditarCadastro()).isFalse();
+        assertThat(dto.habilitarDisponibilizarCadastro()).isFalse();
+        assertThat(dto.habilitarDevolverCadastro()).isFalse();
+        assertThat(dto.habilitarAceitarCadastro()).isFalse();
+        assertThat(dto.habilitarHomologarCadastro()).isFalse();
+        assertThat(dto.habilitarEditarMapa()).isFalse();
+        assertThat(dto.habilitarDisponibilizarMapa()).isFalse();
+        assertThat(dto.habilitarValidarMapa()).isFalse();
+        assertThat(dto.habilitarApresentarSugestoes()).isFalse();
+        assertThat(dto.habilitarDevolverMapa()).isFalse();
+        assertThat(dto.habilitarAceitarMapa()).isFalse();
+        assertThat(dto.habilitarHomologarMapa()).isFalse();
+        assertThat(dto.habilitarAcessoCadastro()).isTrue();
+    }
+
+    @Test
+    void shouldResolverPermissoesForMapeamentoCadastroEmAndamentoChefeMesmaUnidade() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.CHEFE, true, true, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.habilitarEditarCadastro()).isTrue();
+        assertThat(dto.habilitarDisponibilizarCadastro()).isTrue();
+        assertThat(dto.habilitarAcessoCadastro()).isTrue();
+        assertThat(dto.podeReabrirCadastro()).isFalse();
+    }
+
+    @Test
+    void shouldResolverPermissoesForGestorAnaliseCadastro() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.GESTOR, true, true, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.habilitarDevolverCadastro()).isTrue();
+        assertThat(dto.habilitarAceitarCadastro()).isTrue();
+        assertThat(dto.habilitarHomologarCadastro()).isFalse(); // Only Admin
+    }
+
+    @Test
+    void shouldResolverPermissoesForAdminAnaliseCadastro() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_DISPONIBILIZADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.ADMIN, true, true, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.habilitarDevolverCadastro()).isTrue();
+        assertThat(dto.habilitarAceitarCadastro()).isFalse(); // Only Gestor
+        assertThat(dto.habilitarHomologarCadastro()).isTrue();
+    }
+
+    @Test
+    void shouldResolverPermissoesForAcessoMapaHabilitadoGestor() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.GESTOR, false, true, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.habilitarAcessoMapa()).isTrue();
+    }
+
+    @Test
+    void shouldResolverPermissoesForAcessoMapaAdminApenasHomologado() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_HOMOLOGADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.ADMIN, false, true, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.habilitarAcessoMapa()).isTrue();
+    }
+
+    @Test
+    void shouldVisualizarImpactoWhenTemMapaVigente() {
+        when(impactoMapaService.podeVisualizarImpactos(any())).thenReturn(true);
+
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_DISPONIBILIZADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.SERVIDOR, false, true, false, true);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+
+        assertThat(dto.podeVisualizarImpacto()).isTrue();
+    }
+
+    @Test
+    void shouldReabrirCadastroAdmin() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_MAPA_HOMOLOGADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.ADMIN, false, false, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+        assertThat(dto.podeReabrirCadastro()).isTrue();
+    }
+
+    @Test
+    void shouldReabrirRevisaoAdmin() {
+        Subprocesso subprocesso = new Subprocesso();
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.REVISAO_MAPA_HOMOLOGADO);
+
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = createContexto(
+                subprocesso, Perfil.ADMIN, false, false, false, false);
+
+        PermissoesSubprocessoDto dto = acessoService.resolverPermissoes(contexto);
+        assertThat(dto.podeReabrirRevisao()).isTrue();
+    }
+
+    private SubprocessoConsultaService.ContextoConsultaSubprocesso createContexto(
+            Subprocesso subprocesso, Perfil perfil, boolean mesmaUnidade, boolean isHierarquia,
+            boolean processoFinalizado, boolean temMapaVigente) {
+
+        return new SubprocessoConsultaService.ContextoConsultaSubprocesso(
+                subprocesso,
+                perfil,
+                new Unidade(),
+                processoFinalizado,
+                mesmaUnidade,
+                mesmaUnidade,
+                isHierarquia,
+                temMapaVigente
+        );
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoContextoConsultaServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoContextoConsultaServiceTest.java
@@ -1,0 +1,108 @@
+package sgc.subprocesso.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.organizacao.ContextoUsuarioAutenticado;
+import sgc.organizacao.UsuarioFacade;
+import sgc.organizacao.model.Perfil;
+import sgc.organizacao.model.Unidade;
+import sgc.organizacao.service.HierarquiaService;
+import sgc.organizacao.service.UnidadeService;
+import sgc.processo.model.Processo;
+import sgc.processo.model.SituacaoProcesso;
+import sgc.subprocesso.model.Movimentacao;
+import sgc.subprocesso.model.SituacaoSubprocesso;
+import sgc.subprocesso.model.Subprocesso;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubprocessoContextoConsultaServiceTest {
+
+    @Mock
+    private UnidadeService unidadeService;
+
+    @Mock
+    private UsuarioFacade usuarioFacade;
+
+    @Mock
+    private HierarquiaService hierarquiaService;
+
+    @Mock
+    private LocalizacaoSubprocessoService localizacaoSubprocessoService;
+
+    @InjectMocks
+    private SubprocessoContextoConsultaService service;
+
+    private Subprocesso subprocesso;
+    private Unidade unidadeUsuario;
+    private Unidade unidadeAlvo;
+
+    @BeforeEach
+    void setUp() {
+        Processo processo = new Processo();
+        processo.setSituacao(SituacaoProcesso.EM_ANDAMENTO);
+
+        unidadeAlvo = new Unidade();
+        unidadeAlvo.setCodigo(100L);
+
+        subprocesso = new Subprocesso();
+        subprocesso.setUnidade(unidadeAlvo);
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+        subprocesso.setProcesso(processo);
+
+        unidadeUsuario = new Unidade();
+        unidadeUsuario.setCodigo(200L);
+    }
+
+    @Test
+    void shouldMontarContextoBaseSemMovimentacoes() {
+        ContextoUsuarioAutenticado contextoUsuario = new ContextoUsuarioAutenticado(
+                "123", 200L, Perfil.CHEFE);
+
+        when(usuarioFacade.contextoAutenticado()).thenReturn(contextoUsuario);
+        when(unidadeService.buscarPorCodigoComSuperior(200L)).thenReturn(unidadeUsuario);
+        when(localizacaoSubprocessoService.obterLocalizacaoAtual(subprocesso)).thenReturn(unidadeUsuario);
+        when(hierarquiaService.ehMesmaOuSubordinada(unidadeAlvo, unidadeUsuario)).thenReturn(false);
+
+        SubprocessoContextoConsultaService.ContextoConsultaBase contexto = service.montar(subprocesso, Collections.emptyList());
+
+        assertThat(contexto.perfil()).isEqualTo(Perfil.CHEFE);
+        assertThat(contexto.localizacaoAtual()).isEqualTo(unidadeUsuario);
+        assertThat(contexto.processoFinalizado()).isFalse();
+        assertThat(contexto.mesmaUnidade()).isTrue();
+        assertThat(contexto.mesmaUnidadeAlvo()).isFalse();
+        assertThat(contexto.unidadeAlvoNaHierarquiaUsuario()).isFalse();
+    }
+
+    @Test
+    void shouldMontarContextoBaseComMovimentacoes() {
+        ContextoUsuarioAutenticado contextoUsuario = new ContextoUsuarioAutenticado(
+                "456", 100L, Perfil.SERVIDOR);
+
+        when(usuarioFacade.contextoAutenticado()).thenReturn(contextoUsuario);
+        when(unidadeService.buscarPorCodigoComSuperior(100L)).thenReturn(unidadeAlvo);
+
+        Unidade unidadeDestino = new Unidade();
+        unidadeDestino.setCodigo(300L);
+        Movimentacao movimentacao = new Movimentacao();
+        movimentacao.setUnidadeDestino(unidadeDestino);
+
+        SubprocessoContextoConsultaService.ContextoConsultaBase contexto = service.montar(subprocesso, List.of(movimentacao));
+
+        assertThat(contexto.perfil()).isEqualTo(Perfil.SERVIDOR);
+        assertThat(contexto.localizacaoAtual()).isEqualTo(unidadeDestino);
+        assertThat(contexto.processoFinalizado()).isFalse();
+        assertThat(contexto.mesmaUnidade()).isFalse();
+        assertThat(contexto.mesmaUnidadeAlvo()).isTrue();
+        assertThat(contexto.unidadeAlvoNaHierarquiaUsuario()).isTrue();
+    }
+}

--- a/backend/src/test/java/sgc/subprocesso/service/SubprocessoVisualizacaoServiceTest.java
+++ b/backend/src/test/java/sgc/subprocesso/service/SubprocessoVisualizacaoServiceTest.java
@@ -1,0 +1,100 @@
+package sgc.subprocesso.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sgc.mapa.dto.MapaVisualizacaoResponse;
+import sgc.mapa.dto.ImpactoMapaResponse;
+import sgc.mapa.service.ImpactoMapaService;
+import sgc.mapa.service.MapaManutencaoService;
+import sgc.mapa.service.MapaVisualizacaoService;
+import sgc.organizacao.UsuarioFacade;
+import sgc.organizacao.model.Perfil;
+import sgc.organizacao.model.Unidade;
+import sgc.processo.model.Processo;
+import sgc.subprocesso.dto.SubprocessoDetalheResponse;
+import sgc.subprocesso.model.SituacaoSubprocesso;
+import sgc.subprocesso.model.Subprocesso;
+import sgc.subprocesso.model.AnaliseRepo;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SubprocessoVisualizacaoServiceTest {
+
+    @Mock private UsuarioFacade usuarioFacade;
+    @Mock private MapaManutencaoService mapaManutencaoService;
+    @Mock private MapaVisualizacaoService mapaVisualizacaoService;
+    @Mock private ImpactoMapaService impactoMapaService;
+    @Mock private SubprocessoAcessoService acessoService;
+    @Mock private AnaliseRepo analiseRepo;
+    @Mock private AnaliseHistoricoService analiseHistoricoService;
+
+    @InjectMocks
+    private SubprocessoVisualizacaoService service;
+
+    private Subprocesso subprocesso;
+    private Unidade unidade;
+
+    @BeforeEach
+    void setUp() {
+        unidade = new Unidade();
+        unidade.setCodigo(1L);
+        unidade.setSigla("SIGLA");
+        unidade.setNome("Nome da Unidade");
+
+        Processo processo = new Processo();
+        processo.setCodigo(1L);
+        processo.setDescricao("Processo");
+
+        subprocesso = new Subprocesso();
+        subprocesso.setCodigo(100L);
+        subprocesso.setUnidade(unidade);
+        subprocesso.setProcesso(processo);
+        subprocesso.setSituacaoForcada(SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO);
+    }
+
+    @Test
+    void shouldDelegarMapaParaVisualizacao() {
+        MapaVisualizacaoResponse mockResponse = MapaVisualizacaoResponse.builder().build();
+        when(mapaVisualizacaoService.obterMapaParaVisualizacao(subprocesso)).thenReturn(mockResponse);
+
+        MapaVisualizacaoResponse result = service.mapaParaVisualizacao(subprocesso);
+
+        assertThat(result).isSameAs(mockResponse);
+    }
+
+    @Test
+    void shouldDelegarVerificarImpactos() {
+        ImpactoMapaResponse mockResponse = new ImpactoMapaResponse(false, java.util.List.of(), java.util.List.of(), java.util.List.of(), java.util.List.of(), 0, 0, 0, 0);
+        when(impactoMapaService.verificarImpactos(subprocesso)).thenReturn(mockResponse);
+
+        ImpactoMapaResponse result = service.verificarImpactos(subprocesso);
+
+        assertThat(result).isSameAs(mockResponse);
+    }
+
+    @Test
+    void shouldConstruirDetalheCadastro() {
+        SubprocessoConsultaService.ContextoConsultaSubprocesso contexto = new SubprocessoConsultaService.ContextoConsultaSubprocesso(
+                subprocesso, Perfil.SERVIDOR, unidade, false, true, true, true, false
+        );
+
+        when(acessoService.resolverPermissoes(contexto)).thenReturn(null);
+
+        SubprocessoDetalheResponse result = service.construirDetalheCadastro(contexto);
+
+        assertThat(result.subprocesso().codigo()).isEqualTo(100L);
+        assertThat(result.responsavel()).isNull();
+        assertThat(result.titular()).isNull();
+        assertThat(result.movimentacoes()).isEmpty();
+        assertThat(result.localizacaoAtual()).isEqualTo("SIGLA");
+        assertThat(result.permissoes()).isNull();
+    }
+}


### PR DESCRIPTION
This commit adds 6 missing dedicated tests in the backend, improving coverage while adhering to strict mocking rules (no `lenient()`, minimal/precise mocks). All thresholds are successfully verified with the `jacocoTestCoverageVerification` task.

---
*PR created automatically by Jules for task [6140372053946595517](https://jules.google.com/task/6140372053946595517) started by @lgalvao*