### PR TITLE
Fix frontend quality check errors

### DIFF
--- a/frontend/src/views/__tests__/CadastroViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/CadastroViewCoverage.spec.ts
@@ -4,6 +4,7 @@ import CadastroView from '../CadastroView.vue';
 import { createTestingPinia } from '@pinia/testing';
 import { createRouter, createWebHistory } from 'vue-router';
 import { useSubprocessoStore } from '@/stores/subprocesso';
+import { SituacaoSubprocesso } from '@/types/tipos';
 
 vi.mock('@/composables/useAcesso', () => ({
   useAcesso: vi.fn(() => ({
@@ -96,7 +97,7 @@ describe('CadastroView Coverage', () => {
       },
       props: {
         codProcesso: 123,
-        siglaUnidade: 'U1'
+        sigla: 'U1'
       }
     });
   };
@@ -107,13 +108,12 @@ describe('CadastroView Coverage', () => {
 
     const store = useSubprocessoStore();
     // @ts-ignore
-    store.contextoEdicao = {
+    store.contextoCadastro = {
       detalhes: {
         codigo: 1,
-        processo: { codigo: 123, descricao: 'Proc 1' },
-        unidade: { sigla: 'U1', codigo: 2 },
-        situacao: 'EM_ANDAMENTO'
-      }
+        unidade: { sigla: 'U1', nome: 'Unidade 1', codigo: 2 },
+        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO
+      } as any
     };
     // @ts-ignore
     store.garantirContextoEdicao = vi.fn().mockResolvedValue(true);

--- a/frontend/src/views/__tests__/NotificacoesAdminView.spec.ts
+++ b/frontend/src/views/__tests__/NotificacoesAdminView.spec.ts
@@ -188,7 +188,7 @@ describe('NotificacoesAdminView', () => {
     ];
     // @ts-ignore
     vi.mocked(listarResumoSubprocessosAtivos).mockResolvedValue(mockData);
-    vi.mocked(reenviarFalhasDefinitivas).mockResolvedValue({ reenfileiradas: 1 });
+    vi.mocked(reenviarFalhasDefinitivas).mockResolvedValue({ reenfileiradas: 1, subprocessoCodigo: 2 });
 
     const wrapper = mountComponent();
     await flushPromises();

--- a/frontend/src/views/__tests__/SubprocessoViewCoverage.spec.ts
+++ b/frontend/src/views/__tests__/SubprocessoViewCoverage.spec.ts
@@ -4,6 +4,7 @@ import SubprocessoView from '../SubprocessoView.vue';
 import { createTestingPinia } from '@pinia/testing';
 import { createRouter, createWebHistory } from 'vue-router';
 import { useSubprocessoStore } from '@/stores/subprocesso';
+import { SituacaoSubprocesso } from '@/types/tipos';
 
 vi.mock('@/composables/useAcesso', () => ({
   useAcesso: vi.fn(() => ({
@@ -80,10 +81,9 @@ describe('SubprocessoView Coverage', () => {
     store.contextoEdicao = {
       detalhes: {
         codigo: 1,
-        processo: { codigo: 123, descricao: 'Proc 1' },
-        unidade: { sigla: 'U1', codigo: 2 },
-        situacao: 'EM_ANDAMENTO'
-      }
+        unidade: { sigla: 'U1', nome: 'Unidade 1', codigo: 2 },
+        situacao: SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO
+      } as any
     };
 
     // We trigger multiple actions that might not be fully covered in main spec


### PR DESCRIPTION
This PR fixes several type errors discovered during a quality check of the frontend. The errors were primarily in unit test files due to mismatches between mock data and the application's actual data models and store structures.

Key changes:
1. **CadastroViewCoverage.spec.ts**:
   - Corrected `siglaUnidade` prop to `sigla`.
   - Updated `store.contextoEdicao` access to `store.contextoCadastro`.
   - Added missing `nome` property to `unidade` mock.
   - Replaced raw string `'EM_ANDAMENTO'` with `SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO`.
   - Used `as any` casting for complex store state mocks to satisfy TypeScript.

2. **SubprocessoViewCoverage.spec.ts**:
   - Added missing `nome` property to `unidade` mock.
   - Replaced raw string `'EM_ANDAMENTO'` with `SituacaoSubprocesso.MAPEAMENTO_CADASTRO_EM_ANDAMENTO`.
   - Used `as any` casting for complex store state mocks.

3. **NotificacoesAdminView.spec.ts**:
   - Added missing `subprocessoCodigo` to the mock response of `reenviarFalhasDefinitivas` to match the `ReenvioNotificacaoResponse` interface.

All unit tests pass and `npm run typecheck` now completes successfully.

---
*PR created automatically by Jules for task [6300257818841889889](https://jules.google.com/task/6300257818841889889) started by @lgalvao*