### PR TITLE
Fix lint and typecheck warnings in frontend and E2E tests

### DIFF
--- a/e2e/cdu-36.spec.ts
+++ b/e2e/cdu-36.spec.ts
@@ -14,7 +14,7 @@ test.describe.serial('CDU-36 - Gerar relatório de mapas', () => {
     test('Cenários CDU-36: ADMIN define filtros e gera PDF de mapas', async ({_resetAutomatico, page, request, _autenticadoComoAdmin}) => {
         test.slow();
         const descricaoProcesso = `Relatório CDU-36 ${Date.now()}`;
-        const processo = await criarProcessoMapaHomologadoFixture(request, {
+        await criarProcessoMapaHomologadoFixture(request, {
             descricao: descricaoProcesso,
             unidade: 'ASSESSORIA_12',
             diasLimite: 30

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -288,7 +288,6 @@ const {
   loadingInicioRevisao,
   iniciarRevisaoSeNecessario,
   cancelarInicioRevisaoSeNecessario,
-  atualizarCheckboxSemMudancasSilenciosamente,
   sincronizarDisponibilizacaoSemMudancasInicial
 } = useCadastroRevisaoSemMudancas({
   codigoSubprocesso,

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -442,7 +442,6 @@ const {
 
 const analisesCadastro = ref<Analise[]>([]);
 const historicoAnalise = computed(() => analisesCadastro.value || []);
-const temHistoricoAnalise = computed(() => historicoAnalise.value.length > 0);
 const mostrarModalSugestoes = ref(false);
 const mostrarModalVerSugestoes = ref(false);
 const mostrarModalHistorico = ref(false);
@@ -838,7 +837,7 @@ defineExpose({
   confirmarExclusaoCompetencia,
   disponibilizarMapa,
   removerAtividadeAssociada,
-  fecharModalExcluirCompetencia: () => { mostrarModalExcluirCompetencia.value = false; competenciaParaExcluir.value = null; },
+  fecharModalExcluirCompetencia,
   fecharModalDisponibilizar,
   abrirModalDisponibilizar,
   fecharModalCriarNovaCompetencia,


### PR DESCRIPTION
This PR addresses several warnings identified during a comprehensive quality check of the frontend and E2E tests.

### Changes:
- **frontend/src/views/CadastroView.vue**: Removed `atualizarCheckboxSemMudancasSilenciosamente` which was destructured but never used.
- **frontend/src/views/MapaView.vue**: Removed the unused `temHistoricoAnalise` computed property and refactored the `defineExpose` block to use object shorthand for `fecharModalExcluirCompetencia`, resolving a redundant declaration warning.
- **e2e/cdu-36.spec.ts**: Removed the unused `processo` variable assigned from `criarProcessoMapaHomologadoFixture`.

All quality checks (typecheck, lint, and unit tests) were verified to pass after these modifications.

---
*PR created automatically by Jules for task [4449040768303292582](https://jules.google.com/task/4449040768303292582) started by @lgalvao*