### PR TITLE
Corrige exibição indevida de controles de edição em cadastro e mapa

### DIFF
--- a/etc/reqs/regras-acesso.md
+++ b/etc/reqs/regras-acesso.md
@@ -179,6 +179,18 @@ O `AtividadeController` usa `hasRole('CHEFE')` para CRUD de atividades e conheci
 
 ---
 
+
+### 6.1 Exceção de UX para controles de edição
+
+Mesmo quando o backend indicar que o perfil possui a ação estrutural de edição, o frontend deve **ocultar** os controles
+de edição (em vez de apenas desabilitar) nos casos abaixo, quando a situação do subprocesso não permitir edição no
+workflow atual:
+
+- **Cadastro de atividades:** perfil **CHEFE**.
+- **Cadastro de mapa:** perfil **ADMIN**.
+
+Essa exceção é intencional e restrita às telas de cadastro/edição citadas acima.
+
 ## 7. Importação de Atividades
 
 - `POST /subprocessos/{codigo}/importar-atividades` — protegido com

--- a/etc/reqs/ux.md
+++ b/etc/reqs/ux.md
@@ -17,6 +17,7 @@ específicos que funcionam melhor com tratamento próprio.
 - Se a ação nunca puder ser realizada pelo perfil atual, o botão ou controle não deve ser renderizado.
 - Se o perfil pode realizar a ação, mas a localização, situação de workflow, permissão contextual ou estado de
   carregamento impede a execução agora, o controle deve aparecer desabilitado.
+- **Exceção (cadastro de atividades / mapa):** quando o perfil CHEFE (cadastro) ou ADMIN (mapa) possui capacidade estrutural de edição, mas a situação do subprocesso impede a edição naquele momento, os controles de edição **devem ser ocultados** (não apenas desabilitados).
 - Ação desabilitada por workflow/localização deve ter motivo acessível e persistente quando o contexto não for óbvio.
 - Tooltip pode complementar o motivo, mas não deve ser o único canal quando a informação for essencial.
 - Erro corrigível de formulário não deve deixar a ação principal muda; a tentativa deve exibir validação inline ou

--- a/frontend/src/views/CadastroView.vue
+++ b/frontend/src/views/CadastroView.vue
@@ -20,7 +20,7 @@
           @abrir-importar="mostrarModalImportar = true"
       />
 
-      <div v-if="podeEditarCadastro && isRevisao" class="mt-3 mb-2">
+      <div v-if="mostrarControlesEdicaoCadastro && isRevisao" class="mt-3 mb-2">
         <BFormCheckbox
             v-model="disponibilizacaoSemMudancas"
             :disabled="checkboxSemMudancasDesabilitado"
@@ -60,7 +60,7 @@
       />
 
       <CadAtividadeForm
-          v-if="podeEditarCadastro"
+          v-if="mostrarControlesEdicaoCadastro"
           ref="atividadeFormRef"
           v-model="novaAtividade"
           :disabled="!codigoSubprocesso || !habilitarEditarCadastro"
@@ -71,8 +71,8 @@
 
       <EmptyState
           v-if="atividades?.length === 0"
-          :description="podeEditarCadastro ? TEXTOS.atividades.EMPTY_DESCRIPTION : TEXTOS.treeTable.EMPTY_DESCRIPTION"
-          :title="podeEditarCadastro ? TEXTOS.atividades.EMPTY_TITLE : TEXTOS.treeTable.EMPTY_TITLE"
+          :description="mostrarControlesEdicaoCadastro ? TEXTOS.atividades.EMPTY_DESCRIPTION : TEXTOS.treeTable.EMPTY_DESCRIPTION"
+          :title="mostrarControlesEdicaoCadastro ? TEXTOS.atividades.EMPTY_TITLE : TEXTOS.treeTable.EMPTY_TITLE"
           data-testid="cad-atividades-empty-state"
           icon="bi-list-check"
       />
@@ -86,7 +86,7 @@
             :atividade="atividade"
             :erro-validacao="obterErroParaAtividade(atividade.codigo)"
             :habilitar-edicao="habilitarEditarCadastro"
-            :pode-editar="podeEditarCadastro"
+            :pode-editar="mostrarControlesEdicaoCadastro"
             @atualizar-atividade="(desc: string) => salvarEdicaoAtividade(atividade.codigo, desc)"
             @remover-atividade="() => removerAtividade(atividade.codigo)"
             @adicionar-conhecimento="(desc: string) => adicionarConhecimento(atividade.codigo, desc)"
@@ -153,6 +153,7 @@ import {useImpactoMapaModal} from "@/composables/useImpactoMapaModal";
 import {useMapas} from "@/composables/useMapas";
 import {useNotification} from "@/composables/useNotification";
 import {useSubprocessoStore} from "@/stores/subprocesso";
+import {usePerfilStore} from "@/stores/perfil";
 import {useErrorHandler} from "@/composables/useErrorHandler";
 import {useAcesso} from "@/composables/acesso";
 import {useCadastroAtividadesMutacoes} from "@/composables/useCadastroAtividadesMutacoes";
@@ -161,7 +162,7 @@ import {useValidacaoFormulario} from "@/composables/useValidacaoFormulario";
 import {useCadastroOrquestracao} from "@/composables/useCadastroOrquestracao";
 import {useCadastroAnaliseFluxo} from "@/views/cadastroAnaliseFluxo";
 import {useCadastroDisponibilizacao} from "@/views/cadastroDisponibilizacao";
-import {type Atividade, type AtividadeOperacaoResponse, type PermissoesSubprocesso, TipoProcesso} from "@/types/tipos";
+import {type Atividade, type AtividadeOperacaoResponse, type PermissoesSubprocesso, Perfil, TipoProcesso} from "@/types/tipos";
 import {calcularAssinaturaCadastro} from "@/utils/formatters";
 import {normalizarPermissoesSubprocesso} from "@/utils/permissoesSubprocesso";
 import {listarAnalisesCadastro} from "@/services/analiseService";
@@ -186,6 +187,7 @@ const {
 } = useCadastroOrquestracao(props, atividades);
 
 const subprocessoStore = useSubprocessoStore();
+const perfilStore = usePerfilStore();
 const mapasStore = useMapas(codigoSubprocesso);
 const fluxoSubprocesso = useFluxoSubprocesso();
 const {notify, notificacao, clear} = useNotification();
@@ -212,6 +214,13 @@ const {
 } = acesso;
 
 const isRevisao = computed(() => subprocesso.value?.tipoProcesso === TipoProcesso.REVISAO);
+const esconderEdicaoCadastroParaChefe = computed(() =>
+    perfilStore.perfilSelecionado === Perfil.CHEFE
+    && podeEditarCadastro.value
+    && !habilitarEditarCadastro.value
+);
+const mostrarControlesEdicaoCadastro = computed(() => podeEditarCadastro.value && !esconderEdicaoCadastroParaChefe.value);
+
 const permissoesUI = computed<PermissoesSubprocesso>(() => ({
   ...normalizarPermissoesSubprocesso(subprocesso.value?.permissoes),
   podeEditarCadastro: podeEditarCadastro.value,

--- a/frontend/src/views/MapaView.vue
+++ b/frontend/src/views/MapaView.vue
@@ -170,6 +170,7 @@ import {useMapas} from "@/composables/useMapas";
 import {useNotification} from "@/composables/useNotification";
 import {useToastStore} from "@/stores/toast";
 import {useSubprocessoStore} from "@/stores/subprocesso";
+import {usePerfilStore} from "@/stores/perfil";
 import {useInvalidacaoNavegacao} from "@/composables/useInvalidacaoNavegacao";
 import {listarAnalisesValidacao} from "@/services/analiseService";
 import {useValidacaoFormulario} from "@/composables/useValidacaoFormulario";
@@ -179,6 +180,7 @@ import {useMapaAnaliseFluxo} from "@/views/mapaAnaliseFluxo";
 import {useMapaDisponibilizacao} from "@/views/mapaDisponibilizacao";
 import {normalizarErro} from "@/utils/apiError";
 import type {Analise, MapaCompleto,} from "@/types/tipos";
+import {Perfil} from "@/types/tipos";
 import {TEXTOS} from "@/constants/textos";
 
 const props = defineProps<{ codProcesso: number | string; sigla: string; codSubprocesso?: number }>();
@@ -188,6 +190,7 @@ const carregandoFluxoMapa = computed(() => unref(fluxoMapa.carregando) ?? false)
 const {notify} = useNotification();
 const toastStore = useToastStore();
 const subprocessoStore = useSubprocessoStore();
+const perfilStore = usePerfilStore();
 const {invalidarCachesSubprocesso} = useInvalidacaoNavegacao();
 const subprocesso = computed(() => subprocessoStore.contextoEdicao?.detalhes ?? null);
 
@@ -215,7 +218,12 @@ const usarMenuAcoesMapa = computed(() => {
       || Boolean(acaoPrincipalMapa.value?.mostrar)
       || mostrarDisponibilizarMapa.value;
 });
-const modoSomenteLeitura = computed(() => !podeEditarMapa.value);
+const esconderEdicaoMapaParaAdmin = computed(() =>
+  perfilStore.perfilSelecionado === Perfil.ADMIN
+  && podeEditarMapa.value
+  && !habilitarEditarMapa.value
+);
+const modoSomenteLeitura = computed(() => !podeEditarMapa.value || esconderEdicaoMapaParaAdmin.value);
 const mostrarAcaoPrincipalMapa = computed(() => Boolean(acaoPrincipalMapa.value?.mostrar));
 const habilitarAcaoPrincipalMapa = computed(() => acaoPrincipalMapa.value?.habilitar ?? false);
 const rotuloAcaoPrincipalMapa = computed(() => acaoPrincipalMapa.value?.rotuloBotao ?? TEXTOS.mapa.LABEL_HOMOLOGAR);

--- a/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
+++ b/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
@@ -817,6 +817,21 @@ describe("CadastroView.vue", () => {
         expect(btn.exists()).toBe(false);
     });
 
+    it("oculta controles de edição para CHEFE quando a edição não estiver habilitada no workflow", async () => {
+        const wrapper = createWrapper({
+            perfil: {
+                perfilSelecionado: Perfil.CHEFE,
+            },
+        }, {
+            podeEditarCadastro: ref(true),
+            habilitarEditarCadastro: ref(false),
+            podeDisponibilizarCadastro: ref(false),
+        });
+        await flushPromises();
+
+        expect(wrapper.find('[data-testid="cad-atividade-form"]').exists()).toBe(false);
+    });
+
     it("oculta formulário de nova atividade quando o usuário não tem permissão para editar", async () => {
         const wrapper = createWrapper({}, {
             podeEditarCadastro: ref(false),

--- a/frontend/src/views/__tests__/MapaViewSomenteLeitura.spec.ts
+++ b/frontend/src/views/__tests__/MapaViewSomenteLeitura.spec.ts
@@ -240,6 +240,38 @@ describe("MapaView somente leitura", () => {
         expect(wrapper.find('[data-testid="btn-mapa-acao-homologar-aceite"]').attributes('disabled')).toBeDefined();
     });
 
+    it("força modo somente leitura para ADMIN quando edição do mapa não estiver habilitada", async () => {
+        vi.mocked(useAcessoModule.useAcesso).mockReturnValue({
+            podeVisualizarImpacto: ref(false),
+            podeApresentarSugestoes: ref(false),
+            podeEditarMapa: ref(true),
+            podeDisponibilizarMapa: ref(false),
+            mostrarApresentarSugestoes: ref(false),
+            mostrarValidarMapa: ref(false),
+            mostrarDisponibilizarMapa: ref(false),
+            mostrarDevolverMapa: ref(false),
+            habilitarApresentarSugestoes: ref(false),
+            habilitarEditarMapa: ref(false),
+            habilitarDisponibilizarMapa: ref(false),
+            podeValidarMapa: ref(false),
+            habilitarValidarMapa: ref(false),
+            podeVerSugestoes: ref(false),
+            podeAnalisarMapa: ref(false),
+            habilitarDevolverMapa: ref(false),
+            acaoPrincipalMapa: ref(null),
+        } as any);
+
+        const wrapper = mountComponent({
+            perfil: {
+                perfilSelecionado: 'ADMIN',
+            },
+        });
+        await flushPromises();
+
+        expect((wrapper.vm as any).modoSomenteLeitura).toBe(true);
+        expect(wrapper.find('[data-testid="btn-abrir-criar-competencia"]').exists()).toBe(false);
+    });
+
     it("agrupa ações no botão Ações quando for ADMIN e mapa com sugestões", async () => {
         subprocessoStoreCacheMock.contextoEdicao.detalhes.situacao = 'MAPEAMENTO_MAPA_COM_SUGESTOES';
 


### PR DESCRIPTION
### Motivation

- Corrigir um comportamento onde, quando o perfil CHEFE (cadastro) ou ADMIN (mapa) tem capacidade estrutural de edição mas o workflow atual não permite editar, os controles de edição eram exibidos desabilitados em vez de ocultos. 
- Garantir consistência com a decisão de produto: nessas telas específicas os controles de edição devem desaparecer quando a edição não estiver habilitada pelo workflow. 
- Prevenir regressões visuais e de acessibilidade que confundem usuários sobre a disponibilidade real da ação. 

### Description

- Ajusta `frontend/src/views/CadastroView.vue` para usar `usePerfilStore` e introduz `esconderEdicaoCadastroParaChefe` / `mostrarControlesEdicaoCadastro`, trocando os `v-if` relevantes para ocultar o formulário e ações quando o CHEFE não puder editar pelo workflow. 
- Ajusta `frontend/src/views/MapaView.vue` para usar `usePerfilStore` e introduz `esconderEdicaoMapaParaAdmin`, fazendo `modoSomenteLeitura` considerar o caso em que ADMIN tem estrutura de edição mas a habilitação de edição está negada. 
- Atualiza testes de unidade em `frontend/src/views/__tests__/AtividadesCadastroView.spec.ts` e `frontend/src/views/__tests__/MapaViewSomenteLeitura.spec.ts` para cobrir os dois cenários (CHEFE ocultando controles e ADMIN forçando modo somente leitura). 
- Documenta a exceção de UX adicionando a nota em `etc/reqs/ux.md` e a seção `6.1 Exceção de UX para controles de edição` em `etc/reqs/regras-acesso.md`. 

### Testing

- Executado `pnpm -C frontend run test:unit src/views/__tests__/AtividadesCadastroView.spec.ts src/views/__tests__/MapaViewSomenteLeitura.spec.ts` e ambos os arquivos de teste passaram com sucesso. 
- Resultado observado: `Test Files  2 passed` e `Tests  28 passed` (todos os casos novos e existentes na suíte alvo passaram). 
- Nenhum teste automático adicional falhou após as alterações nos componentes e na documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbb56b41fc832b9210af9ea5489150)