### PR TITLE
Otimiza invalidação de cache e deduplica carregamento de subprocesso

### DIFF
--- a/frontend/src/composables/useFluxoSubprocesso.ts
+++ b/frontend/src/composables/useFluxoSubprocesso.ts
@@ -14,6 +14,7 @@ interface WorkflowOptions {
     invalidarCaches?: {
         incluirPainel?: boolean;
         incluirMapas?: boolean;
+        codigoSubprocessoMapa?: number;
     };
     redirecionarPara?: import("vue-router").RouteLocationRaw;
     recarregarContexto?: {
@@ -82,7 +83,7 @@ export function useFluxoSubprocesso() {
             {
                 mensagemSucesso: TEXTOS.sucesso.CADASTRO_ATIVIDADES_DISPONIBILIZADO,
                 redirecionarParaPainel: true,
-                invalidarCaches: {incluirPainel: true, incluirMapas: false}
+                invalidarCaches: {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
             }
         );
     }
@@ -93,7 +94,7 @@ export function useFluxoSubprocesso() {
             {
                 mensagemSucesso: TEXTOS.sucesso.REVISAO_CADASTRO_ATIVIDADES_DISPONIBILIZADA,
                 redirecionarParaPainel: true,
-                invalidarCaches: {incluirPainel: true, incluirMapas: false}
+                invalidarCaches: {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
             }
         );
     }
@@ -122,7 +123,7 @@ export function useFluxoSubprocesso() {
             {
                 mensagemSucesso: TEXTOS.sucesso.DEVOLUCAO_REALIZADA,
                 redirecionarParaPainel: true,
-                invalidarCaches: {incluirPainel: true, incluirMapas: false}
+                invalidarCaches: {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
             }
         );
     }
@@ -133,7 +134,7 @@ export function useFluxoSubprocesso() {
             {
                 mensagemSucesso: TEXTOS.sucesso.DEVOLUCAO_REALIZADA,
                 redirecionarParaPainel: true,
-                invalidarCaches: {incluirPainel: true, incluirMapas: false}
+                invalidarCaches: {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
             }
         );
     }
@@ -146,7 +147,7 @@ export function useFluxoSubprocesso() {
             {
                 mensagemSucesso: options?.mensagemSucesso || TEXTOS.sucesso.ACEITE_REGISTRADO,
                 redirecionarParaPainel: true,
-                invalidarCaches: {incluirPainel: true, incluirMapas: false}
+                invalidarCaches: {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
             }
         );
     }
@@ -159,7 +160,7 @@ export function useFluxoSubprocesso() {
             {
                 mensagemSucesso: options?.mensagemSucesso || TEXTOS.sucesso.ACEITE_REGISTRADO,
                 redirecionarParaPainel: true,
-                invalidarCaches: {incluirPainel: true, incluirMapas: false}
+                invalidarCaches: {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
             }
         );
     }
@@ -176,7 +177,9 @@ export function useFluxoSubprocesso() {
                 mensagemSucesso: options?.mensagemSucesso || TEXTOS.sucesso.HOMOLOGACAO_EFETIVADA,
                 redirecionarParaPainel,
                 redirecionarPara: options?.redirecionarPara,
-                invalidarCaches: redirecionarParaPainel ? {incluirPainel: true, incluirMapas: false} : {}
+                invalidarCaches: redirecionarParaPainel
+                    ? {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
+                    : {}
             }
         );
     }
@@ -193,7 +196,9 @@ export function useFluxoSubprocesso() {
                 mensagemSucesso: options?.mensagemSucesso || TEXTOS.sucesso.HOMOLOGACAO_EFETIVADA,
                 redirecionarParaPainel,
                 redirecionarPara: options?.redirecionarPara,
-                invalidarCaches: redirecionarParaPainel ? {incluirPainel: true, incluirMapas: false} : {}
+                invalidarCaches: redirecionarParaPainel
+                    ? {incluirPainel: true, incluirMapas: false, codigoSubprocessoMapa: codigoSubprocesso}
+                    : {}
             }
         );
     }

--- a/frontend/src/composables/useInvalidacaoNavegacao.ts
+++ b/frontend/src/composables/useInvalidacaoNavegacao.ts
@@ -27,7 +27,12 @@ export function useInvalidacaoNavegacao() {
         mapasStore.invalidar();
     }
 
-    function invalidarCachesSubprocesso(opcoes?: { incluirPainel?: boolean; incluirProcesso?: boolean; incluirMapas?: boolean }): void {
+    function invalidarCachesSubprocesso(opcoes?: {
+        incluirPainel?: boolean;
+        incluirProcesso?: boolean;
+        incluirMapas?: boolean;
+        codigoSubprocessoMapa?: number;
+    }): void {
         if (opcoes?.incluirPainel ?? false) {
             painelStore.invalidar();
         }
@@ -38,7 +43,11 @@ export function useInvalidacaoNavegacao() {
         // Mapas são pesados e nem toda ação de subprocesso altera esse domínio.
         // Mantemos opt-in explícito para evitar recarregamentos desnecessários.
         if (opcoes?.incluirMapas ?? false) {
-            mapasStore.invalidar();
+            if (typeof opcoes?.codigoSubprocessoMapa === "number") {
+                mapasStore.invalidar(opcoes.codigoSubprocessoMapa);
+            } else {
+                mapasStore.invalidar();
+            }
         }
     }
 

--- a/frontend/src/composables/useInvalidacaoNavegacao.ts
+++ b/frontend/src/composables/useInvalidacaoNavegacao.ts
@@ -35,7 +35,9 @@ export function useInvalidacaoNavegacao() {
             processoStore.invalidar();
         }
         subprocessoStore.invalidar();
-        if (opcoes?.incluirMapas ?? true) {
+        // Mapas são pesados e nem toda ação de subprocesso altera esse domínio.
+        // Mantemos opt-in explícito para evitar recarregamentos desnecessários.
+        if (opcoes?.incluirMapas ?? false) {
             mapasStore.invalidar();
         }
     }

--- a/frontend/src/views/subprocessoCarregamento.ts
+++ b/frontend/src/views/subprocessoCarregamento.ts
@@ -31,8 +31,14 @@ export function useSubprocessoCarregamento({
     const codigoSubprocesso = ref<number | null>(null);
     const erroNaoEncontrado = ref(false);
     const carregamentoInicialConcluido = ref(false);
+    let carregamentoEmAndamento: Promise<void> | null = null;
 
     async function carregarSubprocesso(limpar = false) {
+        if (!limpar && carregamentoEmAndamento) {
+            await carregamentoEmAndamento;
+            return;
+        }
+        const tarefaCarregamento = (async () => {
         const resultadoDireto = typeof codSubprocesso === "number"
             ? await garantirContextoEdicao(codSubprocesso, limpar)
             : null;
@@ -52,6 +58,16 @@ export function useSubprocessoCarregamento({
 
         codigoSubprocesso.value = resultado.codigo;
         erroNaoEncontrado.value = false;
+        })();
+
+        carregamentoEmAndamento = tarefaCarregamento;
+        try {
+            await tarefaCarregamento;
+        } finally {
+            if (carregamentoEmAndamento === tarefaCarregamento) {
+                carregamentoEmAndamento = null;
+            }
+        }
     }
 
     async function atualizarSubprocessoAtual() {


### PR DESCRIPTION
### Motivation
- Reduzir chamadas espúrias e recargas pesadas ao alternar entre views mantidas em `keepAlive` para melhorar percepção de velocidade da aplicação.
- Evitar invalidações de cache prematuras que forçam recarga de dados volumosos (ex.: mapas) quando a ação não os altera.
- Prevenir múltiplos carregamentos concorrentes do mesmo contexto de subprocesso gerados por ciclos de `onMounted`/`watch`/`onActivated`.

### Description
- Altera `useInvalidacaoNavegacao` para tornar a invalidação do store de mapas opt-in (`incluirMapas` agora default `false`) para evitar recargas desnecessárias de dados pesados (arquivo `frontend/src/composables/useInvalidacaoNavegacao.ts`).
- Adiciona deduplicação de carregamento em `useSubprocessoCarregamento` usando `carregamentoEmAndamento` para aguardar uma requisição em andamento em vez de disparar uma nova, preservando o caminho de `limpar=true` para refresh forçado (arquivo `frontend/src/views/subprocessoCarregamento.ts`).
- Mantém comportamento funcional de invalidações explícitas e recarregamentos forçados após workflows para não quebrar consistência dos dados.

### Testing
- Executado `pnpm -C frontend run test:unit src/composables/__tests__/useInvalidacaoNavegacao.spec.ts src/views/__tests__/SubprocessoView.spec.ts` e os testes unitários relevantes passaram (`2 files, 26 tests passed`).
- Observado um primeiro run com `npm run test:unit` que falhou por filtro/caminho do Vitest; após ajustar comando para `pnpm` os testes automáticos completaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc384b91e4832b93b1f8c239a20944)