### PR TITLE
Add nullable date fields to subprocess and unit mappings and update tests/stories

### DIFF
--- a/frontend/src/components/processo/SubprocessoResumoHeader.stories.ts
+++ b/frontend/src/components/processo/SubprocessoResumoHeader.stories.ts
@@ -85,6 +85,7 @@ const subprocessoMock: SubprocessoDetalhe = {
     ultimaDataLimiteSubprocesso: '2025-09-30',
     tipoProcesso: TipoProcesso.MAPEAMENTO,
     prazoEtapaAtual: '2025-03-31',
+    dataFimEtapa1: null,
     isEmAndamento: true,
     etapaAtual: 1,
     movimentacoes: [],

--- a/frontend/src/components/processo/__tests__/SubprocessoCards.spec.ts
+++ b/frontend/src/components/processo/__tests__/SubprocessoCards.spec.ts
@@ -75,6 +75,7 @@ describe("SubprocessoCards.vue", () => {
             dataCriacaoProcesso: "2025-01-01T00:00:00",
             tipoProcesso: TipoProcesso.REVISAO,
             prazoEtapaAtual: "2025-01-01T00:00:00",
+            dataFimEtapa1: null,
             ultimaDataLimiteSubprocesso: "2025-01-01T00:00:00",
             isEmAndamento: true,
             etapaAtual: 1,

--- a/frontend/src/composables/__tests__/useAcesso.spec.ts
+++ b/frontend/src/composables/__tests__/useAcesso.spec.ts
@@ -60,6 +60,7 @@ function criarSubprocesso(parciais: Partial<SubprocessoDetalhe> = {}): Subproces
         ultimaDataLimiteSubprocesso: '2025-01-01T00:00:00',
         tipoProcesso: TipoProcesso.MAPEAMENTO,
         prazoEtapaAtual: '2025-01-01T00:00:00',
+        dataFimEtapa1: null,
         isEmAndamento: true,
         etapaAtual: 1,
         movimentacoes: [],

--- a/frontend/src/services/__tests__/unidadeService.spec.ts
+++ b/frontend/src/services/__tests__/unidadeService.spec.ts
@@ -92,6 +92,8 @@ describe('unidadeService', () => {
                     tipoResponsabilidade: undefined,
                     titular: null,
                     responsavel: null,
+                    dataInicioResponsabilidade: null,
+                    dataFimResponsabilidade: null,
                     filhas: [
                         {
                             codigo: 2,
@@ -103,6 +105,8 @@ describe('unidadeService', () => {
                             tipoResponsabilidade: undefined,
                             titular: null,
                             responsavel: null,
+                            dataInicioResponsabilidade: null,
+                            dataFimResponsabilidade: null,
                             filhas: []
                         }
                     ]

--- a/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
+++ b/frontend/src/views/__tests__/AtividadesCadastroView.spec.ts
@@ -129,6 +129,7 @@ function criarContextoEdicao(): ContextoCadastroAtividadesSubprocesso {
         ultimaDataLimiteSubprocesso: "2025-01-01T00:00:00",
         tipoProcesso: TipoProcesso.MAPEAMENTO,
         prazoEtapaAtual: "2025-01-01T00:00:00",
+        dataFimEtapa1: null,
         isEmAndamento: true,
         etapaAtual: 1,
         movimentacoes: [],


### PR DESCRIPTION
### Motivation

- Introduce explicit nullable date properties to support new timeline data in subprocess and unit models so components and services can surface end/start dates when available.

### Description

- Added `dataFimEtapa1: null` to `SubprocessoDetalhe` test fixtures and stories to reflect the new optional end-of-step field.  
- Added `dataInicioResponsabilidade` and `dataFimResponsabilidade` (set to `null`) to mapped unit objects in the `unidadeService` test expectations.  
- Updated multiple test files and a Storybook story to include the new nullable date fields: `SubprocessoCards.spec.ts`, `useAcesso.spec.ts`, `unidadeService.spec.ts`, `AtividadesCadastroView.spec.ts`, and `SubprocessoResumoHeader.stories.ts`.

### Testing

- Ran the unit test suite for the frontend (`vitest` via `pnpm test`), which executed the updated specs and all tests passed.  
- Verified the updated story compiles with Storybook by including the new mock field in `SubprocessoResumoHeader.stories.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cacec790832b9d84def1756bdc93)