### PR TITLE
Fix frontend lint warnings and verify quality check

### DIFF
--- a/frontend/src/components/processo/HistoricoAnaliseModal.vue
+++ b/frontend/src/components/processo/HistoricoAnaliseModal.vue
@@ -122,7 +122,7 @@
 
 <script lang="ts" setup>
 import {ref} from "vue";
-import {BAlert, BButton, BModal, BSpinner, BTable} from "bootstrap-vue-next";
+import {BButton, BModal, BSpinner, BTable} from "bootstrap-vue-next";
 import ModalVisualizacaoTextoFormatado from "@/components/comum/ModalVisualizacaoTextoFormatado.vue";
 import type {Analise} from "@/types/tipos";
 import {formatarDataHoraBR} from "@/utils/date";

--- a/frontend/src/views/RelatorioMapasView.vue
+++ b/frontend/src/views/RelatorioMapasView.vue
@@ -41,7 +41,7 @@
 
 <script lang="ts" setup>
 import {computed, onMounted, ref} from "vue";
-import {BAlert, BButton} from "bootstrap-vue-next";
+import {BButton} from "bootstrap-vue-next";
 import LayoutPadrao from "@/components/layout/LayoutPadrao.vue";
 import PageHeader from "@/components/layout/PageHeader.vue";
 import CarregamentoPagina from "@/components/comum/CarregamentoPagina.vue";


### PR DESCRIPTION
This PR fixes minor linting warnings identified during a quality check of the frontend. Specifically, it removes unused `BAlert` imports from `HistoricoAnaliseModal.vue` and `RelatorioMapasView.vue`. These changes ensure that the `npm run quality:all` and root `npm run lint` commands pass with zero warnings, satisfying the project's quality requirements. Full project type-checking and unit tests were also verified to pass successfully.

---
*PR created automatically by Jules for task [3678646566174830133](https://jules.google.com/task/3678646566174830133) started by @lgalvao*