### PR TITLE
Frontend quality check and lint fixes

### DIFF
--- a/frontend/src/components/administracao/NotificacaoTabela.vue
+++ b/frontend/src/components/administracao/NotificacaoTabela.vue
@@ -93,8 +93,7 @@ import {
   formatarAssunto,
   formatarDestinatario,
   formatarQuando,
-  formatarTipoNotificacao,
-  resumirContexto
+  formatarTipoNotificacao
 } from "@/utils/notificacaoFormatters";
 
 defineProps<{

--- a/frontend/src/components/comum/EditorTextoRico.vue
+++ b/frontend/src/components/comum/EditorTextoRico.vue
@@ -3,7 +3,6 @@ import {computed, onBeforeUnmount, ref, useAttrs, watch} from "vue";
 import {Editor, EditorContent} from "@tiptap/vue-3";
 import StarterKit from "@tiptap/starter-kit";
 import {
-    htmlTemConteudo,
     LIMITE_PADRAO_TEXTO_FORMATADO,
     normalizarHtmlEditor,
     obterComprimentoHtmlFormatado


### PR DESCRIPTION
I have performed a comprehensive quality check on the frontend and root project.

Summary of actions:
1. **Linting**: Fixed two unused import warnings in `NotificacaoTabela.vue` and `EditorTextoRico.vue`. Verified zero warnings across the frontend using `quality:lint` (which enforces `--max-warnings 0`).
2. **Typechecking**: Successfully ran `npm run typecheck` at the root, which covers both E2E and frontend projects.
3. **Unit Tests**: Executed all 1295 frontend unit tests, ensuring they all pass.
4. **Integrity**: Ran the `cruft:check` tool to ensure project architecture remains within defined budgets.
5. **Tooling**: Resolved a missing dependency issue in `etc/scripts` to allow the full quality suite to execute.

All quality gates are now passing.

---
*PR created automatically by Jules for task [7488498344914331182](https://jules.google.com/task/7488498344914331182) started by @lgalvao*