### PR TITLE
Quality check and fix for frontend lint warnings

### DIFF
--- a/frontend/src/components/administracao/NotificacaoTabela.vue
+++ b/frontend/src/components/administracao/NotificacaoTabela.vue
@@ -93,8 +93,7 @@ import {
   formatarAssunto,
   formatarDestinatario,
   formatarQuando,
-  formatarTipoNotificacao,
-  resumirContexto
+  formatarTipoNotificacao
 } from "@/utils/notificacaoFormatters";
 
 defineProps<{


### PR DESCRIPTION
This PR performs a quality check on the frontend and root project.
It identifies a lint warning in `NotificacaoTabela.vue` where `resumirContexto` was imported but never used.
Removing this unused import allows the frontend quality suite (`npm run quality:all`) to pass, as it enforces zero warnings.
All other checks (unit tests and typechecking in both root and frontend) were already passing.

---
*PR created automatically by Jules for task [12408661956723567752](https://jules.google.com/task/12408661956723567752) started by @lgalvao*