### PR TITLE
Fix lint error and verify frontend quality checks

### DIFF
--- a/etc/scripts/codigo/idioma-consistencia-auditar.js
+++ b/etc/scripts/codigo/idioma-consistencia-auditar.js
@@ -35,7 +35,6 @@ const NOMES_INGLES_EXATOS = new Set([
 ]);
 
 // Sufixos de identificador que deveriam ser `Codigo` no SGC
-const SUFIXOS_ID = /^(?:.*[A-Z]|^)id$|Id$/;
 const SUFIXOS_ID_FINAL = /Id$/;
 const NOME_EXATO_ID = /^id$/;
 


### PR DESCRIPTION
I performed a quality check on the frontend and root project.
Found and fixed a lint error in `etc/scripts/codigo/idioma-consistencia-auditar.js` where `SUFIXOS_ID` was defined but never used.
Verified that `npm run lint`, `npm run typecheck` (in root), and `npm run quality:all` (in frontend) all pass successfully.
Ensured that no unnecessary artifacts (like cruft snapshots) are included in the submission.

---
*PR created automatically by Jules for task [10361531906769369688](https://jules.google.com/task/10361531906769369688) started by @lgalvao*